### PR TITLE
Add a flat Use-Def view to the LLVM-IR mode

### DIFF
--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -48,6 +48,7 @@ UI-free pipeline to its React components.
 - `contracts/graph-data.md` — the `GraphData` shape and the `nodeType`↔`astData` union.
 - `specs/llvm-ir.md`, `specs/mermaid.md`, `specs/selectiondag.md` — accepted input syntax and
   graph conversion rules per IR.
+- `specs/llvm-use-def-view.md` — the LLVM-IR mode's second view (SSA dataflow projection).
 - `specs/graph-view.md` — mode-independent viewer behavior (debounce, position preservation,
   layout, sizing, responsive mode).
 

--- a/docs/internal/contracts/graph-data.md
+++ b/docs/internal/contracts/graph-data.md
@@ -23,8 +23,13 @@ interface GraphEdge {
   sourceHandle?: string; // SelectionDAG only
   targetHandle?: string; // SelectionDAG only
   isChainOrGlue?: boolean; // SelectionDAG only
+  dashed?: boolean; // render with strokeDasharray (LLVM use-def phi edges)
 }
 ```
+
+`dashed` is mode-agnostic: the standard edge factory (`createReactFlowEdge`) applies a dash
+pattern when it is set. The LLVM Use-Def view sets it on phi incoming-value edges
+(`specs/llvm-use-def-view.md` §3.1).
 
 This is what let `useGraphData` and `layout.ts` collapse their SelectionDAG-specific code paths
 (`updateSelectionDAGGraph`, `getSelectionDAGLayoutedElements`) into the single `updateGraph`/
@@ -44,6 +49,8 @@ type GraphNode = GraphNodeBase &
     | { nodeType: "llvm-metadata"; astData: LLVMMetadata }
     | { nodeType: "llvm-declaration"; astData: LLVMDeclaration }
     | { nodeType: "llvm-exit"; astData: Record<string, never> }
+    | { nodeType: "llvm-useDefInstruction"; astData: LLVMUseDefInstructionData }
+    | { nodeType: "llvm-useDefValue"; astData: LLVMUseDefValueData }
     | { nodeType: "mermaid-node"; astData: MermaidASTNode }
     | { nodeType: "selectionDAG-node"; astData: SelectionDAGNode }
     | { nodeType?: undefined; astData?: undefined } // codeNode fallback, no specialized renderer
@@ -51,7 +58,14 @@ type GraphNode = GraphNodeBase &
 ```
 
 `GraphNodeBase` holds the fields every node has regardless of mode: `id`, `label`, `type?`,
-`language?`, `blockLabel?`.
+`language?`, `blockLabel?`. There is **no container/parent field**: every graph this contract
+describes is flat, including the LLVM Use-Def view (see its plan's §2 for why compound layout
+was rejected).
+
+The `llvm-useDef*` astData shapes (`LLVMUseDefInstructionData`, `LLVMUseDefValueData`) are
+view-data shapes living in `src/ast/llvmAST.ts` next to `LLVMFunctionHeaderData`, which set
+the precedent: not AST nodes of their own, just the typed payload a renderer expects.
+Conversion rules: `specs/llvm-use-def-view.md`.
 
 **What this buys:** a graphBuilder pushing `{ ..., nodeType: "llvm-globalVariable", astData: gVar }`
 is checked against the `LLVMGlobalVariable` shape at the call site — no cast needed, and pushing the

--- a/docs/internal/contracts/ir-mode-registry.md
+++ b/docs/internal/contracts/ir-mode-registry.md
@@ -20,8 +20,56 @@ interface IRModeDefinition {
   nodeTypes: Record<string, ComponentType<NodeProps>>; // this mode's React Flow node renderers
   edgeBuilder: IREdgeBuilder; // see below
   dagreOptions?: Partial<dagre.GraphLabel>; // e.g. SelectionDAG's { ranksep: 50 }
+  views?: IRViewDefinition[]; // optional alternative projections — see "Views" below
 }
 ```
+
+## Views
+
+A mode may expose several **views** of the same text — e.g. LLVM-IR's CFG vs its
+Use-Def dataflow graph (`specs/llvm-use-def-view.md`). A view is a projection:
+same editor language, same default code, same parser front-end, different
+`GraphData`.
+
+```ts
+interface IRViewDefinition {
+  key: string; // stable, e.g. "cfg", "use-def"
+  label: string; // toggle label, e.g. "CFG"
+  parse: (code: string) => GraphData; // same throw-on-invalid rule as the mode's parse
+  edgeBuilder?: IREdgeBuilder; // defaults to the mode's edgeBuilder
+  dagreOptions?: Partial<dagre.GraphLabel>; // defaults to the mode's dagreOptions
+}
+```
+
+Rules:
+
+- `views` is optional. A mode without it has a single implicit view built from
+  its top-level `parse`/`edgeBuilder`/`dagreOptions` (Mermaid and SelectionDAG
+  stay exactly as they were).
+- When present, `views` has ≥ 2 entries and `views[0]` is the **default view**;
+  it must behave identically to the mode's top-level fields (share the same
+  function references — don't duplicate logic).
+- `useIRWorkspace` owns the active view key. Switching **views keeps the editor
+  code** (that is the point of views); switching **modes resets** the view to the
+  default and replaces the code with `defaultCode`, as before.
+- The toolbar renders a view `ToggleButtonGroup` only when the active mode has
+  `views`.
+- A mode's `nodeTypes` covers every view's node renderers (GraphViewer merges
+  `nodeTypes` per mode, not per view).
+- Because a view switch changes the topology signature, `useGraphData` does a
+  full re-layout in each direction; positions are not preserved across view
+  switches (`specs/graph-view.md` §2).
+
+The layout-relevant half of a mode is named separately so a view-resolved value
+can be passed where a mode used to be:
+
+```ts
+type IRLayoutBehavior = Pick<IRModeDefinition, "edgeBuilder" | "dagreOptions">;
+```
+
+`useGraphData.updateGraph(graph, behavior)` takes `IRLayoutBehavior` rather than
+the full `IRModeDefinition`; a mode object satisfies it structurally, and the
+workspace passes the active view's resolved `edgeBuilder`/`dagreOptions`.
 
 `IREdgeBuilder` (`src/utils/layout.ts`) captures the two things that differ between how LLVM/Mermaid
 and SelectionDAG decide what an edge should look like:
@@ -53,8 +101,9 @@ All three current modes live in `src/irModes/`: `llvmMode.ts`, `mermaidMode.ts`,
 
 - `App.tsx` / `useIRWorkspace` — looks up the active mode by key, calls `mode.parse(code)`,
   uses `mode.defaultCode` on mode switch and `mode.editorLanguage` for the editor.
-- `useGraphData` — takes the full mode object into `updateGraph(graph, mode)` /
-  `resetLayout()`, so layout and edge-building are mode-driven rather than branching by string.
+- `useGraphData` — takes an `IRLayoutBehavior` into `updateGraph(graph, behavior)` /
+  `resetLayout()`, so layout and edge-building are mode- (or view-) driven rather than
+  branching by string.
 - `GraphViewer` — merges `nodeTypes` from every entry in `IR_MODE_LIST` (plus the
   mode-agnostic fallback `codeNode`) instead of importing each mode's node components directly.
 

--- a/docs/internal/plans/2026-08-llvm-use-def-view.md
+++ b/docs/internal/plans/2026-08-llvm-use-def-view.md
@@ -1,0 +1,174 @@
+# Plan: LLVM-IR Use-Def graph view
+
+- **Status:** In progress (2026-08-09)
+- **Depends on:** the §3.5 use-def foundation of `docs/internal/specs/llvm-ir.md`
+  (parser-only `defs`/`uses` fields, implemented by
+  `plans/2026-07-llvm-line-oriented-parser.md` step 11). This plan builds the
+  consumer that §3.5 explicitly deferred.
+
+## 1. Goal
+
+Add a second way to look at LLVM-IR: a **use-def graph** showing SSA dataflow
+(which instruction defines each value, which instructions read it), next to the
+existing CFG view. The parser already attaches `defs`/`uses` to every
+instruction and terminator; this plan adds the graphBuilder, the registry
+support for multiple views, the node components, and the UI entry point that
+consume them. No parser changes.
+
+The graph is **flat**: instruction nodes are ranked directly by their use-def
+edges, so vertical position means dataflow depth. Basic-block membership is
+carried by a colored badge on each instruction node instead of by a container.
+
+## 2. Prototype retrospective
+
+A prototype (branch `claude/llvm-ir-use-def-graph-j6y5fs`, not merged) built the
+same view with **one React Flow container node per basic block** and a compound
+layout path in `src/utils/layout.ts`. It is the reason this plan exists, and the
+reason the design changed:
+
+- **Dimension estimation drift.** Container size was computed from the estimated
+  dimensions of its stacked children (`converter.ts`'s character-count
+  estimation, §5 of `specs/graph-view.md`). Estimates are close enough for
+  spacing between free-standing nodes, but a container is a hard boundary: when
+  the real rendered children are taller or wider than the estimate, the parent
+  is already too small.
+- **`extent: "parent"` clamping cascades.** React Flow then clamps every child
+  back inside the undersized parent, so children pile up on the parent's edge
+  and overlap each other. The failure is visual, not thrown, and it gets worse
+  the longer the instruction text is — i.e. on exactly the real-world input the
+  view is for.
+- **Dagre ranks containers, not dataflow.** With containers as the top-level
+  nodes, child-to-child edges have to be lifted to the container level for
+  ranking, and intra-block edges are dropped from ranking entirely. The
+  resulting vertical order expresses block order, not dataflow depth — which
+  discards the main thing a use-def view is supposed to show. Program order
+  inside a block is _a_ topological order of its dataflow, but it is not the
+  one a reader wants: chains that fan out across blocks get no rank at all.
+
+Compound layout is therefore **rejected**: no container nodes, no `parentId`, no
+`extent: "parent"`, no compound path in `layout.ts`. Revisiting grouping with a
+layout engine that supports it natively (ELK) is possible future work (§9), not
+part of this plan.
+
+The prototype's non-layout parts were sound and are carried over: the view
+toggle as the UI entry point, the `views?` registry extension, the lazy external
+value nodes, and the textual phi-incoming extraction.
+
+## 3. Decisions (settled up front)
+
+| Question                  | Decision                                                                                                                          | Why                                                                                                                                                                                        |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| UI entry point            | **View toggle inside the LLVM-IR mode** (CFG / Use-Def), not a 4th registry mode                                                  | Same text, same parser, different projection. A separate mode would reset the editor to `defaultCode` on switch (`useIRWorkspace.changeMode`), losing the code the user was looking at.    |
+| Registry impact           | Extend `IRModeDefinition` with optional `views` (§4)                                                                              | The registry contract has no multi-view concept today; extending the contract beats a mode-key special case in the toolbar. Modes without `views` are untouched.                           |
+| Graph shape               | **Flat.** No containers, no `parentId`; Dagre ranks instruction nodes directly by use-def edges                                   | Rank then equals dataflow depth, which is the point of the view. Avoids the estimation/clamping failure of §2 entirely.                                                                    |
+| Block correspondence      | A **block badge** on each instruction node: the block's display label, tinted from an 8-color muted palette cycled by block index | Keeps the CFG correspondence readable without a geometric container. Color survives the flat layout scattering a block's instructions across ranks.                                        |
+| Node granularity          | One node per instruction/terminator line **that participates in dataflow**                                                        | SSA: each value has exactly one defining line, so instruction nodes double as value nodes. A line with empty `defs` and empty `uses` (`br label %x`, `ret void`) would be an isolated dot. |
+| Edge labels               | Plain use-def edges are **unlabeled**; only phi edges carry a label                                                               | The defined name is already visible in the source node's text, so `%v` on the edge is redundant clutter at the density this view produces.                                                 |
+| Function arguments        | Synthetic value nodes (one per named parameter), plus the same shape for dangling references                                      | Arguments have no defining instruction; without a source node their flow is invisible. Dangling refs (degraded parses, undefined names) reuse the shape so edge construction stays total.  |
+| phi edges                 | Dashed, labeled `%v (%bb)` with the incoming block(s)                                                                             | phi incoming values are cross-iteration/cross-path flow; visually separating them makes loops legible, and the incoming block is not otherwise recoverable from the graph.                 |
+| Non-function module items | Omitted from the use-def view (globals, metadata, attribute groups, declarations, targets, debug records)                         | `uses` are SSA locals only (§3.5); those items never participate.                                                                                                                          |
+
+## 4. Registry contract extension (`contracts/ir-mode-registry.md`)
+
+```ts
+/** One selectable projection of a mode's text (e.g. LLVM's CFG vs Use-Def). */
+interface IRViewDefinition {
+  key: string; // stable, e.g. "cfg", "use-def"
+  label: string; // toggle label, e.g. "CFG"
+  parse: (code: string) => GraphData;
+  edgeBuilder?: IREdgeBuilder; // defaults to the mode's
+  dagreOptions?: Partial<dagre.GraphLabel>; // defaults to the mode's
+}
+
+interface IRModeDefinition {
+  // ...existing fields...
+  /**
+   * Optional alternative projections. When present: >= 2 entries, views[0]
+   * is the default and MUST behave identically to the mode's top-level
+   * parse/edgeBuilder/dagreOptions (share the function references).
+   */
+  views?: IRViewDefinition[];
+}
+```
+
+- `useIRWorkspace` gains `viewKey` state. Switching views keeps the editor code
+  (that is the whole point); switching modes resets `viewKey` to the default
+  view. The active view supplies `parse`, `edgeBuilder`, `dagreOptions`.
+- `useGraphData.updateGraph`'s second parameter narrows from `IRModeDefinition`
+  to an `IRLayoutBehavior = Pick<IRModeDefinition, "edgeBuilder" | "dagreOptions">`
+  so the workspace can pass view-resolved behavior. Existing callers satisfy the
+  narrower type structurally.
+- `ToolbarPane` shows a CFG/Use-Def `ToggleButtonGroup` only when the active mode
+  has `views`.
+- A view switch changes the topology signature, so `useGraphData` performs a full
+  re-layout in each direction. Positions are not preserved across view switches;
+  this is accepted (documented in `specs/graph-view.md`).
+
+## 5. GraphData extension (`contracts/graph-data.md`)
+
+- `GraphEdge` gains `dashed?: boolean` — rendered as `strokeDasharray` by the
+  standard edge factory. Used by phi edges; mode-agnostic on purpose.
+- `GraphNodeBase` is **unchanged** (no `parentId`, per §2).
+- Two new `nodeType` variants (astData shapes live in `src/ast/llvmAST.ts` next
+  to `LLVMFunctionHeaderData`, which set the precedent for view-data shapes):
+  - `llvm-useDefInstruction` /
+    `LLVMUseDefInstructionData { text, def, isTerminator, blockLabel, blockIndex }`.
+  - `llvm-useDefValue` /
+    `LLVMUseDefValueData { name, kind: "argument" | "external", paramType? }`.
+
+## 6. Graph construction (`src/graphBuilder/llvmUseDefGraphBuilder.ts`)
+
+New spec: `docs/internal/specs/llvm-use-def-view.md` (normative rules + pinning
+tests). Summary:
+
+- Per function: one value node per named parameter; one instruction node per
+  instruction and terminator that has a non-empty `defs` or `uses`; all ids
+  namespaced by function with the CFG builder's `func_<name>` prefix.
+- A def map (parameter name / instruction def → node id) resolves each `uses`
+  entry to its source node; an unresolved name lazily creates an `external`
+  value node.
+- One edge per (def node → using node, value) triple, unlabeled.
+- phi lines: incoming `[ value, %block ]` pairs are re-extracted from
+  `originalText` (textual scan; the AST keeps phi generic per `specs/llvm-ir.md`
+  §5 "phi instructions do not contribute edges"). A use matching an incoming
+  value gets `dashed: true` and label `%v (%bb)`. `src/graphBuilder` must not
+  import from `src/parser` (layering rule), hence the textual scan.
+- `direction: "TD"`; the view supplies its own `dagreOptions`.
+
+## 7. Components (`src/components/Graph/LLVM/UseDef/`)
+
+- `LLVMUseDefInstructionNode` — a code card: the instruction text plus a block
+  badge chip (`blockLabel`, tinted by `blockIndex % 8`), top target handle,
+  bottom source handle.
+- `LLVMUseDefValueNode` — a pill showing `%name` (+ parameter type when known),
+  source handle only; `argument` and `external` are styled differently so a
+  dangling reference is visibly not a parameter.
+- Colocated `*.stories.tsx` for each, per Storybook convention.
+
+## 8. Steps
+
+1. Docs first: this plan; contract updates (`ir-mode-registry.md`,
+   `graph-data.md`); new `specs/llvm-use-def-view.md`; `specs/llvm-ir.md` §3.5
+   "no consumer yet" note updated; `specs/graph-view.md` view-toggle behavior;
+   `architecture.md` registry line; `docs/user/supported-formats.md`.
+2. Types: `IRViewDefinition`, `views?`, `IRLayoutBehavior`; `dashed`; the two new
+   astData shapes + `GraphNode` union variants.
+3. graphBuilder + unit tests
+   (`src/graphBuilder/__tests__/llvm/useDefGraph.test.ts`).
+4. Edge factory: honor `dashed` in `converter.ts`.
+5. Node components + stories.
+6. Registry entry (`llvmMode.views`), workspace/toolbar wiring, `updateGraph`
+   signature narrowing.
+7. Integration test additions; E2E: toggle to Use-Def in the smoke suite and
+   assert instruction nodes appear.
+8. `npm run test:run`, `format`, `lint`, `build`.
+
+## 9. Non-goals
+
+- Memory dependence (store→load) — permanently out of scope per §3.5.
+- Cross-function dataflow (call argument → parameter linking).
+- Views for Mermaid/SelectionDAG (single-view modes stay as they are).
+- Overlaying use-def edges on the CFG view (the "hybrid" idea).
+- Visual grouping of a block's instructions. Containers are rejected for Dagre
+  (§2); revisiting this with ELK, which supports hierarchical layout natively,
+  is possible future work.

--- a/docs/internal/specs/graph-view.md
+++ b/docs/internal/specs/graph-view.md
@@ -10,12 +10,15 @@ covering test.
 
 ## 1. Parse cycle
 
-- Editing the code (or switching modes) schedules a parse of the active mode after a
-  **750 ms debounce** (`PARSE_DEBOUNCE_MS` in `useIRWorkspace`); intermediate keystrokes cancel
-  the pending parse.
+- Editing the code (or switching modes or views) schedules a parse of the active mode's
+  active view after a **750 ms debounce** (`PARSE_DEBOUNCE_MS` in `useIRWorkspace`);
+  intermediate keystrokes cancel the pending parse.
 - On success the graph updates and any error clears. On failure the **previous graph stays**
   and the error message is shown in a snackbar (truncated to 100 characters).
-- Switching modes replaces the editor content with the new mode's `defaultCode`.
+- Switching modes replaces the editor content with the new mode's `defaultCode` and resets
+  the active view to the mode's default view.
+- Switching views (modes with `views`, see `contracts/ir-mode-registry.md`) **keeps the
+  editor content** and re-parses it with the new view's `parse`.
 
 > Pinned by (end-to-end): `e2e/smoke.spec.ts` — "editing the code updates the graph",
 > "invalid code shows a parse error", the two mode-switching tests. The exact debounce value
@@ -23,7 +26,9 @@ covering test.
 
 ## 2. Graph updates — topology signature
 
-`useGraphData.updateGraph(graph, mode)` computes a **topology signature**:
+`useGraphData.updateGraph(graph, behavior)` (where `behavior` is the active view's
+`edgeBuilder`/`dagreOptions`, structurally satisfied by a mode object — see
+`contracts/ir-mode-registry.md`) computes a **topology signature**:
 `direction | sorted node ids | sorted source-target pairs`.
 
 - **Signature changed** (first parse, node/edge added or removed, direction changed):
@@ -32,6 +37,10 @@ covering test.
   node **positions are preserved**, labels/content update in place, and each edge's rendered
   type is re-derived by the mode's `IREdgeBuilder` with the previous type available
   (SelectionDAG keeps types stable; LLVM/Mermaid re-classify from current positions).
+- Switching views always changes the signature (the two projections emit different node id
+  namespaces), so each view switch performs a full re-layout; **positions are not preserved
+  across view switches**. This is intended: the two projections have unrelated topologies, so
+  there is nothing meaningful to carry over.
 
 > Pinned by: `src/hooks/__tests__/useGraphData.test.ts` (layout on first call, position
 > preservation, re-layout on topology change, SelectionDAG position/edge-type stability)
@@ -92,6 +101,10 @@ Dagre needs node sizes before React renders anything, so `converter.ts` estimate
   (LLVM-IR, SelectionDAG, Mermaid).
   > Pinned by: `e2e/smoke.spec.ts` (selects each mode by visible label). Order:
   > _observed, untested_.
+- **View toggle**: when the active mode defines `views`, a `ToggleButtonGroup` next to the
+  mode selector lists them in registry order (LLVM-IR: CFG, Use-Def) with the active view
+  selected; it is absent for single-view modes.
+  > Pinned by: `e2e/smoke.spec.ts` ("LLVM-IR use-def view").
 - **Clear** empties the editor (the subsequent parse of the empty string follows §1: e.g.
   an empty module is valid LLVM-IR, but empty Mermaid input is a parse error).
   _(observed, untested)_

--- a/docs/internal/specs/llvm-ir.md
+++ b/docs/internal/specs/llvm-ir.md
@@ -238,12 +238,14 @@ them yet (see the plan's follow-ups).
 
 ### 3.5 Use-def foundation
 
-**Parser-only.** Every instruction and terminator parsed from a source line carries two
-extra fields, `defs` and `uses` (possibly empty arrays of sigil-free local names). No
-consumer exists yet: the graphBuilder and UI ignore both fields (the use-def graph view is
-a separate future plan). SSA values only — memory dependence (store→load) is out of scope,
+Every instruction and terminator parsed from a source line carries two extra fields,
+`defs` and `uses` (possibly empty arrays of sigil-free local names). The consumer is the
+**Use-Def view** (`specs/llvm-use-def-view.md`, built by
+`plans/2026-08-llvm-use-def-view.md`); the CFG graphBuilder described in §4 still ignores
+both fields. SSA values only — memory dependence (store→load) is out of scope,
 permanently. The one node without the fields is the synthetic empty terminator of the
-§3.4 label recovery, which has no source line.
+§3.4 label recovery, which has no source line (and, having neither defs nor uses, gets no
+Use-Def node either).
 
 > Pinned by: `src/parser/llvm/__tests__/useDef.test.ts` ("attachment coverage",
 > "corpus-wide properties")
@@ -339,7 +341,9 @@ The produced graph always has `direction: "TD"`.
 - `landingpad` clause continuation lines (`cleanup` / `catch …` / `filter …` printed on
   their own line) become separate opaque instructions in the block (_observed, untested_);
   single-line landingpads — what the corpus contains — parse as one instruction.
-- `phi` instructions do not contribute edges (they are generic instructions textually).
+- `phi` instructions do not contribute CFG edges (they are generic instructions textually).
+  The Use-Def view recovers their incoming pairs by scanning `originalText`
+  (`specs/llvm-use-def-view.md` §3.1).
   > Pinned by: `classify.test.ts` ("when a phi uses bracketed block refs, should classify
   > instruction")
 - Operand classification is heuristic, and only the write-target marking of

--- a/docs/internal/specs/llvm-use-def-view.md
+++ b/docs/internal/specs/llvm-use-def-view.md
@@ -35,9 +35,10 @@ targets, debug records — produce **no nodes**.
 All ids are namespaced by function, using the same `func_<name>` prefixing
 convention as the CFG builder, so identical block labels or value names across
 functions cannot collide. Quoted identifiers are an exception: `uniqueId`
-strips only the sigil (`@`/`%`) and surrounding quotes, so a quoted name whose
-_contents_ include `@`, `%`, or `"` can still collide with an unrelated name
-after stripping (e.g. `@"a@b"` and `@ab` both prefix to `func_ab`) — a
+removes every `@`, `%`, and `"` character anywhere in the name (a global
+strip, not just the leading sigil and surrounding quotes), so a quoted name
+whose _contents_ include `@`, `%`, or `"` can still collide with an unrelated
+name after stripping (e.g. `@"a@b"` and `@ab` both prefix to `func_ab`) — a
 pre-existing encoding gap shared with the CFG builder (`llvmGraphBuilder.ts`);
 fixing it is follow-up work outside this spec (_observed, untested_).
 

--- a/docs/internal/specs/llvm-use-def-view.md
+++ b/docs/internal/specs/llvm-use-def-view.md
@@ -1,0 +1,167 @@
+# Spec: LLVM-IR Use-Def view
+
+Behavior specification for the Use-Def projection of LLVM-IR — the second view
+of the `llvm-ir` mode (`views: [cfg, use-def]`), selected by the toolbar's view
+toggle. Input syntax is unchanged from `specs/llvm-ir.md`; this spec covers only
+the AST → `GraphData` conversion performed by
+`src/graphBuilder/llvmUseDefGraphBuilder.ts`, which consumes the §3.5
+`defs`/`uses` fields (the consumer that §3.5 deferred).
+
+Conventions: every normative statement carries a **Pinned by** reference to the
+test(s) that fix the behavior. Unqualified test names refer to
+`src/graphBuilder/__tests__/llvm/useDefGraph.test.ts`. Statements marked
+_observed, untested_ describe current behavior with no covering test.
+
+Plan: `docs/internal/plans/2026-08-llvm-use-def-view.md`.
+
+## 1. What the view shows
+
+SSA dataflow, per function: one node per instruction line that participates in
+dataflow, one edge per (defining line → reading line) relationship. The graph is
+**flat** — there are no container nodes and no `parentId`, so Dagre ranks
+instruction nodes directly by their use-def edges and vertical position means
+dataflow depth. Basic-block membership is carried on the instruction node itself
+as a colored badge (§2), not by geometry.
+
+Control flow is **not** shown: a `br` contributes at most the read of its
+condition, never an edge to another block. Module-level items that never
+participate in SSA dataflow — globals, metadata, attribute groups, declarations,
+targets, debug records — produce **no nodes**.
+
+> Pinned by: "module-level items produce no nodes"
+
+## 2. Nodes
+
+All ids are namespaced by function, using the same `func_<name>` prefixing
+convention as the CFG builder, so identical block labels or value names across
+functions cannot collide.
+
+### 2.1 Instruction nodes
+
+`nodeType: "llvm-useDefInstruction"`, id `<funcPrefix>_ud_<blockId>_i<n>` where
+`n` is the 0-based index of the line among the lines its block actually emits,
+in program order.
+
+One node per instruction **and** per terminator **that participates in
+dataflow** — that is, whose `defs` or `uses` is non-empty. A line with an empty
+`defs` **and** an empty `uses` gets **no node**: an unconditional `br label %x`,
+a `ret void`, or an `unreachable` would otherwise be an isolated dot with no
+incident edge.
+
+> Pinned by: "one node per instruction with defs or uses",
+> "lines with neither defs nor uses get no node",
+> "terminators that read or define values get nodes"
+
+Debug records (`#dbg_*`) and the §3.4 synthetic empty terminator (no source
+line, `originalText === ""`, no `defs`/`uses`) never produce a node.
+
+> Pinned by: "debug records and the synthetic empty terminator get no node"
+
+`astData` is
+`{ text, def, isTerminator, blockLabel, blockIndex }`:
+
+| Field          | Value                                                                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`         | the line's `originalText`                                                                                                                   |
+| `def`          | the §3.5 def name (sigil-free), or `null` when the line defines nothing                                                                     |
+| `isTerminator` | whether the line is the block's terminator                                                                                                  |
+| `blockLabel`   | the block's **display** label: `"entry"` for a first block whose label is `null`, otherwise the block's label, falling back to its block id |
+| `blockIndex`   | the block's 0-based position within its function, in AST block order                                                                        |
+
+`blockIndex` exists to drive the badge tint (§4); it is a rendering input, not a
+semantic ordering claim.
+
+> Pinned by: "instruction node ids are namespaced per function",
+> "instruction astData carries text, def and isTerminator",
+> "blockLabel is entry for the unlabeled entry block",
+> "blockIndex is the block's position in its function"
+
+### 2.2 Value nodes
+
+`nodeType: "llvm-useDefValue"`, `astData: { name, kind, paramType? }`:
+
+- `kind: "argument"` — one per **named** function parameter, id
+  `<funcPrefix>_udarg_<name>`, emitted whether or not the parameter is used;
+  `paramType` is the parameter's raw type text. Unnamed parameters get no node
+  (the parser leaves `name: null`); a body referring to an implicit `%0`-style
+  parameter name resolves as `external` instead.
+- `kind: "external"` — created **lazily** for a `uses` entry whose name has no
+  known def in the function (degraded parses, undefined names, implicit
+  parameter names), id `<funcPrefix>_udext_<name>`. Use extraction is heuristic
+  (§3.5), so edge construction must be total rather than throwing on an
+  unresolved name.
+
+> Pinned by: "one argument node per named parameter",
+> "unnamed parameters get no argument node",
+> "external value node for names with no known def"
+
+## 3. Edges
+
+For every emitted node `N` and every name `v` in `N.uses`, one edge from the
+node that defines `v` — the instruction node whose `def` is `v`, else the
+argument value node for `v`, else a lazily created external value node — to `N`.
+
+- `id`: `e-<sourceId>-<targetId>-<v>`.
+- **No label.** The defined name is already visible in the source node's text,
+  so a `%v` label would be redundant. Only phi edges are labeled (§3.1).
+- `uses` is already deduplicated per line (§3.5), so a line reading `%v` twice
+  gets one edge.
+- Self-reference cannot occur: §3.5 excludes a line's own def from its `uses`.
+- Terminators participate on both sides: `br`/`switch` conditions and `ret`
+  values are uses; `invoke`/`callbr` results are defs that source edges into
+  other blocks.
+
+> Pinned by: "one edge per use, from the defining node",
+> "plain use-def edges carry no label", "edge ids embed the value name",
+> "a value read twice on one line gets one edge",
+> "uses of parameters connect to the argument node"
+
+### 3.1 phi edges
+
+For a `phi` line, the incoming `[ value, %block ]` pairs are re-extracted
+**textually** from `originalText`: the AST keeps phi generic (`specs/llvm-ir.md`
+§5, "phi instructions do not contribute edges") and `src/graphBuilder` must not
+import from `src/parser`, so the builder scans the text itself.
+
+An edge whose value name appears as a local incoming value gets `dashed: true`
+and the label `%v (%bb)` naming the incoming block. When the same value arrives
+from several blocks it is still one edge, and the label lists them:
+`%v (%bb1, %bb2)`. Constant incoming values (e.g. `[ 0, %7 ]`) contribute no
+edge — they are not in `uses`.
+
+Quoted local names inside phi incoming lists are not matched by the textual scan
+and fall back to a plain (solid, unlabeled) edge — _observed, untested_.
+
+> Pinned by: "phi incoming edges are dashed and labeled with the incoming block",
+> "a value arriving from several blocks gets one edge listing them",
+> "constant phi incoming values contribute no edge"
+
+## 4. Layout and rendering behavior
+
+- `GraphData.direction` is `"TD"`, and **no node carries `parentId`** — the view
+  deliberately produces a flat graph so that Dagre's ranking is the dataflow
+  order (see the plan's §2 retrospective for why containers were rejected).
+- The view supplies its own `dagreOptions` (_observed, untested_) and reuses the
+  standard `codeGraphEdgeBuilder`: back edges are classified from vertical
+  position, so a loop-carried phi edge — whose source sits at or below its
+  target — renders as a back edge without any special casing.
+- Instruction nodes render as code cards with a block badge chip showing
+  `blockLabel`, tinted from an 8-color muted palette indexed by
+  `blockIndex % 8`. The badge is what preserves the CFG correspondence in the
+  absence of containers.
+- Value nodes render as pills; `argument` and `external` are styled differently
+  so a dangling reference is visibly not a parameter.
+- `dashed` edges render with a dash pattern via the standard edge factory
+  (`contracts/graph-data.md`).
+
+> Pinned by: "direction is TD", "no node carries parentId"; the rendering
+> details are _observed, untested_ (visual, covered by Storybook stories only).
+
+## 5. Non-goals
+
+- Control flow. It is the CFG view's job; this view drops edgeless terminators
+  entirely (§2.1).
+- Memory dependence (store→load) — out of scope permanently (§3.5).
+- Cross-function dataflow (call argument → parameter linking).
+- Use-def edges overlaid on the CFG view.
+- Visual grouping of a block's instructions (see the plan's §9).

--- a/docs/internal/specs/llvm-use-def-view.md
+++ b/docs/internal/specs/llvm-use-def-view.md
@@ -34,7 +34,17 @@ targets, debug records — produce **no nodes**.
 
 All ids are namespaced by function, using the same `func_<name>` prefixing
 convention as the CFG builder, so identical block labels or value names across
-functions cannot collide.
+functions cannot collide. Quoted identifiers are an exception: `uniqueId`
+strips only the sigil (`@`/`%`) and surrounding quotes, so a quoted name whose
+_contents_ include `@`, `%`, or `"` can still collide with an unrelated name
+after stripping (e.g. `@"a@b"` and `@ab` both prefix to `func_ab`) — a
+pre-existing encoding gap shared with the CFG builder (`llvmGraphBuilder.ts`);
+fixing it is follow-up work outside this spec (_observed, untested_).
+
+> Pinned by: "node and edge ids stay unique across functions with identical
+> labels, defs, params, and external names" (instruction, argument, external
+> node ids and edge ids together, across functions); per-node-type
+> namespacing is further pinned in §2.1 and §2.2.
 
 ### 2.1 Instruction nodes
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -24,6 +24,9 @@ example already loaded.
 - **Mode selector** (top right): switch between **LLVM-IR**, **SelectionDAG**, and **Mermaid**.
   Switching loads that mode's example code, so you always start from something that renders.
   See [supported-formats.md](supported-formats.md) for what each mode accepts.
+- **View toggle** (next to the mode selector, LLVM-IR only): switch between the **CFG** and
+  **Use-Def** views of the same code. Unlike switching modes, switching views keeps what you
+  typed. See [supported-formats.md](supported-formats.md#llvm-ir).
 - **Editor**: type or paste IR. The graph re-renders about a second after you stop typing.
   If the input doesn't parse, an error message pops up over the graph and the previous graph
   stays until the input parses again.

--- a/docs/user/supported-formats.md
+++ b/docs/user/supported-formats.md
@@ -44,7 +44,22 @@ LLVM ~2.x through current is accepted:
 | 14+          | opaque `ptr`, `#dbg_value(...)` debug records, `callbr`                                                                                                                     |
 | any          | `comdat`, `module asm`, `uselistorder` — accepted and ignored                                                                                                               |
 
-**Graph structure:** every basic block becomes a node and every terminator becomes the
+**Views:** LLVM-IR has two views, switched by the CFG / Use-Def toggle in the toolbar. The
+editor content is kept when switching views (only switching _mode_ replaces it with that
+mode's example), and each switch re-lays-out the graph from scratch.
+
+- **CFG** (default) — the control-flow graph described below.
+- **Use-Def** — SSA dataflow instead: one node per instruction, with an edge from the
+  instruction that defines each `%value` to every instruction that reads it. Nodes are
+  arranged by dataflow depth, so an instruction sits below everything it reads. Each node
+  carries a colored badge naming the basic block it came from, so you can still tell blocks
+  apart. Function arguments appear as their own small pills, and a value with no visible
+  definition gets a differently styled pill. `phi` incoming values arrive on dashed edges
+  labeled with their incoming block. Instructions that neither define nor read a value
+  (`br label %x`, `ret void`) are left out, and control flow is not drawn — that is the CFG
+  view's job. Memory dependence (store→load) is not shown.
+
+**Graph structure (CFG view):** every basic block becomes a node and every terminator becomes the
 block's outgoing edges. Conditional `br` edges are labeled `true` / `false`; `switch` gets a
 `default` edge plus one edge per case, labeled with the case value; `invoke` gets a `to`
 edge (normal path) and an `unwind` edge (exception path); `ret` connects to a shared

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -134,6 +134,29 @@ test.describe("IR Visualizer smoke tests", () => {
     });
   });
 
+  test("LLVM-IR use-def view", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".react-flow__node").first()).toBeVisible();
+
+    await page.getByRole("button", { name: "Use-Def" }).click();
+
+    // Instruction nodes render individually; "%5 = add i32 %0, 45" only
+    // exists as its own node in the use-def projection, never in the CFG
+    // view's basic-block cards.
+    await expect(
+      page.locator(".react-flow__node", { hasText: "%5 = add i32 %0, 45" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Switching views keeps the editor content (spec: views/graph-view.md §1).
+    await expect(page.locator(".view-lines")).toContainText("define");
+
+    // Toggling back restores the CFG (exit node is CFG-only).
+    await page.getByRole("button", { name: "CFG" }).click();
+    await expect(page.locator(".react-flow")).toContainText("exit", {
+      timeout: 10_000,
+    });
+  });
+
   test("renders a graph from LLVM 2.x era IR with invoke/unwind", async ({
     page,
   }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ function App() {
   const {
     mode,
     modeKey,
+    views,
+    activeViewKey,
     code,
     setCode,
     error,
@@ -24,6 +26,7 @@ function App() {
     onEdgesChange,
     resetLayout,
     changeMode,
+    changeView,
     clearCode,
   } = useIRWorkspace();
 
@@ -55,6 +58,9 @@ function App() {
       <ToolbarPane
         mode={modeKey}
         onModeChange={handleModeChange}
+        views={views}
+        activeViewKey={activeViewKey}
+        onViewChange={changeView}
         isNarrow={isNarrow}
         activePane={activePane}
         onActivePaneChange={setActivePane}

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { parseMermaid } from "../parser/mermaid";
-import { parseLLVM } from "../parser/llvm";
+import { parseLLVM, parseLLVMUseDef } from "../parser/llvm";
 import { parseSelectionDAGToGraphData } from "../parser/selectionDAG";
+import { llvmMode } from "../irModes/llvmMode";
 
 describe("Integration: parseMermaid (parser + graph builder)", () => {
   it("should produce GraphData from Mermaid text", () => {
@@ -120,6 +121,69 @@ define void @foo() {
 
     const declNode = graph.nodes.find((n) => n.nodeType === "llvm-declaration");
     expect(declNode).toBeDefined();
+  });
+});
+
+describe("Integration: parseLLVMUseDef (parser + use-def graph builder)", () => {
+  it("should produce a flat dataflow graph from the default LLVM example", () => {
+    const graph = parseLLVMUseDef(llvmMode.defaultCode);
+
+    expect(graph.nodes.length).toBeGreaterThan(0);
+    expect(graph.edges.length).toBeGreaterThan(0);
+    expect(graph.direction).toBe("TD");
+
+    // The view is flat: Dagre ranks instructions directly, so no node may
+    // carry a parentId (the rejected compound/container design).
+    graph.nodes.forEach((node) => {
+      expect(node).not.toHaveProperty("parentId");
+    });
+
+    const instructionNodes = graph.nodes.filter(
+      (n) => n.nodeType === "llvm-useDefInstruction",
+    );
+    const valueNodes = graph.nodes.filter(
+      (n) => n.nodeType === "llvm-useDefValue",
+    );
+    expect(instructionNodes.length).toBeGreaterThan(0);
+    expect(valueNodes.length).toBeGreaterThan(0);
+
+    // The default code's loop (blocks 9/12) carries loop-carried phis, e.g.
+    // `%10 = phi i32 [ %1, %7 ], [ %15, %12 ]`: at least one incoming edge
+    // must render dashed with a "%v (%bb)" label.
+    const phiEdges = graph.edges.filter((e) => e.dashed === true);
+    expect(phiEdges.length).toBeGreaterThan(0);
+    phiEdges.forEach((e) => {
+      expect(e.label).toMatch(/^%\S+ \(%?\S+(, %?\S+)*\)$/);
+    });
+  });
+
+  it("should produce a dataflow graph for a simple function", () => {
+    const input = `
+define i32 @main(i32 %n) {
+entry:
+  %x = add i32 %n, 2
+  ret i32 %x
+}`;
+
+    const graph = parseLLVMUseDef(input);
+
+    const instructionNodes = graph.nodes.filter(
+      (n) => n.nodeType === "llvm-useDefInstruction",
+    );
+    expect(instructionNodes).toHaveLength(2); // add + ret
+
+    // %n flows from the argument node into the add; %x flows from the add
+    // into the ret. Neither edge carries a label (only phi edges do).
+    expect(graph.edges).toHaveLength(2);
+    graph.edges.forEach((edge) => {
+      expect(edge.label).toBeUndefined();
+      expect(edge.dashed).toBeUndefined();
+    });
+
+    const argNode = graph.nodes.find(
+      (n) => n.nodeType === "llvm-useDefValue" && n.astData.kind === "argument",
+    );
+    expect(argNode).toBeDefined();
   });
 });
 

--- a/src/ast/llvmAST.ts
+++ b/src/ast/llvmAST.ts
@@ -36,6 +36,47 @@ export interface LLVMFunctionHeaderData {
   name: string;
 }
 
+/**
+ * astData shape for a Use-Def view instruction node (not a distinct AST node
+ * in its own right). See docs/internal/specs/llvm-use-def-view.md §2.1.
+ */
+export interface LLVMUseDefInstructionData {
+  /** The line's originalText. */
+  text: string;
+  /** The §3.5 def name (sigil-free), or null when the line defines nothing. */
+  def: string | null;
+  /** Whether the line is the block's terminator. */
+  isTerminator: boolean;
+  /**
+   * The block's display label: "entry" for a first block whose label is
+   * null, otherwise the block's label, falling back to its block id.
+   */
+  blockLabel: string;
+  /**
+   * The block's 0-based position within its function, in AST block order.
+   * Drives the badge tint (blockIndex % 8); not a semantic ordering claim.
+   */
+  blockIndex: number;
+}
+
+/**
+ * astData shape for a Use-Def view value node — an argument or an
+ * externally-resolved value (not a distinct AST node in its own right). See
+ * spec §2.2.
+ */
+export interface LLVMUseDefValueData {
+  /** Sigil-free local name. */
+  name: string;
+  /**
+   * "argument" for a named function parameter; "external" for a use with no
+   * known def in the function (degraded parses, undefined names, implicit
+   * parameter names).
+   */
+  kind: "argument" | "external";
+  /** The parameter's raw type text, for kind "argument" when known. */
+  paramType?: string;
+}
+
 export interface LLVMParam {
   type: string;
   name: string | null;

--- a/src/components/AppShell/ToolbarPane.tsx
+++ b/src/components/AppShell/ToolbarPane.tsx
@@ -7,10 +7,32 @@ import {
   type SelectChangeEvent,
 } from "@mui/material";
 import { IR_MODE_LIST, type IRModeKey } from "../../irModes";
+import type { IRViewDefinition } from "../../irModes/types";
+
+const toggleGroupSx = {
+  height: 26,
+  "& .MuiToggleButton-root": {
+    fontSize: "11px",
+    px: 1.2,
+    py: 0,
+    textTransform: "none",
+    color: "#666",
+    borderColor: "#d0d0d0",
+    "&.Mui-selected": {
+      backgroundColor: "#e8e8e8",
+      color: "#222",
+      fontWeight: 600,
+    },
+  },
+};
 
 interface ToolbarPaneProps {
   mode: IRModeKey;
   onModeChange: (event: SelectChangeEvent) => void;
+  /** The active mode's views; the toggle renders only when this is set. */
+  views?: IRViewDefinition[];
+  activeViewKey?: string | null;
+  onViewChange?: (viewKey: string) => void;
   isNarrow: boolean;
   activePane: "editor" | "graph";
   onActivePaneChange: (pane: "editor" | "graph") => void;
@@ -19,6 +41,9 @@ interface ToolbarPaneProps {
 export function ToolbarPane({
   mode,
   onModeChange,
+  views,
+  activeViewKey,
+  onViewChange,
   isNarrow,
   activePane,
   onActivePaneChange,
@@ -58,25 +83,28 @@ export function ToolbarPane({
               if (v !== null) onActivePaneChange(v);
             }}
             size="small"
-            sx={{
-              height: 26,
-              "& .MuiToggleButton-root": {
-                fontSize: "11px",
-                px: 1.2,
-                py: 0,
-                textTransform: "none",
-                color: "#666",
-                borderColor: "#d0d0d0",
-                "&.Mui-selected": {
-                  backgroundColor: "#e8e8e8",
-                  color: "#222",
-                  fontWeight: 600,
-                },
-              },
-            }}
+            sx={toggleGroupSx}
           >
             <ToggleButton value="editor">Code</ToggleButton>
             <ToggleButton value="graph">Graph</ToggleButton>
+          </ToggleButtonGroup>
+        )}
+
+        {views && (
+          <ToggleButtonGroup
+            value={activeViewKey}
+            exclusive
+            onChange={(_e, v: string | null) => {
+              if (v !== null) onViewChange?.(v);
+            }}
+            size="small"
+            sx={toggleGroupSx}
+          >
+            {views.map((view) => (
+              <ToggleButton key={view.key} value={view.key}>
+                {view.label}
+              </ToggleButton>
+            ))}
           </ToggleButtonGroup>
         )}
 

--- a/src/components/Graph/LLVM/UseDef/LLVMUseDefInstructionNode.stories.tsx
+++ b/src/components/Graph/LLVM/UseDef/LLVMUseDefInstructionNode.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import LLVMUseDefInstructionNode from "./LLVMUseDefInstructionNode";
+import { NodeStoryCanvas } from "../../common/NodeStoryCanvas";
+import type { LLVMUseDefInstructionData } from "../../../../ast/llvmAST";
+import { USE_DEF_BADGE_PALETTE } from "./useDefStyleConstants";
+
+interface StoryArgs {
+  astData: LLVMUseDefInstructionData;
+}
+
+const meta = {
+  title: "Graph/LLVM/UseDef/Instruction",
+  parameters: { layout: "centered" },
+  render: (args) => (
+    <NodeStoryCanvas
+      nodeType="llvmUseDefInstruction"
+      component={LLVMUseDefInstructionNode}
+      astData={args.astData}
+    />
+  ),
+} satisfies Meta<StoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    astData: {
+      text: "%5 = add i32 %0, 45",
+      def: "5",
+      isTerminator: false,
+      blockLabel: "entry",
+      blockIndex: 0,
+    },
+  },
+};
+
+export const Terminator: Story = {
+  args: {
+    astData: {
+      text: "br i1 %2, label %4, label %7",
+      def: null,
+      isTerminator: true,
+      blockLabel: "4",
+      blockIndex: 1,
+    },
+  },
+};
+
+export const Phi: Story = {
+  args: {
+    astData: {
+      text: "%10 = phi i32 [ %1, %7 ], [ %15, %12 ]",
+      def: "10",
+      isTerminator: false,
+      blockLabel: "loop.header",
+      blockIndex: 2,
+    },
+  },
+};
+
+export const LongLine: Story = {
+  args: {
+    astData: {
+      text: "%42 = call noundef i32 @very_long_function_name(ptr noundef %ptr, i64 noundef %len, i32 noundef %flags)",
+      def: "42",
+      isTerminator: false,
+      blockLabel: "cleanup.cont.unwind",
+      blockIndex: 3,
+    },
+  },
+  render: (args) => (
+    <NodeStoryCanvas
+      nodeType="llvmUseDefInstruction"
+      component={LLVMUseDefInstructionNode}
+      astData={args.astData}
+      width={900}
+    />
+  ),
+};
+
+/**
+ * The badge tint is `blockIndex % 8`, so the palette repeats once a function
+ * has more than eight blocks. This story shows all eight tints at once.
+ */
+export const BadgePalette: Story = {
+  args: {
+    astData: {
+      text: "%1 = load i32, ptr %p",
+      def: "1",
+      isTerminator: false,
+      blockLabel: "bb0",
+      blockIndex: 0,
+    },
+  },
+  render: () => (
+    <div style={{ display: "flex", flexWrap: "wrap" }}>
+      {USE_DEF_BADGE_PALETTE.map((_, blockIndex) => (
+        <NodeStoryCanvas
+          key={blockIndex}
+          nodeType="llvmUseDefInstruction"
+          component={LLVMUseDefInstructionNode}
+          astData={{
+            text: `%${blockIndex} = load i32, ptr %p`,
+            def: String(blockIndex),
+            isTerminator: false,
+            blockLabel: `bb${blockIndex}`,
+            blockIndex,
+          }}
+          width={340}
+          height={150}
+        />
+      ))}
+    </div>
+  ),
+};

--- a/src/components/Graph/LLVM/UseDef/LLVMUseDefInstructionNode.tsx
+++ b/src/components/Graph/LLVM/UseDef/LLVMUseDefInstructionNode.tsx
@@ -1,0 +1,68 @@
+import type { NodeProps } from "@xyflow/react";
+import type { LLVMUseDefInstructionData } from "../../../../ast/llvmAST";
+import NodeShell from "../../common/NodeShell";
+import HighlightedCode from "../../common/HighlightedCode";
+import {
+  USE_DEF_BADGE_BORDER_RADIUS,
+  USE_DEF_BADGE_FONT_SIZE,
+  USE_DEF_BADGE_GAP,
+  USE_DEF_BADGE_LINE_HEIGHT,
+  USE_DEF_BADGE_PADDING_X,
+  USE_DEF_BADGE_PADDING_Y,
+  USE_DEF_BADGE_PALETTE,
+  USE_DEF_INSTRUCTION_BORDER_COLOR,
+  USE_DEF_TERMINATOR_BORDER_COLOR,
+} from "./useDefStyleConstants";
+
+/**
+ * One instruction/terminator line of the Use-Def view
+ * (specs/llvm-use-def-view.md §2.1). The view is flat, so basic-block
+ * membership is shown by a tinted badge chip instead of a container.
+ * NodeShell provides the hidden top target / bottom source handles that
+ * use-def edges attach to.
+ */
+const LLVMUseDefInstructionNode = ({ data }: NodeProps) => {
+  const instruction = data.astData as LLVMUseDefInstructionData;
+  const tint =
+    USE_DEF_BADGE_PALETTE[
+      ((instruction.blockIndex % USE_DEF_BADGE_PALETTE.length) +
+        USE_DEF_BADGE_PALETTE.length) %
+        USE_DEF_BADGE_PALETTE.length
+    ];
+
+  return (
+    <NodeShell
+      borderColor={
+        instruction.isTerminator
+          ? USE_DEF_TERMINATOR_BORDER_COLOR
+          : USE_DEF_INSTRUCTION_BORDER_COLOR
+      }
+      style={{ whiteSpace: "pre" }}
+    >
+      <div style={{ marginBottom: `${USE_DEF_BADGE_GAP}px` }}>
+        <span
+          style={{
+            display: "inline-block",
+            padding: `${USE_DEF_BADGE_PADDING_Y}px ${USE_DEF_BADGE_PADDING_X}px`,
+            borderRadius: `${USE_DEF_BADGE_BORDER_RADIUS}px`,
+            fontFamily: "monospace",
+            fontSize: `${USE_DEF_BADGE_FONT_SIZE}px`,
+            lineHeight: `${USE_DEF_BADGE_LINE_HEIGHT}px`,
+            fontWeight: 600,
+            backgroundColor: tint.bg,
+            color: tint.fg,
+          }}
+        >
+          {instruction.blockLabel}
+        </span>
+      </div>
+      <HighlightedCode
+        code={instruction.text}
+        language="llvm"
+        style={{ whiteSpace: "pre" }}
+      />
+    </NodeShell>
+  );
+};
+
+export default LLVMUseDefInstructionNode;

--- a/src/components/Graph/LLVM/UseDef/LLVMUseDefValueNode.stories.tsx
+++ b/src/components/Graph/LLVM/UseDef/LLVMUseDefValueNode.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import LLVMUseDefValueNode from "./LLVMUseDefValueNode";
+import { NodeStoryCanvas } from "../../common/NodeStoryCanvas";
+import type { LLVMUseDefValueData } from "../../../../ast/llvmAST";
+
+interface StoryArgs {
+  astData: LLVMUseDefValueData;
+}
+
+const meta = {
+  title: "Graph/LLVM/UseDef/Value",
+  parameters: { layout: "centered" },
+  render: (args) => (
+    <NodeStoryCanvas
+      nodeType="llvmUseDefValue"
+      component={LLVMUseDefValueNode}
+      astData={args.astData}
+    />
+  ),
+} satisfies Meta<StoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Argument: Story = {
+  args: {
+    astData: { name: "a", kind: "argument", paramType: "i32" },
+  },
+};
+
+/** A parameter whose type the parser did not capture renders as `%name`. */
+export const ArgumentWithoutType: Story = {
+  args: {
+    astData: { name: "cond", kind: "argument" },
+  },
+};
+
+export const External: Story = {
+  args: {
+    astData: { name: "undefined.value", kind: "external" },
+  },
+};

--- a/src/components/Graph/LLVM/UseDef/LLVMUseDefValueNode.tsx
+++ b/src/components/Graph/LLVM/UseDef/LLVMUseDefValueNode.tsx
@@ -1,0 +1,43 @@
+import type { NodeProps } from "@xyflow/react";
+import type { LLVMUseDefValueData } from "../../../../ast/llvmAST";
+import NodeShell from "../../common/NodeShell";
+import {
+  USE_DEF_ARGUMENT_BACKGROUND,
+  USE_DEF_ARGUMENT_BORDER_COLOR,
+  USE_DEF_EXTERNAL_BACKGROUND,
+  USE_DEF_EXTERNAL_BORDER_COLOR,
+  USE_DEF_VALUE_BORDER_RADIUS,
+} from "./useDefStyleConstants";
+
+/**
+ * Value source node of the Use-Def view (specs/llvm-use-def-view.md §2.2):
+ * a function argument, or an "external" name with no visible def. Rendered
+ * as a pill, styled per kind so a dangling reference is visibly not a
+ * parameter; edges leave from NodeShell's bottom source handle.
+ */
+const LLVMUseDefValueNode = ({ data }: NodeProps) => {
+  const value = data.astData as LLVMUseDefValueData;
+  const isArgument = value.kind === "argument";
+  const text = value.paramType
+    ? `%${value.name}: ${value.paramType}`
+    : `%${value.name}`;
+
+  return (
+    <NodeShell
+      borderRadius={`${USE_DEF_VALUE_BORDER_RADIUS}px`}
+      borderColor={
+        isArgument
+          ? USE_DEF_ARGUMENT_BORDER_COLOR
+          : USE_DEF_EXTERNAL_BORDER_COLOR
+      }
+      backgroundColor={
+        isArgument ? USE_DEF_ARGUMENT_BACKGROUND : USE_DEF_EXTERNAL_BACKGROUND
+      }
+      style={{ whiteSpace: "pre", textAlign: "center" }}
+    >
+      {text}
+    </NodeShell>
+  );
+};
+
+export default LLVMUseDefValueNode;

--- a/src/components/Graph/LLVM/UseDef/useDefStyleConstants.ts
+++ b/src/components/Graph/LLVM/UseDef/useDefStyleConstants.ts
@@ -1,0 +1,65 @@
+/**
+ * Constants shared by the Use-Def node components' CSS and by
+ * `converter.ts`'s dimension estimation (specs/graph-view.md §5: change the
+ * constant, never a literal, or the estimated layout spacing drifts from
+ * what is actually rendered).
+ */
+
+/** Padding of instruction/value cards; matches NodeShell's default 10px. */
+export const USE_DEF_CARD_PADDING = 10;
+/** Border width of instruction/value cards (NodeShell's 1px, per side). */
+export const USE_DEF_CARD_BORDER = 1;
+
+/** Font size of the block badge chip, in px. */
+export const USE_DEF_BADGE_FONT_SIZE = 11;
+/** Line height of the block badge chip, in px. */
+export const USE_DEF_BADGE_LINE_HEIGHT = 14;
+/** Vertical padding inside the block badge chip, in px (per side). */
+export const USE_DEF_BADGE_PADDING_Y = 1;
+/** Horizontal padding inside the block badge chip, in px (per side). */
+export const USE_DEF_BADGE_PADDING_X = 6;
+/** Corner radius of the block badge chip, in px. */
+export const USE_DEF_BADGE_BORDER_RADIUS = 4;
+/** Gap between the badge row and the instruction line below it, in px. */
+export const USE_DEF_BADGE_GAP = 4;
+
+/**
+ * Total vertical space the badge row occupies inside an instruction card:
+ * the chip itself plus the gap below it. Instruction cards add this to their
+ * estimated height; value pills have no badge row.
+ */
+export const USE_DEF_BADGE_ROW_HEIGHT =
+  USE_DEF_BADGE_LINE_HEIGHT + USE_DEF_BADGE_PADDING_Y * 2 + USE_DEF_BADGE_GAP;
+
+/** Border color of an instruction card whose line is a terminator. */
+export const USE_DEF_TERMINATOR_BORDER_COLOR = "#a88";
+/** Border color of a plain (non-terminator) instruction card. */
+export const USE_DEF_INSTRUCTION_BORDER_COLOR = "#777";
+
+/**
+ * Muted tints for the block badge, indexed by `blockIndex % 8`
+ * (specs/llvm-use-def-view.md §4). The badge is what preserves the CFG
+ * correspondence in this container-less view, so the colors have to stay
+ * distinguishable while keeping dark text readable on a pale background.
+ */
+export const USE_DEF_BADGE_PALETTE: { bg: string; fg: string }[] = [
+  { bg: "#e3ecf7", fg: "#2f5382" },
+  { bg: "#e4f1e4", fg: "#2e6b34" },
+  { bg: "#f7ecd9", fg: "#8a5a1f" },
+  { bg: "#f6e4e4", fg: "#8a3038" },
+  { bg: "#ece4f5", fg: "#5b3a86" },
+  { bg: "#dff0ef", fg: "#1f6b66" },
+  { bg: "#f5e4f0", fg: "#863a6e" },
+  { bg: "#e9edf0", fg: "#46596a" },
+];
+
+/** Background of an `argument` value pill. */
+export const USE_DEF_ARGUMENT_BACKGROUND = "#f2f6fb";
+/** Border color of an `argument` value pill. */
+export const USE_DEF_ARGUMENT_BORDER_COLOR = "#7a92b5";
+/** Background of an `external` value pill. */
+export const USE_DEF_EXTERNAL_BACKGROUND = "#fbf7f0";
+/** Border color of an `external` value pill. */
+export const USE_DEF_EXTERNAL_BORDER_COLOR = "#b5a27a";
+/** Corner radius that makes a value node read as a pill. */
+export const USE_DEF_VALUE_BORDER_RADIUS = 16;

--- a/src/graphBuilder/__tests__/llvm/useDefGraph.test.ts
+++ b/src/graphBuilder/__tests__/llvm/useDefGraph.test.ts
@@ -1,0 +1,673 @@
+import { describe, expect, it } from "vitest";
+import { convertASTToUseDefGraph } from "../../llvmUseDefGraphBuilder";
+import { expectUniqueIds } from "../helpers/assertGraph";
+import { createModule } from "../helpers/llvmFixtures";
+import type {
+  LLVMBasicBlock,
+  LLVMBasicBlockItem,
+  LLVMDebugRecord,
+  LLVMFunction,
+  LLVMGenericInstruction,
+  LLVMOpaqueTerminator,
+  LLVMParam,
+  LLVMTerminator,
+  LLVMUseDefInstructionData,
+} from "../../../ast/llvmAST";
+import type { GraphNode } from "../../../types/graph";
+
+/**
+ * Fixtures for the Use-Def view. The shared `llvmFixtures` helpers predate
+ * the §3.5 `defs`/`uses` fields and build no parameters, so this suite
+ * carries its own line/block/function builders that set them explicitly.
+ */
+
+interface LineSpec {
+  text: string;
+  defs?: string[];
+  uses?: string[];
+  opcode?: string;
+}
+
+function line({
+  text,
+  defs = [],
+  uses = [],
+  opcode = "op",
+}: LineSpec): LLVMGenericInstruction {
+  return {
+    type: "Instruction",
+    opcode,
+    operands: [],
+    originalText: text,
+    defs,
+    uses,
+  };
+}
+
+function terminator(spec: LineSpec): LLVMGenericInstruction {
+  return line(spec);
+}
+
+/** The §3.4 synthetic terminator: no source line, no defs/uses. */
+function emptyTerminator(): LLVMOpaqueTerminator {
+  return { type: "Instruction", opcode: "", successors: [], originalText: "" };
+}
+
+function debugRecord(): LLVMDebugRecord {
+  return {
+    type: "DebugRecord",
+    content: "#dbg_value(i32 %a, !1, !DIExpression(), !2)",
+    originalText: "  #dbg_value(i32 %a, !1, !DIExpression(), !2)",
+  };
+}
+
+function block(
+  id: string,
+  label: string | null,
+  instructions: LLVMBasicBlockItem[],
+  term: LLVMTerminator = terminator({ text: "ret void" }),
+): LLVMBasicBlock {
+  return { type: "BasicBlock", id, label, instructions, terminator: term };
+}
+
+function func(
+  name: string,
+  blocks: LLVMBasicBlock[],
+  params: LLVMParam[] = [],
+): LLVMFunction {
+  return {
+    type: "Function",
+    name,
+    params,
+    blocks,
+    definition: `define void @${name}()`,
+    entry: blocks[0],
+  };
+}
+
+function moduleOf(...functions: LLVMFunction[]) {
+  return createModule({ functions });
+}
+
+function instructionNodes(nodes: GraphNode[]): GraphNode[] {
+  return nodes.filter((node) => node.nodeType === "llvm-useDefInstruction");
+}
+
+function valueNodes(nodes: GraphNode[]): GraphNode[] {
+  return nodes.filter((node) => node.nodeType === "llvm-useDefValue");
+}
+
+function instructionData(node: GraphNode): LLVMUseDefInstructionData {
+  if (node.nodeType !== "llvm-useDefInstruction") {
+    throw new Error(`node ${node.id} is not a use-def instruction node`);
+  }
+  return node.astData;
+}
+
+describe("llvm useDef graphBuilder", () => {
+  describe("nodes", () => {
+    it("module-level items produce no nodes", () => {
+      const graph = convertASTToUseDefGraph(
+        createModule({
+          globalVariables: [
+            {
+              type: "GlobalVariable",
+              name: "@g",
+              value: "i32 0",
+              originalText: "@g = global i32 0",
+            },
+          ],
+          attributes: [
+            {
+              type: "AttributeGroup",
+              id: "#0",
+              value: "{ nounwind }",
+              originalText: "attributes #0 = { nounwind }",
+            },
+          ],
+          metadata: [
+            {
+              type: "Metadata",
+              id: "!0",
+              value: "!{i32 1}",
+              originalText: "!0 = !{i32 1}",
+            },
+          ],
+          declarations: [
+            {
+              type: "Declaration",
+              name: "declaration",
+              definition: "declare i32 @puts(ptr)",
+            },
+          ],
+          targets: [{ type: "Target", key: "datalayout", value: '"e-m:o"' }],
+          sourceFilenames: [
+            {
+              type: "SourceFilename",
+              name: "a.c",
+              originalText: 'source_filename = "a.c"',
+            },
+          ],
+        }),
+      );
+
+      expect(graph.nodes).toHaveLength(0);
+      expect(graph.edges).toHaveLength(0);
+    });
+
+    it("one node per instruction with defs or uses", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block(
+              "entry",
+              "entry",
+              [
+                line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+                line({ text: "%b = mul i32 %a, 3", defs: ["b"], uses: ["a"] }),
+              ],
+              terminator({ text: "ret i32 %b", opcode: "ret", uses: ["b"] }),
+            ),
+          ]),
+        ),
+      );
+
+      expect(instructionNodes(graph.nodes)).toHaveLength(3);
+      expectUniqueIds(graph.nodes);
+    });
+
+    it("lines with neither defs nor uses get no node", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block(
+              "entry",
+              "entry",
+              [
+                line({ text: "fence seq_cst", opcode: "fence" }),
+                line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+              ],
+              terminator({ text: "br label %next", opcode: "br" }),
+            ),
+          ]),
+        ),
+      );
+
+      const nodes = instructionNodes(graph.nodes);
+      expect(nodes).toHaveLength(1);
+      expect(instructionData(nodes[0]).text).toBe("%a = add i32 1, 2");
+      // The skipped `fence` line consumes no index: emitted lines are what
+      // `i<n>` counts (spec §2.1).
+      expect(nodes[0].id).toBe("func_foo_ud_entry_i0");
+    });
+
+    it("terminators that read or define values get nodes", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block(
+              "entry",
+              "entry",
+              [line({ text: "%c = icmp eq i32 1, 2", defs: ["c"] })],
+              terminator({
+                text: "br i1 %c, label %then, label %else",
+                opcode: "br",
+                uses: ["c"],
+              }),
+            ),
+          ]),
+        ),
+      );
+
+      const nodes = instructionNodes(graph.nodes);
+      expect(nodes).toHaveLength(2);
+      const term = nodes[1];
+      expect(instructionData(term).isTerminator).toBe(true);
+      expect(instructionData(term).text).toBe(
+        "br i1 %c, label %then, label %else",
+      );
+      expect(instructionData(nodes[0]).isTerminator).toBe(false);
+    });
+
+    it("debug records and the synthetic empty terminator get no node", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block(
+              "entry",
+              "entry",
+              [line({ text: "%a = add i32 1, 2", defs: ["a"] }), debugRecord()],
+              emptyTerminator(),
+            ),
+          ]),
+        ),
+      );
+
+      const nodes = instructionNodes(graph.nodes);
+      expect(nodes).toHaveLength(1);
+      expect(instructionData(nodes[0]).text).toBe("%a = add i32 1, 2");
+    });
+
+    it("instruction node ids are namespaced per function", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("entry", "entry", [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+            ]),
+          ]),
+          func("bar", [
+            block("entry", "entry", [
+              line({ text: "%a = add i32 3, 4", defs: ["a"] }),
+            ]),
+          ]),
+        ),
+      );
+
+      const ids = instructionNodes(graph.nodes).map((node) => node.id);
+      expect(ids).toEqual(["func_foo_ud_entry_i0", "func_bar_ud_entry_i0"]);
+      expectUniqueIds(graph.nodes);
+    });
+
+    it("instruction astData carries text, def and isTerminator", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block(
+              "entry",
+              "entry",
+              [line({ text: "%a = add i32 1, 2", defs: ["a"] })],
+              terminator({ text: "ret i32 %a", opcode: "ret", uses: ["a"] }),
+            ),
+          ]),
+        ),
+      );
+
+      const [defining, returning] = instructionNodes(graph.nodes);
+      expect(instructionData(defining)).toMatchObject({
+        text: "%a = add i32 1, 2",
+        def: "a",
+        isTerminator: false,
+      });
+      expect(instructionData(returning)).toMatchObject({
+        text: "ret i32 %a",
+        def: null,
+        isTerminator: true,
+      });
+    });
+
+    it("blockLabel is entry for the unlabeled entry block", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("0", null, [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+            ]),
+            block("named", "named", [
+              line({ text: "%b = add i32 3, 4", defs: ["b"] }),
+            ]),
+            block("7", null, [
+              line({ text: "%c = add i32 5, 6", defs: ["c"] }),
+            ]),
+          ]),
+        ),
+      );
+
+      const labels = instructionNodes(graph.nodes).map(
+        (node) => instructionData(node).blockLabel,
+      );
+      // First block with a null label reads "entry"; a later null-labeled
+      // block falls back to its block id (spec §2.1).
+      expect(labels).toEqual(["entry", "named", "7"]);
+    });
+
+    it("blockIndex is the block's position in its function", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("entry", "entry", [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+            ]),
+            block("mid", "mid", [
+              line({ text: "%b = add i32 3, 4", defs: ["b"] }),
+            ]),
+            block("tail", "tail", [
+              line({ text: "%c = add i32 5, 6", defs: ["c"] }),
+            ]),
+          ]),
+        ),
+      );
+
+      const indexes = instructionNodes(graph.nodes).map(
+        (node) => instructionData(node).blockIndex,
+      );
+      expect(indexes).toEqual([0, 1, 2]);
+    });
+
+    it("one argument node per named parameter", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func(
+            "foo",
+            [block("entry", "entry", [])],
+            [
+              { type: "i32", name: "%x" },
+              { type: "ptr noundef", name: "%y" },
+            ],
+          ),
+        ),
+      );
+
+      const args = valueNodes(graph.nodes);
+      expect(args).toHaveLength(2);
+      expect(args.map((node) => node.id)).toEqual([
+        "func_foo_udarg_x",
+        "func_foo_udarg_y",
+      ]);
+      expect(args[0].astData).toEqual({
+        name: "x",
+        kind: "argument",
+        paramType: "i32",
+      });
+      expect(args[1].astData).toEqual({
+        name: "y",
+        kind: "argument",
+        paramType: "ptr noundef",
+      });
+    });
+
+    it("unnamed parameters get no argument node", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func(
+            "foo",
+            [
+              block("entry", "entry", [
+                line({ text: "%a = add i32 %0, 1", defs: ["a"], uses: ["0"] }),
+              ]),
+            ],
+            [
+              { type: "i32", name: null },
+              { type: "...", name: null },
+            ],
+          ),
+        ),
+      );
+
+      expect(
+        valueNodes(graph.nodes).filter(
+          (node) =>
+            node.nodeType === "llvm-useDefValue" &&
+            node.astData.kind === "argument",
+        ),
+      ).toHaveLength(0);
+      // The implicit `%0` parameter name resolves as external instead.
+      expect(graph.nodes.map((node) => node.id)).toContain("func_foo_udext_0");
+    });
+
+    it("external value node for names with no known def", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("entry", "entry", [
+              line({
+                text: "%a = add i32 %undef, 1",
+                defs: ["a"],
+                uses: ["undef"],
+              }),
+              line({
+                text: "%b = mul i32 %undef, 2",
+                defs: ["b"],
+                uses: ["undef"],
+              }),
+            ]),
+          ]),
+        ),
+      );
+
+      const externals = valueNodes(graph.nodes);
+      expect(externals).toHaveLength(1);
+      expect(externals[0].id).toBe("func_foo_udext_undef");
+      expect(externals[0].astData).toEqual({ name: "undef", kind: "external" });
+      // Created once and reused by every unresolved reader.
+      expect(
+        graph.edges.filter((edge) => edge.source === externals[0].id),
+      ).toHaveLength(2);
+    });
+  });
+
+  describe("edges", () => {
+    it("one edge per use, from the defining node", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("entry", "entry", [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+              line({ text: "%b = mul i32 %a, 3", defs: ["b"], uses: ["a"] }),
+              line({
+                text: "%c = sub i32 %a, %b",
+                defs: ["c"],
+                uses: ["a", "b"],
+              }),
+            ]),
+          ]),
+        ),
+      );
+
+      const [a, b, c] = instructionNodes(graph.nodes).map((node) => node.id);
+      expect(
+        graph.edges.map((edge) => ({
+          source: edge.source,
+          target: edge.target,
+        })),
+      ).toEqual([
+        { source: a, target: b },
+        { source: a, target: c },
+        { source: b, target: c },
+      ]);
+      expectUniqueIds(graph.edges);
+    });
+
+    it("plain use-def edges carry no label", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("entry", "entry", [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+              line({ text: "%b = mul i32 %a, 3", defs: ["b"], uses: ["a"] }),
+            ]),
+          ]),
+        ),
+      );
+
+      expect(graph.edges).toHaveLength(1);
+      expect(graph.edges[0].label).toBeUndefined();
+      expect(graph.edges[0].dashed).toBeUndefined();
+    });
+
+    it("edge ids embed the value name", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("entry", "entry", [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+              line({ text: "%b = mul i32 %a, 3", defs: ["b"], uses: ["a"] }),
+            ]),
+          ]),
+        ),
+      );
+
+      expect(graph.edges[0].id).toBe(
+        "e-func_foo_ud_entry_i0-func_foo_ud_entry_i1-a",
+      );
+    });
+
+    it("a value read twice on one line gets one edge", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("entry", "entry", [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+              // `uses` is deduplicated per line by the parser (§3.5).
+              line({ text: "%b = mul i32 %a, %a", defs: ["b"], uses: ["a"] }),
+            ]),
+          ]),
+        ),
+      );
+
+      expect(graph.edges).toHaveLength(1);
+    });
+
+    it("uses of parameters connect to the argument node", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func(
+            "foo",
+            [
+              block("entry", "entry", [
+                line({ text: "%a = add i32 %x, 1", defs: ["a"], uses: ["x"] }),
+              ]),
+            ],
+            [{ type: "i32", name: "%x" }],
+          ),
+        ),
+      );
+
+      expect(graph.edges).toHaveLength(1);
+      expect(graph.edges[0].source).toBe("func_foo_udarg_x");
+      expect(graph.edges[0].target).toBe("func_foo_ud_entry_i0");
+      expect(graph.edges[0].label).toBeUndefined();
+    });
+
+    it("phi incoming edges are dashed and labeled with the incoming block", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("bb1", "bb1", [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+            ]),
+            block("bb2", "bb2", [
+              line({ text: "%b = add i32 3, 4", defs: ["b"] }),
+            ]),
+            block("join", "join", [
+              line({
+                text: "%r = phi i32 [ %a, %bb1 ], [ %b, %bb2 ]",
+                opcode: "phi",
+                defs: ["r"],
+                uses: ["a", "b"],
+              }),
+            ]),
+          ]),
+        ),
+      );
+
+      expect(graph.edges).toHaveLength(2);
+      expect(graph.edges.every((edge) => edge.dashed === true)).toBe(true);
+      expect(graph.edges.map((edge) => edge.label)).toEqual([
+        "%a (%bb1)",
+        "%b (%bb2)",
+      ]);
+    });
+
+    it("a value arriving from several blocks gets one edge listing them", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("bb1", "bb1", [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+            ]),
+            block("join", "join", [
+              line({
+                text: "%r = phi i32 [ %a, %bb1 ], [ %a, %bb2 ]",
+                opcode: "phi",
+                defs: ["r"],
+                uses: ["a"],
+              }),
+            ]),
+          ]),
+        ),
+      );
+
+      expect(graph.edges).toHaveLength(1);
+      expect(graph.edges[0].label).toBe("%a (%bb1, %bb2)");
+      expect(graph.edges[0].dashed).toBe(true);
+      expect(graph.edges[0].id).toBe(
+        "e-func_foo_ud_bb1_i0-func_foo_ud_join_i0-a",
+      );
+    });
+
+    it("constant phi incoming values contribute no edge", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("bb2", "bb2", [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+            ]),
+            block("join", "join", [
+              line({
+                text: "%r = phi i32 [ 0, %bb1 ], [ %a, %bb2 ]",
+                opcode: "phi",
+                defs: ["r"],
+                uses: ["a"],
+              }),
+            ]),
+          ]),
+        ),
+      );
+
+      expect(graph.edges).toHaveLength(1);
+      expect(graph.edges[0].label).toBe("%a (%bb2)");
+    });
+  });
+
+  describe("invariants", () => {
+    it("direction is TD", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func("foo", [
+            block("entry", "entry", [
+              line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+            ]),
+          ]),
+        ),
+      );
+
+      expect(graph.direction).toBe("TD");
+    });
+
+    it("no node carries parentId", () => {
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func(
+            "foo",
+            [
+              block(
+                "entry",
+                null,
+                [
+                  line({
+                    text: "%a = add i32 %x, 1",
+                    defs: ["a"],
+                    uses: ["x"],
+                  }),
+                  line({
+                    text: "%b = mul i32 %a, %undef",
+                    defs: ["b"],
+                    uses: ["a", "undef"],
+                  }),
+                ],
+                terminator({ text: "ret i32 %b", opcode: "ret", uses: ["b"] }),
+              ),
+            ],
+            [{ type: "i32", name: "%x" }],
+          ),
+        ),
+      );
+
+      expect(graph.nodes.length).toBeGreaterThan(0);
+      graph.nodes.forEach((node) => {
+        expect(node).not.toHaveProperty("parentId");
+      });
+    });
+  });
+});

--- a/src/graphBuilder/__tests__/llvm/useDefGraph.test.ts
+++ b/src/graphBuilder/__tests__/llvm/useDefGraph.test.ts
@@ -670,4 +670,69 @@ describe("llvm useDef graphBuilder", () => {
       });
     });
   });
+
+  describe("cross-function id uniqueness", () => {
+    it("node and edge ids stay unique across functions with identical labels, defs, params, and external names", () => {
+      // Two functions that are identical in every way the ids are built
+      // from — same block label ("entry"), same instruction defs/uses
+      // ("a", "b", "c"), same named parameter ("x"), same unresolved name
+      // ("undef") — so only the func_<name> prefix (spec §2) can keep
+      // instruction, argument, external, and edge ids from colliding.
+      const makeFunction = (name: string): LLVMFunction =>
+        func(
+          name,
+          [
+            block(
+              "entry",
+              "entry",
+              [
+                line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+                line({
+                  text: "%b = mul i32 %a, %x",
+                  defs: ["b"],
+                  uses: ["a", "x"],
+                }),
+                line({
+                  text: "%c = add i32 %undef, 1",
+                  defs: ["c"],
+                  uses: ["undef"],
+                }),
+              ],
+              terminator({ text: "ret i32 %c", opcode: "ret", uses: ["c"] }),
+            ),
+          ],
+          [{ type: "i32", name: "%x" }],
+        );
+
+      const graph = convertASTToUseDefGraph(
+        moduleOf(makeFunction("foo"), makeFunction("bar")),
+      );
+
+      // 4 dataflow-participating lines per function (a, b, c, ret).
+      expect(instructionNodes(graph.nodes)).toHaveLength(8);
+      // 1 argument node + 1 external node per function.
+      expect(valueNodes(graph.nodes)).toHaveLength(4);
+      expectUniqueIds(graph.nodes);
+
+      // 4 edges per function: a->b, x->b, undef->c, c->ret.
+      expect(graph.edges).toHaveLength(8);
+      expectUniqueIds(graph.edges);
+
+      // Explicit edge-id uniqueness check: the "-a" suffix (edge id embeds
+      // the value name, spec §3) is identical for both functions, so this
+      // is exactly the case that would collide without the func_<name>
+      // prefix on the edge's source/target ids.
+      const edgeIdsEndingInA = graph.edges
+        .map((edge) => edge.id)
+        .filter((id) => id.endsWith("-a"));
+      expect(edgeIdsEndingInA).toHaveLength(2);
+      expect(new Set(edgeIdsEndingInA).size).toBe(2);
+      expect(edgeIdsEndingInA).toEqual(
+        expect.arrayContaining([
+          "e-func_foo_ud_entry_i0-func_foo_ud_entry_i1-a",
+          "e-func_bar_ud_entry_i0-func_bar_ud_entry_i1-a",
+        ]),
+      );
+    });
+  });
 });

--- a/src/graphBuilder/index.ts
+++ b/src/graphBuilder/index.ts
@@ -1,3 +1,4 @@
 export { convertASTToGraph as convertLLVMASTToGraph } from "./llvmGraphBuilder";
+export { convertASTToUseDefGraph as convertLLVMASTToUseDefGraph } from "./llvmUseDefGraphBuilder";
 export { convertASTToGraph as convertMermaidASTToGraph } from "./mermaidGraphBuilder";
 export { convertASTToGraph as convertSelectionDAGASTToGraph } from "./selectionDAGGraphBuilder";

--- a/src/graphBuilder/llvmUseDefGraphBuilder.ts
+++ b/src/graphBuilder/llvmUseDefGraphBuilder.ts
@@ -1,0 +1,215 @@
+import type { GraphData, GraphNode, GraphEdge } from "../types/graph";
+import type {
+  LLVMBasicBlock,
+  LLVMFunction,
+  LLVMInstruction,
+  LLVMModule,
+  LLVMTerminator,
+} from "../ast/llvmAST";
+
+/**
+ * Use-Def view builder (docs/internal/specs/llvm-use-def-view.md): SSA
+ * dataflow per function — one node per instruction/terminator line that
+ * participates in dataflow, plus value nodes for named parameters and for
+ * names with no known def, and one edge per (defining line → reading line).
+ *
+ * Consumes the §3.5 `defs`/`uses` fields. The graph is deliberately FLAT:
+ * no container nodes and no `parentId`, so Dagre ranks instruction nodes by
+ * their use-def edges and vertical position means dataflow depth (see the
+ * plan's §2 for why compound layout was rejected). Module-level items —
+ * globals, metadata, attribute groups, declarations, targets, debug records
+ * — never participate in SSA dataflow and contribute nothing here.
+ */
+
+/** Matches llvmGraphBuilder's uniqueId so both views namespace the same way. */
+const uniqueId = (prefix: string, name: string) =>
+  `${prefix}_${name.replace(/[@%"]/g, "")}`;
+
+/** One line already emitted as a node, queued for the edge pass. */
+interface EmittedLine {
+  nodeId: string;
+  line: LLVMInstruction | LLVMTerminator;
+}
+
+/**
+ * The sigil-free, unquoted form of a raw local name as the tokenizer would
+ * canonicalize it, so parameter names compare equal to `uses` entries
+ * (`%"odd name"` → `odd name`).
+ */
+function localName(raw: string): string {
+  const withoutSigil = raw.startsWith("%") ? raw.slice(1) : raw;
+  const quoted = /^"(.*)"$/.exec(withoutSigil);
+  return quoted === null ? withoutSigil : quoted[1];
+}
+
+/**
+ * The block's display label (spec §2.1): "entry" for a first block whose
+ * label is null, otherwise the block's label, falling back to the block id
+ * (implicit numeric blocks carry no label).
+ */
+function blockDisplayLabel(block: LLVMBasicBlock, blockIndex: number): string {
+  if (block.label !== null && block.label !== "") return block.label;
+  return blockIndex === 0 ? "entry" : block.id;
+}
+
+/** A line participates in dataflow when it defines or reads something. */
+function participates(line: LLVMInstruction | LLVMTerminator): boolean {
+  return (line.defs?.length ?? 0) > 0 || (line.uses?.length ?? 0) > 0;
+}
+
+/**
+ * Incoming `[ value, %block ]` pairs of a phi line, extracted textually
+ * from originalText: the AST keeps phi generic (`specs/llvm-ir.md` §5) and
+ * `src/graphBuilder` must not import from `src/parser`, so the builder
+ * scans the text itself (spec §3.1). Maps a local incoming VALUE name to
+ * the incoming block(s) it arrives from. Constant incoming values and
+ * quoted names do not match the value slot and simply produce no entry.
+ */
+function phiIncomingBlocks(originalText: string): Map<string, string[]> {
+  const incoming = new Map<string, string[]>();
+  const pair = /\[\s*%([A-Za-z0-9$._-]+)\s*,\s*%([A-Za-z0-9$._-]+)\s*\]/g;
+  for (const match of originalText.matchAll(pair)) {
+    const [, value, block] = match;
+    const blocks = incoming.get(value) ?? [];
+    blocks.push(block);
+    incoming.set(value, blocks);
+  }
+  return incoming;
+}
+
+function isPhi(line: LLVMInstruction | LLVMTerminator): boolean {
+  return line.opcode === "phi";
+}
+
+function buildFunctionGraph(
+  func: LLVMFunction,
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+): void {
+  const funcPrefix = uniqueId("func", func.name);
+  /** value name -> id of the node that defines it (argument or instruction) */
+  const defSource = new Map<string, string>();
+  const emitted: EmittedLine[] = [];
+
+  // Argument value nodes: one per NAMED parameter, emitted whether or not
+  // the parameter is used. Unnamed parameters have no name to resolve
+  // against, so a body reading an implicit `%0` resolves as external.
+  func.params.forEach((param) => {
+    if (param.name === null) return;
+    const name = localName(param.name);
+    const argId = `${funcPrefix}_udarg_${name}`;
+    nodes.push({
+      id: argId,
+      label: param.type === "" ? `%${name}` : `%${name}: ${param.type}`,
+      type: "round",
+      language: "text",
+      nodeType: "llvm-useDefValue",
+      astData: { name, kind: "argument", paramType: param.type },
+    });
+    defSource.set(name, argId);
+  });
+
+  // Pass 1 — instruction nodes, registering every def. Edges are a separate
+  // pass so a phi can read a value defined in a later block.
+  func.blocks.forEach((block, blockIndex) => {
+    const lines: { line: LLVMInstruction | LLVMTerminator; term: boolean }[] =
+      [];
+    block.instructions.forEach((item) => {
+      // Debug records (#dbg_*) never participate in dataflow.
+      if (item.type === "DebugRecord") return;
+      lines.push({ line: item, term: false });
+    });
+    // The §3.4 synthetic empty terminator has no source line — no node.
+    if (block.terminator.originalText !== "") {
+      lines.push({ line: block.terminator, term: true });
+    }
+
+    const blockLabel = blockDisplayLabel(block, blockIndex);
+    // `index` counts the lines the block actually EMITS: a skipped line
+    // (no defs and no uses) consumes no index (spec §2.1).
+    let index = 0;
+    lines.forEach(({ line, term }) => {
+      if (!participates(line)) return;
+      const nodeId = `${funcPrefix}_ud_${block.id}_i${String(index)}`;
+      index++;
+      const def = line.defs?.[0] ?? null;
+      nodes.push({
+        id: nodeId,
+        label: line.originalText,
+        type: "square",
+        language: "llvm",
+        nodeType: "llvm-useDefInstruction",
+        astData: {
+          text: line.originalText,
+          def,
+          isTerminator: term,
+          blockLabel,
+          blockIndex,
+        },
+      });
+      if (def !== null) defSource.set(def, nodeId);
+      emitted.push({ nodeId, line });
+    });
+  });
+
+  // Pass 2 — edges. A name with no known def lazily gets an "external"
+  // value node so edge construction is total (spec §2.2): use extraction is
+  // heuristic, so an unresolved name must not throw.
+  const externals = new Map<string, string>();
+  const resolveSource = (name: string): string => {
+    const known = defSource.get(name);
+    if (known !== undefined) return known;
+    let externalId = externals.get(name);
+    if (externalId === undefined) {
+      externalId = `${funcPrefix}_udext_${name}`;
+      externals.set(name, externalId);
+      nodes.push({
+        id: externalId,
+        label: `%${name}`,
+        type: "round",
+        language: "text",
+        nodeType: "llvm-useDefValue",
+        astData: { name, kind: "external" },
+      });
+    }
+    return externalId;
+  };
+
+  emitted.forEach(({ nodeId, line }) => {
+    const incoming = isPhi(line)
+      ? phiIncomingBlocks(line.originalText)
+      : undefined;
+    (line.uses ?? []).forEach((name) => {
+      const sourceId = resolveSource(name);
+      // `uses` is deduplicated per line (§3.5), so one edge per name; the
+      // incoming blocks of a phi value are aggregated into that one edge's
+      // label rather than producing several colliding edges.
+      const fromBlocks = incoming?.get(name);
+      const edge: GraphEdge = {
+        id: `e-${sourceId}-${nodeId}-${name}`,
+        source: sourceId,
+        target: nodeId,
+        type: "arrow",
+      };
+      if (fromBlocks !== undefined) {
+        // phi edge: dashed, and labeled with the incoming block(s). Plain
+        // use-def edges stay unlabeled — the name is visible in the source
+        // node's text (spec §3).
+        edge.label = `%${name} (${fromBlocks.map((b) => `%${b}`).join(", ")})`;
+        edge.dashed = true;
+      }
+      edges.push(edge);
+    });
+  });
+}
+
+export function convertASTToUseDefGraph(module: LLVMModule): GraphData {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+
+  module.functions.forEach((func) => {
+    buildFunctionGraph(func, nodes, edges);
+  });
+
+  return { nodes, edges, direction: "TD" };
+}

--- a/src/hooks/useGraphData.ts
+++ b/src/hooks/useGraphData.ts
@@ -6,7 +6,7 @@ import {
   useEdgesState,
 } from "@xyflow/react";
 import type { GraphData, GraphNode, GraphEdge } from "../types/graph";
-import type { IRModeDefinition } from "../irModes/types";
+import type { IRLayoutBehavior } from "../irModes/types";
 import { getLayoutedElements } from "../utils/layout";
 import { createReactFlowNode } from "../utils/converter";
 
@@ -30,11 +30,11 @@ export const useGraphData = () => {
 
   const [current, setCurrent] = useState<{
     graph: GraphData;
-    mode: IRModeDefinition;
+    mode: IRLayoutBehavior;
   } | null>(null);
 
   const updateGraph = useCallback(
-    (graph: GraphData, mode: IRModeDefinition) => {
+    (graph: GraphData, mode: IRLayoutBehavior) => {
       setCurrent({ graph, mode });
       const signature = getTopologySignature(graph);
 

--- a/src/hooks/useIRWorkspace.ts
+++ b/src/hooks/useIRWorkspace.ts
@@ -1,19 +1,26 @@
 import { useCallback, useEffect, useState } from "react";
 import { useGraphData } from "./useGraphData";
 import { IR_MODES, DEFAULT_IR_MODE_KEY, type IRModeKey } from "../irModes";
+import type { IRModeDefinition } from "../irModes/types";
 
 const PARSE_DEBOUNCE_MS = 750;
 
 /**
  * Owns the IR-mode/code/parse/error side of the app: which mode is active,
- * the editor's current text, the debounced parse-on-change effect, and the
- * resulting graph (via useGraphData). Mode switching and parsing are driven
- * entirely by the IR mode registry (src/irModes) — see
- * docs/internal/contracts/ir-mode-registry.md.
+ * which of the mode's views is active (contracts/ir-mode-registry.md
+ * "Views"), the editor's current text, the debounced parse-on-change
+ * effect, and the resulting graph (via useGraphData). Mode switching and
+ * parsing are driven entirely by the IR mode registry (src/irModes).
  */
 export function useIRWorkspace() {
   const [modeKey, setModeKey] = useState<IRModeKey>(DEFAULT_IR_MODE_KEY);
-  const mode = IR_MODES[modeKey];
+  // Widen to the contract type: per-mode inferred literals differ in which
+  // optional fields (views, dagreOptions) they carry.
+  const mode: IRModeDefinition = IR_MODES[modeKey];
+  // null = the mode's default view (views[0], or the implicit single view).
+  const [viewKey, setViewKey] = useState<string | null>(null);
+  const activeView =
+    mode.views?.find((view) => view.key === viewKey) ?? mode.views?.[0];
   const [code, setCode] = useState(mode.defaultCode);
   const [error, setError] = useState<string | null>(null);
 
@@ -29,8 +36,12 @@ export function useIRWorkspace() {
   useEffect(() => {
     const timer = setTimeout(() => {
       try {
-        const graph = mode.parse(code);
-        updateGraph(graph, mode);
+        const parse = activeView?.parse ?? mode.parse;
+        const graph = parse(code);
+        updateGraph(graph, {
+          edgeBuilder: activeView?.edgeBuilder ?? mode.edgeBuilder,
+          dagreOptions: activeView?.dagreOptions ?? mode.dagreOptions,
+        });
         setError(null);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Unknown error");
@@ -38,11 +49,17 @@ export function useIRWorkspace() {
     }, PARSE_DEBOUNCE_MS);
 
     return () => clearTimeout(timer);
-  }, [code, mode, updateGraph]);
+  }, [code, mode, activeView, updateGraph]);
 
   const changeMode = useCallback((newModeKey: IRModeKey) => {
     setModeKey(newModeKey);
+    setViewKey(null); // back to the new mode's default view
     setCode(IR_MODES[newModeKey].defaultCode);
+  }, []);
+
+  // Switching views keeps the editor code — that is the point of views.
+  const changeView = useCallback((newViewKey: string) => {
+    setViewKey(newViewKey);
   }, []);
 
   const clearCode = useCallback(() => setCode(""), []);
@@ -50,6 +67,8 @@ export function useIRWorkspace() {
   return {
     mode,
     modeKey,
+    views: mode.views,
+    activeViewKey: activeView?.key ?? null,
     code,
     setCode,
     error,
@@ -59,6 +78,7 @@ export function useIRWorkspace() {
     onEdgesChange,
     resetLayout,
     changeMode,
+    changeView,
     clearCode,
   };
 }

--- a/src/irModes/llvmMode.ts
+++ b/src/irModes/llvmMode.ts
@@ -1,4 +1,4 @@
-import { parseLLVM } from "../parser/llvm";
+import { parseLLVM, parseLLVMUseDef } from "../parser/llvm";
 import { codeGraphEdgeBuilder } from "../utils/layout";
 import LLVMBasicBlockNode from "../components/Graph/LLVM/LLVMBasicBlockNode";
 import LLVMFunctionHeaderNode from "../components/Graph/LLVM/LLVMFunctionHeaderNode";
@@ -7,6 +7,8 @@ import LLVMAttributeGroupNode from "../components/Graph/LLVM/LLVMAttributeGroupN
 import LLVMMetadataNode from "../components/Graph/LLVM/LLVMMetadataNode";
 import LLVMDeclarationNode from "../components/Graph/LLVM/LLVMDeclarationNode";
 import LLVMExitNode from "../components/Graph/LLVM/LLVMExitNode";
+import LLVMUseDefInstructionNode from "../components/Graph/LLVM/UseDef/LLVMUseDefInstructionNode";
+import LLVMUseDefValueNode from "../components/Graph/LLVM/UseDef/LLVMUseDefValueNode";
 import type { IRModeDefinition } from "./types";
 
 const DEFAULT_CODE = `
@@ -55,6 +57,19 @@ export const llvmMode = {
     llvmMetadata: LLVMMetadataNode,
     llvmDeclaration: LLVMDeclarationNode,
     llvmExit: LLVMExitNode,
+    llvmUseDefInstruction: LLVMUseDefInstructionNode,
+    llvmUseDefValue: LLVMUseDefValueNode,
   },
   edgeBuilder: codeGraphEdgeBuilder,
+  // views[0] shares parse/edgeBuilder with the top-level fields per the
+  // registry contract ("Views"): it IS the default view.
+  views: [
+    { key: "cfg", label: "CFG", parse: parseLLVM },
+    {
+      key: "use-def",
+      label: "Use-Def",
+      parse: parseLLVMUseDef,
+      dagreOptions: { ranksep: 60, nodesep: 40 },
+    },
+  ],
 } satisfies IRModeDefinition;

--- a/src/irModes/types.ts
+++ b/src/irModes/types.ts
@@ -22,11 +22,43 @@ export interface IRModeDefinition {
   /** Text -> graph. Throws Error on invalid input (see the registry contract
    * for SelectionDAG's per-line tolerance, which is not an exception to this). */
   parse: (code: string) => GraphData;
-  /** This mode's React Flow node renderers, keyed by the camelCase nodeType. */
+  /** This mode's React Flow node renderers, keyed by the camelCase nodeType.
+   * Covers every view's renderers (GraphViewer merges per mode, not per view). */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   nodeTypes: Record<string, ComponentType<NodeProps<any>>>;
   /** How to classify and build this mode's edges (see IREdgeBuilder). */
   edgeBuilder: IREdgeBuilder;
   /** Dagre layout overrides, e.g. SelectionDAG's wider row spacing. */
   dagreOptions?: Partial<dagre.GraphLabel>;
+  /**
+   * Optional alternative projections of the same text (e.g. LLVM's CFG vs
+   * Use-Def). When present: >= 2 entries, views[0] is the default and must
+   * behave identically to the top-level parse/edgeBuilder/dagreOptions
+   * (share the function references). See the registry contract, "Views".
+   */
+  views?: IRViewDefinition[];
 }
+
+/** One selectable projection of a mode's text (registry contract, "Views"). */
+export interface IRViewDefinition {
+  /** Stable identifier, e.g. "cfg", "use-def". */
+  key: string;
+  /** Toggle label, e.g. "CFG". */
+  label: string;
+  /** Text -> graph; same throw-on-invalid rule as the mode's parse. */
+  parse: (code: string) => GraphData;
+  /** Defaults to the mode's edgeBuilder. */
+  edgeBuilder?: IREdgeBuilder;
+  /** Defaults to the mode's dagreOptions. */
+  dagreOptions?: Partial<dagre.GraphLabel>;
+}
+
+/**
+ * The layout-relevant behavior of the active view: what useGraphData needs
+ * to lay a graph out. A bare IRModeDefinition satisfies it structurally
+ * (single-view modes), and useIRWorkspace builds one from the active view.
+ */
+export type IRLayoutBehavior = Pick<
+  IRModeDefinition,
+  "edgeBuilder" | "dagreOptions"
+>;

--- a/src/parser/llvm/index.ts
+++ b/src/parser/llvm/index.ts
@@ -1,3 +1,3 @@
 // Entry point for the LLVM-IR parser: the line-oriented implementation
 // (docs/internal/plans/2026-07-llvm-line-oriented-parser.md).
-export { parseLLVM, parseLLVMToAST } from "./parse";
+export { parseLLVM, parseLLVMToAST, parseLLVMUseDef } from "./parse";

--- a/src/parser/llvm/parse.ts
+++ b/src/parser/llvm/parse.ts
@@ -11,6 +11,7 @@
 import type { GraphData } from "../../types/graph";
 import type { LLVMModule } from "../../ast/llvmAST";
 import { convertASTToGraph } from "../../graphBuilder/llvmGraphBuilder";
+import { convertASTToUseDefGraph } from "../../graphBuilder/llvmUseDefGraphBuilder";
 import { buildModule } from "./module";
 
 export function parseLLVMToAST(input: string): LLVMModule {
@@ -19,4 +20,13 @@ export function parseLLVMToAST(input: string): LLVMModule {
 
 export function parseLLVM(input: string): GraphData {
   return convertASTToGraph(buildModule(input));
+}
+
+/**
+ * Use-Def projection of the same text: the second view of the `llvm-ir`
+ * mode (docs/internal/specs/llvm-use-def-view.md). Same AST, different
+ * graphBuilder — no parser changes are involved.
+ */
+export function parseLLVMUseDef(input: string): GraphData {
+  return convertASTToUseDefGraph(buildModule(input));
 }

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -5,6 +5,8 @@ import type {
   LLVMFunctionHeaderData,
   LLVMGlobalVariable,
   LLVMMetadata,
+  LLVMUseDefInstructionData,
+  LLVMUseDefValueData,
 } from "../ast/llvmAST";
 import type { MermaidASTNode } from "../ast/mermaidAST";
 import type { SelectionDAGNode as SelectionDAGNodeAST } from "../ast/selectionDAGAST";
@@ -31,6 +33,8 @@ type GraphNodeAstData =
   | { nodeType: "llvm-metadata"; astData: LLVMMetadata }
   | { nodeType: "llvm-declaration"; astData: LLVMDeclaration }
   | { nodeType: "llvm-exit"; astData: Record<string, never> }
+  | { nodeType: "llvm-useDefInstruction"; astData: LLVMUseDefInstructionData }
+  | { nodeType: "llvm-useDefValue"; astData: LLVMUseDefValueData }
   | { nodeType: "mermaid-node"; astData: MermaidASTNode }
   | { nodeType: "selectionDAG-node"; astData: SelectionDAGNodeAST }
   | { nodeType?: undefined; astData?: undefined };
@@ -48,6 +52,11 @@ export interface GraphEdge {
   sourceHandle?: string;
   targetHandle?: string;
   isChainOrGlue?: boolean;
+  /**
+   * Render with a dash pattern (strokeDasharray) via the standard edge
+   * factory. Mode-agnostic; used by the LLVM Use-Def view's phi edges.
+   */
+  dashed?: boolean;
 }
 
 export interface GraphData {

--- a/src/utils/__tests__/converter.test.ts
+++ b/src/utils/__tests__/converter.test.ts
@@ -9,6 +9,7 @@ import {
   NODE_PADDING,
 } from "../converter";
 import type { GraphNode, GraphEdge } from "../../types/graph";
+import { USE_DEF_BADGE_ROW_HEIGHT } from "../../components/Graph/LLVM/UseDef/useDefStyleConstants";
 
 describe("createSelectionDAGReactFlowEdge", () => {
   it("should create a normal edge when isChainOrGlue is false", () => {
@@ -133,6 +134,38 @@ describe("calculateNodeDimensions", () => {
     expect(dims.height).toBe(2 * FALLBACK_LINE_HEIGHT + NODE_PADDING * 2);
   });
 
+  it("should give a use-def instruction card a taller box than a value pill", () => {
+    const label = "%1 = add i32 %0, 1";
+    const instruction: GraphNode = {
+      id: "f_main_ud_entry_i0",
+      label,
+      nodeType: "llvm-useDefInstruction",
+      astData: {
+        text: label,
+        def: "1",
+        isTerminator: false,
+        blockLabel: "entry",
+        blockIndex: 0,
+      },
+    };
+    const value: GraphNode = {
+      id: "f_main_udarg_a",
+      label,
+      nodeType: "llvm-useDefValue",
+      astData: { name: "a", kind: "argument", paramType: "i32" },
+    };
+
+    const instructionDims = calculateNodeDimensions(instruction);
+    const valueDims = calculateNodeDimensions(value);
+
+    // Same text, same width; the instruction card additionally stacks the
+    // block badge row above the code line.
+    expect(instructionDims.width).toBe(valueDims.width);
+    expect(instructionDims.height).toBe(
+      valueDims.height + USE_DEF_BADGE_ROW_HEIGHT,
+    );
+  });
+
   it("should handle empty label", () => {
     const node: GraphNode = {
       id: "E",
@@ -249,5 +282,28 @@ describe("createReactFlowEdge", () => {
 
     const rfEdge = createReactFlowEdge(graphEdge);
     expect(rfEdge.label).toBeUndefined();
+  });
+
+  it("should create a dashed edge when dashed is set", () => {
+    const graphEdge: GraphEdge = {
+      id: "e3",
+      source: "A",
+      target: "B",
+      dashed: true,
+    };
+
+    const rfEdge = createReactFlowEdge(graphEdge);
+    expect(rfEdge.style).toEqual({ stroke: "#666", strokeDasharray: "6 6" });
+  });
+
+  it("should not set strokeDasharray when dashed is not set", () => {
+    const graphEdge: GraphEdge = {
+      id: "e4",
+      source: "A",
+      target: "B",
+    };
+
+    const rfEdge = createReactFlowEdge(graphEdge);
+    expect(rfEdge.style).not.toHaveProperty("strokeDasharray");
   });
 });

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -12,6 +12,13 @@ import {
   NODE_LINE_HEIGHT,
 } from "../components/Graph/common/nodeTextStyle";
 import { CODE_FRAGMENT_PADDING_Y } from "../components/Graph/common/CodeFragment";
+import {
+  USE_DEF_BADGE_FONT_SIZE,
+  USE_DEF_BADGE_PADDING_X,
+  USE_DEF_BADGE_ROW_HEIGHT,
+  USE_DEF_CARD_BORDER,
+  USE_DEF_CARD_PADDING,
+} from "../components/Graph/LLVM/UseDef/useDefStyleConstants";
 import { getFontMetrics } from "./fontUtils";
 
 export const NODE_PADDING = 20;
@@ -147,9 +154,69 @@ const calculateCodeNodeDimensions = (
   return { width, height };
 };
 
+// Use-def instruction/value cards render through NodeShell (10px padding,
+// 1px border), not the 20px NODE_PADDING boxes, so they get their own
+// estimation. The Use-Def graph is flat (no containers), so an inaccurate
+// estimate is cosmetic — it only shifts Dagre's spacing — and erring a few
+// px large reads better than nodes overlapping.
+const MIN_CHARS_USE_DEF = 8;
+const MAX_CHARS_USE_DEF = 80;
+const USE_DEF_SIZE_SLACK = 8;
+
+/**
+ * Width of the block badge chip: its text at the badge font size (scaled
+ * from the measured monospace metrics) plus its horizontal padding. A short
+ * instruction under a long block label would otherwise get a card narrower
+ * than its own badge.
+ */
+const estimateBadgeWidth = (blockLabel: string, charWidth: number) => {
+  const scale = USE_DEF_BADGE_FONT_SIZE / parseFloat(NODE_FONT_SIZE);
+  return blockLabel.length * charWidth * scale + USE_DEF_BADGE_PADDING_X * 2;
+};
+
+const calculateUseDefCardDimensions = (node: GraphNode) => {
+  const metrics = getFontMetrics(
+    NODE_FONT_FAMILY,
+    NODE_FONT_SIZE,
+    NODE_LINE_HEIGHT,
+  );
+  const lines = getLabelLines(node.label);
+  const { maxLineLength, totalLines } = measureWrappedLines(
+    lines,
+    MAX_CHARS_USE_DEF,
+  );
+  const chars = Math.max(
+    Math.min(maxLineLength, MAX_CHARS_USE_DEF),
+    MIN_CHARS_USE_DEF,
+  );
+  // NodeShell frame: padding and border on both sides.
+  const frame = (USE_DEF_CARD_PADDING + USE_DEF_CARD_BORDER) * 2;
+  // Instruction cards stack a block badge chip above the code line; value
+  // pills have no badge row.
+  const badgeLabel =
+    node.nodeType === "llvm-useDefInstruction" ? node.astData.blockLabel : null;
+  const badgeRow = badgeLabel === null ? 0 : USE_DEF_BADGE_ROW_HEIGHT;
+  const contentWidth = Math.max(
+    chars * metrics.width,
+    badgeLabel === null ? 0 : estimateBadgeWidth(badgeLabel, metrics.width),
+  );
+
+  return {
+    width: contentWidth + frame + USE_DEF_SIZE_SLACK,
+    height: totalLines * metrics.height + frame + badgeRow + USE_DEF_SIZE_SLACK,
+  };
+};
+
 export const calculateNodeDimensions = (node: GraphNode) => {
   if (node.nodeType === "selectionDAG-node") {
     return calculateSelectionDAGDimensions(node);
+  }
+
+  if (
+    node.nodeType === "llvm-useDefInstruction" ||
+    node.nodeType === "llvm-useDefValue"
+  ) {
+    return calculateUseDefCardDimensions(node);
   }
 
   return calculateCodeNodeDimensions(node);
@@ -194,7 +261,10 @@ export const createReactFlowEdge = (
       type: MarkerType.ArrowClosed,
       color: "#666",
     },
-    style: { stroke: "#666" },
+    style: {
+      stroke: "#666",
+      ...(edge.dashed ? { strokeDasharray: "6 6" } : {}),
+    },
   };
 };
 


### PR DESCRIPTION
## Summary

Adds a second projection to the LLVM-IR mode: a **Use-Def view** showing SSA dataflow, toggled next to the existing CFG view. Consumes the parser's §3.5 `defs`/`uses` fields (this is the consumer that spec section deferred).

- **View toggle, not a 4th mode** — the registry contract gains `views?: IRViewDefinition[]`; switching views keeps the editor code, switching modes still resets it. Single-view modes (Mermaid, SelectionDAG) are untouched.
- **Flat dataflow graph** — one node per instruction/terminator that defines or reads a value; Dagre ranks nodes directly by use-def edges, so vertical position means dataflow depth. Lines with no defs and no uses (`br label %x`, `ret void`) emit no node.
- **Block correspondence via badges** — each instruction card carries a colored chip naming its basic block (8-color muted palette cycled by block index) instead of container nodes.
- **Value pills** — function arguments and unresolved names get their own source nodes (styled differently), so edge construction is total on degraded input.
- **phi edges** — dashed, labeled `%v (%bb)` with the incoming block(s), extracted textually so the graphBuilder keeps its no-parser-imports layering.

This replaces the container/compound-layout prototype (branch `claude/llvm-ir-use-def-graph-j6y5fs`): estimated container sizes drifted from rendered sizes and React Flow's `extent: "parent"` clamping cascaded children into overlap. The plan's retrospective (`docs/internal/plans/2026-08-llvm-use-def-view.md` §2) records why compound layout was rejected.

Docs-first: normative spec `docs/internal/specs/llvm-use-def-view.md` (every rule pinned by a named test), contract updates in `ir-mode-registry.md` (Views) and `graph-data.md` (`dashed`, two nodeTypes), plus user docs.

## Verification

- 511 unit/integration tests (23 new builder tests pinning the spec, converter and integration coverage) and 7 Playwright E2E tests pass; lint / format / build clean.
- Externally audited (commit-range review by a non-Claude model): confirmed flat-graph invariants, omission rule, phi scan, and no regression to existing modes.

## Known follow-ups (pre-existing on main, deliberately not fixed here)

1. Perpetual re-parse loop: `useGraphData.updateGraph` is recreated on every nodes/edges change, so the 750 ms parse effect re-fires indefinitely (predates this branch).
2. Quoted-identifier id collision: `uniqueId` strips every `@`/`%`/`"`, so `@\"a@b\"` and `@ab` both prefix to `func_ab` in both the CFG and Use-Def builders (documented as a caveat in the new spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHc8KY5jBeRifdoPygjk6p