### PR TITLE
feat: quiet gray shell chrome — revert the visual language, keep canvas-first

### DIFF
--- a/docs/internal/plans/2026-08-canvas-first-shell.md
+++ b/docs/internal/plans/2026-08-canvas-first-shell.md
@@ -94,51 +94,61 @@ authoritative where they differ from §§1–4 above. The proposal predates the 
 Use-Def view toggle (`docs/internal/specs/llvm-use-def-view.md`), so the toolbar
 it describes is missing one control; that gap is closed here.
 
-### Concept: the editor panel is itself a node
+### Concept: quiet shell chrome, code-colored canvas
 
-All floating chrome — editor panel, collapsed pill, canvas control cluster —
-reuses the **exact visual grammar of the graph nodes** rendered by
-`src/components/Graph/common/NodeShell.tsx`: white surface, `1px solid #777`
-border, `4px` border radius, monospace type, and NodeShell's **corner-chip
-idiom** (a small label chip in the top-left corner, grey background, bold 12 px,
-rounded only on the outer top-left and inner bottom-right corner). The shell
-does not introduce a second visual language; it extends the one the canvas
-already speaks.
+Floating chrome — editor panel, collapsed pill, canvas control cluster — uses
+the pre-#60 **quiet gray language**: neutral grays, sans-serif type, light
+borders, no decorated hue. The graph nodes keep their own visual grammar
+(`src/components/Graph/common/NodeShell.tsx`: white surface, `1px solid #777`
+border, `4px` radius, monospace type, corner-chip idiom) unchanged — node
+styling is out of scope for this plan. The shell chrome does **not** borrow
+that grammar; the two are deliberately distinct now, so the graph nodes read
+as the one visually "interesting" layer and the chrome stays out of their way.
 
 ### Design tokens
 
 All values are derived from colors already present in the codebase; no new hues
 are invented.
 
-| Token       | Value                                                         | Use                                                                  |
-| ----------- | ------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `ground`    | `#FAFAFA`                                                     | Full-viewport canvas background; dot `<Background />` dots `#D7DBDF` |
-| `paper`     | `#FFFFFF`                                                     | Surface of panel / pill / control cluster (identical to nodes)       |
-| `line`      | `#777`                                                        | Border color for all floating chrome (identical to NodeShell)        |
-| `ink`       | `#1F2328`                                                     | Primary text                                                         |
-| `ink-muted` | `#57606A`                                                     | Secondary text (status footer, chip labels)                          |
-| `ok`        | `#1A7F37`                                                     | Parse-success indicator only — never decorative                      |
-| `error`     | `#CF222E`                                                     | Parse-failure indicator only — never decorative                      |
-| `accent`    | `#8250DF`                                                     | Focus rings and selected states only (github-light entity purple)    |
-| elevation   | `0 1px 2px rgba(31,35,40,.08), 0 8px 24px rgba(31,35,40,.08)` | Floating chrome only; graph nodes stay flat (no shadow)              |
+| Token          | Value                                                                  | Use                                                                      |
+| -------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `ground`       | `#FAFAFA`                                                              | Full-viewport canvas background; dot `<Background />` dots `#D7DBDF`     |
+| `paper`        | `#FFFFFF`                                                              | Surface of panel / pill / control cluster (identical to nodes)           |
+| `control`      | `#d0d0d0` (hover `controlHover` `#999`, focused `controlFocus` `#777`) | Border on interactive shell controls (select, toggle group, buttons)     |
+| `line`         | `#999`                                                                 | Outer border of floating surfaces (panel, pill, control cluster)         |
+| `ink`          | `#1F2328`                                                              | Primary text                                                             |
+| `ink-muted`    | `#57606A`                                                              | Secondary text (status footer)                                           |
+| `ok`           | `#1A7F37`                                                              | Parse-success indicator only — never decorative                          |
+| `error`        | `#CF222E`                                                              | Parse-failure indicator only — never decorative                          |
+| `selectedFill` | `#e8e8e8` (text `#222`, weight 600)                                    | Selected toggle-button state (replaces the deleted `accent` token)       |
+| `hoverFill`    | `#f0f0f0`                                                              | Hover fill for shell chrome buttons                                      |
+| `focusRing`    | 2 px `#57606A`                                                         | Focus-visible ring on all interactive shell chrome (neutral, not accent) |
+| elevation      | `0 1px 2px rgba(31,35,40,.05), 0 4px 12px rgba(31,35,40,.06)`          | Floating chrome only; graph nodes stay flat (no shadow)                  |
+
+The `accent` (`#8250DF`) token from the original proposal is **deleted**.
+Green `ok` / red `error` are the only semantic (non-gray) colors anywhere in
+the shell. Graph nodes keep their existing `1px solid #777` border
+unchanged — that border is NodeShell's, not a shell-chrome token, and is out
+of scope here.
 
 - **No translucency and no backdrop blur anywhere.** All surfaces are fully
   opaque. This explicitly rejects the "subtle translucency/blur" allowed in §2.
-- **Typography**: no webfonts are added. The brand mark, corner chips, mode
-  selector, and status footer use the same monospace stack as the graph nodes
-  (`src/components/Graph/common/nodeTextStyle.ts`); all other UI text uses
-  `system-ui`.
+- **Typography**: no webfonts are added. All shell chrome (brand title, mode
+  selector, toggles, buttons) uses the app's system sans-serif stack
+  (`system-ui`). Monospace is reserved for the status footer (compiler-output
+  feel) and the canvas/graph nodes themselves — it is no longer used for shell
+  chrome.
 
-### Signature element: the brand corner chip
+### Signature element: the brand title
 
-The editor panel header carries a NodeShell-style corner chip labeled
-`ir-visualizer`. It is the app's signature mark and the clearest statement of
-the "panel as node" concept — the panel is literally a node with the app's name
-in its block label.
+The editor panel header carries a small sans-serif **"IR Visualizer" title**
+(~13 px, `#333`), vertically centered in the header row — not a NodeShell-style
+corner chip. The corner-chip idiom remains exclusively a graph-node affordance;
+the panel is chrome around the canvas, not a node itself.
 
 ### Panel header composition
 
-Left to right: the brand corner chip, the **IR mode selector** (registry-driven,
+Left to right: the brand title, the **IR mode selector** (registry-driven,
 unchanged contract), the **CFG/Use-Def view toggle** for modes that define
 `views`, a **Clear** action, and a **collapse** button. The view toggle moves
 out of the removed toolbar and into the panel header — **not** into the canvas
@@ -157,12 +167,12 @@ One line of monospace text, styled after a compiler diagnostic:
 
 ### Collapse pill and its position
 
-The panel collapses to a small floating pill rendered as a miniature node (same
-border and chip grammar) labeled `code`. Collapse state is session-local
-`useState`. The old narrow-mode `activePane: "editor" | "graph"` state is
-replaced by a single `panelOpen: boolean` shared by both wide and narrow modes.
-The pill sits **top-left in wide mode** and **bottom-left in narrow mode**
-(thumb reach).
+The panel collapses to a small floating pill, styled as a **plain small
+button** with a sans-serif `Code` label — not a miniature node. Collapse state
+is session-local `useState`. The old narrow-mode `activePane: "editor" |
+"graph"` state is replaced by a single `panelOpen: boolean` shared by both wide
+and narrow modes. The pill sits **top-left in wide mode** and **bottom-left in
+narrow mode** (thumb reach).
 
 ### Event containment
 
@@ -188,8 +198,9 @@ animations. Everything is disabled under `prefers-reduced-motion`.
 
 ### Accessibility floor
 
-2 px `accent`-colored focus rings on every interactive piece of chrome, full
-keyboard operability, and WCAG AA contrast for status-footer text.
+2 px `focusRing` (`#57606A`, neutral gray, not accent) on every interactive
+piece of chrome, full keyboard operability, and WCAG AA contrast for
+status-footer text.
 
 ### Spec sections affected
 
@@ -223,6 +234,24 @@ keep-last-good-graph-on-error behavior of `specs/graph-view.md` §1, and the
 topology-signature rules of §2 (full re-layout on signature change,
 position/edge-type preservation on content-only updates), all hold exactly as
 specified and remain pinned by the existing tests.
+
+## Amendment (2026-08-09): quiet visual language revision
+
+After using the shipped shell (PR #60), the node-grammar chrome described in
+"Agreed design decisions" above proved too heavy in practice: the panel,
+pill, and control cluster borrowing NodeShell's corner-chip idiom and
+monospace type meant the controls competed visually with the graph nodes
+instead of framing them, and the `accent` purple was the only decorated hue
+in an otherwise code-colored tool. The canvas-first **layout** from §§1–4
+(full-bleed canvas, floating panel, bottom-right control cluster, narrow-mode
+sheet) is unaffected and stays as shipped. Only the shell chrome's **visual
+language** reverts to the pre-#60 quiet gray look: neutral grays, sans-serif
+type, and light borders for panel/pill/controls, with the `accent` token
+deleted and the corner-chip/monospace grammar left exclusively to the graph
+nodes. "Agreed design decisions" above has been edited in place to reflect
+this; see the design-tokens table, the brand-title, collapse-pill, and
+accessibility-floor subsections for the specifics. `specs/graph-view.md` §6
+is updated to match.
 
 ## What does _not_ change
 

--- a/docs/internal/plans/2026-08-canvas-first-shell.md
+++ b/docs/internal/plans/2026-08-canvas-first-shell.md
@@ -110,22 +110,22 @@ as the one visually "interesting" layer and the chrome stays out of their way.
 All values are derived from colors already present in the codebase; no new hues
 are invented.
 
-| Token          | Value                                                                  | Use                                                                      |
-| -------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `ground`       | `#FAFAFA`                                                              | Full-viewport canvas background; dot `<Background />` dots `#D7DBDF`     |
-| `paper`        | `#FFFFFF`                                                              | Surface of panel / pill / control cluster (identical to nodes)           |
-| `control`      | `#d0d0d0` (hover `controlHover` `#999`, focused `controlFocus` `#777`) | Border on interactive shell controls (select, toggle group, buttons)     |
-| `line`         | `#999`                                                                 | Outer border of floating surfaces (panel, pill, control cluster)         |
-| `ink`          | `#1F2328`                                                              | Primary text                                                             |
-| `ink-muted`    | `#57606A`                                                              | Secondary text (status footer)                                           |
-| `ok`           | `#1A7F37`                                                              | Parse-success indicator only — never decorative                          |
-| `error`        | `#CF222E`                                                              | Parse-failure indicator only — never decorative                          |
-| `selectedFill` | `#e8e8e8` (text `#222`, weight 600)                                    | Selected toggle-button state (replaces the deleted `accent` token)       |
-| `hoverFill`    | `#f0f0f0`                                                              | Hover fill for shell chrome buttons                                      |
-| `focusRing`    | 2 px `#57606A`                                                         | Focus-visible ring on all interactive shell chrome (neutral, not accent) |
-| elevation      | `0 1px 2px rgba(31,35,40,.05), 0 4px 12px rgba(31,35,40,.06)`          | Floating chrome only; graph nodes stay flat (no shadow)                  |
+| Token          | Value                                                                  | Use                                                                                                                                                                                                                                          |
+| -------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ground`       | `#FAFAFA`                                                              | Full-viewport canvas background; dot `<Background />` dots `#D7DBDF`                                                                                                                                                                         |
+| `paper`        | `#FFFFFF`                                                              | Surface of panel / pill / control cluster (identical to nodes)                                                                                                                                                                               |
+| `control`      | `#d0d0d0` (hover `controlHover` `#999`, focused `controlFocus` `#777`) | Border on bordered interactive controls (select, toggle group, outlined buttons); `controlHover` applies to all of them, `controlFocus` only to the select's focused field border — toggles and buttons signal focus via `focusRing` instead |
+| `line`         | `#999`                                                                 | Outer border of floating surfaces (panel, pill, control cluster)                                                                                                                                                                             |
+| `ink`          | `#1F2328`                                                              | Primary text                                                                                                                                                                                                                                 |
+| `ink-muted`    | `#57606A`                                                              | Secondary text (status footer)                                                                                                                                                                                                               |
+| `ok`           | `#1A7F37`                                                              | Parse-success indicator only — never decorative                                                                                                                                                                                              |
+| `error`        | `#CF222E`                                                              | Parse-failure indicator only — never decorative                                                                                                                                                                                              |
+| `selectedFill` | `#e8e8e8` (text `#222`, weight 600)                                    | Selected toggle-button state (replaces the deleted `accent` token)                                                                                                                                                                           |
+| `hoverFill`    | `#f0f0f0`                                                              | Hover fill for shell chrome buttons                                                                                                                                                                                                          |
+| `focusRing`    | 2 px `#57606A`                                                         | Focus-visible ring on all interactive shell chrome (neutral, not accent)                                                                                                                                                                     |
+| elevation      | `0 1px 2px rgba(31,35,40,.05), 0 4px 12px rgba(31,35,40,.06)`          | Floating chrome only; graph nodes stay flat (no shadow)                                                                                                                                                                                      |
 
-The `accent` (`#8250DF`) token from the original proposal is **deleted**.
+The `accent` purple token from the original proposal is **deleted**.
 Green `ok` / red `error` are the only semantic (non-gray) colors anywhere in
 the shell. Graph nodes keep their existing `1px solid #777` border
 unchanged — that border is NodeShell's, not a shell-chrome token, and is out
@@ -138,6 +138,11 @@ of scope here.
   (`system-ui`). Monospace is reserved for the status footer (compiler-output
   feel) and the canvas/graph nodes themselves — it is no longer used for shell
   chrome.
+- **Icon-only buttons are deliberately borderless**: the panel collapse button
+  and the canvas control cluster's zoom / fit / reset buttons carry no
+  `control` border of their own — their enclosing surface (panel, pill,
+  cluster) already has one via `line` — and signal hover/focus with
+  `hoverFill` and `focusRing` instead.
 
 ### Signature element: the brand title
 

--- a/docs/internal/specs/graph-view.md
+++ b/docs/internal/specs/graph-view.md
@@ -116,8 +116,9 @@ design decisions this section encodes.
 A single overlay card at the **top-left**, inset from the viewport edges, holding everything
 that is not the canvas.
 
-- **Header**, left to right: the brand corner chip (`ir-visualizer`), the **mode selector**,
-  the **view toggle**, a **Clear** action, and a **collapse** button.
+- **Header**, left to right: the brand title ("IR Visualizer", small sans-serif, ~13 px,
+  `#333`), the **mode selector**, the **view toggle**, a **Clear** action, and a **collapse**
+  button.
 - **Mode selector** lists the registry modes in `IR_MODES` insertion order
   (LLVM-IR, SelectionDAG, Mermaid).
   > Pinned by: `e2e/smoke.spec.ts` (selects each mode by visible label). Order:
@@ -138,11 +139,11 @@ that is not the canvas.
   handler on the panel root is an additional safety net. _(observed, untested)_
 - **Resize**: right-edge drag via `usePaneResize` — min 280 px, max 60 vw, initial 420 px.
   Wide mode only. _(observed, untested)_
-- **Collapse**: the panel collapses to a small floating pill rendered as a miniature node
-  (same border and corner-chip grammar) labeled `code`, giving the graph the full viewport.
-  The state is a session-local `panelOpen: boolean` (no persistence); the same flag drives
-  wide and narrow mode. The pill sits **top-left in wide mode** and **bottom-left in narrow
-  mode**. _(observed, untested)_
+- **Collapse**: the panel collapses to a small floating pill styled as a plain small button
+  with a sans-serif `Code` label, giving the graph the full viewport. The state is a
+  session-local `panelOpen: boolean` (no persistence); the same flag drives wide and narrow
+  mode. The pill sits **top-left in wide mode** and **bottom-left in narrow mode**.
+  _(observed, untested)_
 
 ### 6.3 Status footer
 
@@ -180,31 +181,41 @@ drag-resizer is wide-mode-only. _(observed, untested)_
 
 ### 6.6 Visual grammar and design tokens
 
-All floating chrome — editor panel, collapsed pill, control cluster — reuses the graph
-nodes' visual grammar from `src/components/Graph/common/NodeShell.tsx`: `1px solid #777`
-border, `4px` radius, white surface, monospace type, and the corner-chip idiom (small label
-chip in the top-left corner, grey background, bold 12 px, rounded on the outer top-left and
-inner bottom-right corners only). Conceptually, the editor panel is itself a node.
+Floating chrome — editor panel, collapsed pill, control cluster — uses the quiet gray
+language: neutral grays, sans-serif type, and light borders, distinct from the graph nodes'
+own grammar in `src/components/Graph/common/NodeShell.tsx` (`1px solid #777` border, `4px`
+radius, white surface, monospace type, corner-chip idiom). That NodeShell grammar — including
+the corner-chip idiom — remains exclusively a graph-node affordance; the shell chrome does not
+borrow it, and the editor panel is chrome around the canvas, not a node itself.
 
-| Token       | Value                                                         | Use                                                      |
-| ----------- | ------------------------------------------------------------- | -------------------------------------------------------- |
-| `ground`    | `#FAFAFA`                                                     | Canvas background; `<Background />` dot color `#D7DBDF`  |
-| `paper`     | `#FFFFFF`                                                     | Panel / pill / control-cluster surface (same as nodes)   |
-| `line`      | `#777`                                                        | Border color for all floating chrome (same as NodeShell) |
-| `ink`       | `#1F2328`                                                     | Primary text                                             |
-| `ink-muted` | `#57606A`                                                     | Secondary text (status footer, chip labels)              |
-| `ok`        | `#1A7F37`                                                     | Parse success only — never decorative                    |
-| `error`     | `#CF222E`                                                     | Parse failure only — never decorative                    |
-| `accent`    | `#8250DF`                                                     | Focus rings and selected states only                     |
-| elevation   | `0 1px 2px rgba(31,35,40,.08), 0 8px 24px rgba(31,35,40,.08)` | Floating chrome only; graph nodes stay flat (no shadow)  |
+| Token          | Value                                                                  | Use                                                                      |
+| -------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `ground`       | `#FAFAFA`                                                              | Canvas background; `<Background />` dot color `#D7DBDF`                  |
+| `paper`        | `#FFFFFF`                                                              | Panel / pill / control-cluster surface (same as nodes)                   |
+| `control`      | `#d0d0d0` (hover `controlHover` `#999`, focused `controlFocus` `#777`) | Border on interactive shell controls (select, toggle group, buttons)     |
+| `line`         | `#999`                                                                 | Outer border of floating surfaces (panel, pill, control cluster)         |
+| `ink`          | `#1F2328`                                                              | Primary text                                                             |
+| `ink-muted`    | `#57606A`                                                              | Secondary text (status footer)                                           |
+| `ok`           | `#1A7F37`                                                              | Parse success only — never decorative                                    |
+| `error`        | `#CF222E`                                                              | Parse failure only — never decorative                                    |
+| `selectedFill` | `#e8e8e8` (text `#222`, weight 600)                                    | Selected toggle-button state                                             |
+| `hoverFill`    | `#f0f0f0`                                                              | Hover fill for shell chrome buttons                                      |
+| `focusRing`    | 2 px `#57606A`                                                         | Focus-visible ring on all interactive shell chrome (neutral, not accent) |
+| elevation      | `0 1px 2px rgba(31,35,40,.05), 0 4px 12px rgba(31,35,40,.06)`          | Floating chrome only; graph nodes stay flat (no shadow)                  |
+
+There is no `accent` token: the `#8250DF` purple used by the shipped shell (PR #60) has been
+removed. `ok` (green) and `error` (red) are the only semantic, non-gray colors anywhere in the
+shell chrome. Graph nodes keep their existing `1px solid #777` border unchanged — that border
+belongs to NodeShell, not to a shell-chrome token, and node styling is out of scope here.
 
 - **No translucency and no backdrop blur**: every surface is fully opaque.
-- **Typography**: no webfonts. The brand mark, corner chips, mode selector, and status footer
-  use the graph nodes' monospace stack (`common/nodeTextStyle.ts`); other UI text uses
-  `system-ui`.
+- **Typography**: no webfonts. All shell chrome — brand title, mode selector, view toggle,
+  buttons — uses the app's system sans-serif stack (`system-ui`). Monospace is reserved for
+  the status footer (compiler-output feel) and the canvas/graph nodes; it is no longer used
+  anywhere in the shell chrome.
 - **Motion**: exactly one animation — the panel ⇄ pill collapse/expand morph (~180 ms
   ease-out) with an animated `fitView` recenter. Disabled under `prefers-reduced-motion`.
-- **Accessibility floor**: 2 px `accent` focus rings on all interactive chrome, keyboard
-  operability, WCAG AA contrast for status-footer text.
+- **Accessibility floor**: 2 px `focusRing` (neutral gray `#57606A`, not accent) on all
+  interactive chrome, keyboard operability, WCAG AA contrast for status-footer text.
 
 _(§6.6 as a whole: observed, untested — the tokens are enforced by review, not by tests.)_

--- a/docs/internal/specs/graph-view.md
+++ b/docs/internal/specs/graph-view.md
@@ -188,22 +188,22 @@ radius, white surface, monospace type, corner-chip idiom). That NodeShell gramma
 the corner-chip idiom — remains exclusively a graph-node affordance; the shell chrome does not
 borrow it, and the editor panel is chrome around the canvas, not a node itself.
 
-| Token          | Value                                                                  | Use                                                                      |
-| -------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `ground`       | `#FAFAFA`                                                              | Canvas background; `<Background />` dot color `#D7DBDF`                  |
-| `paper`        | `#FFFFFF`                                                              | Panel / pill / control-cluster surface (same as nodes)                   |
-| `control`      | `#d0d0d0` (hover `controlHover` `#999`, focused `controlFocus` `#777`) | Border on interactive shell controls (select, toggle group, buttons)     |
-| `line`         | `#999`                                                                 | Outer border of floating surfaces (panel, pill, control cluster)         |
-| `ink`          | `#1F2328`                                                              | Primary text                                                             |
-| `ink-muted`    | `#57606A`                                                              | Secondary text (status footer)                                           |
-| `ok`           | `#1A7F37`                                                              | Parse success only — never decorative                                    |
-| `error`        | `#CF222E`                                                              | Parse failure only — never decorative                                    |
-| `selectedFill` | `#e8e8e8` (text `#222`, weight 600)                                    | Selected toggle-button state                                             |
-| `hoverFill`    | `#f0f0f0`                                                              | Hover fill for shell chrome buttons                                      |
-| `focusRing`    | 2 px `#57606A`                                                         | Focus-visible ring on all interactive shell chrome (neutral, not accent) |
-| elevation      | `0 1px 2px rgba(31,35,40,.05), 0 4px 12px rgba(31,35,40,.06)`          | Floating chrome only; graph nodes stay flat (no shadow)                  |
+| Token          | Value                                                                  | Use                                                                                                                                                                                                                                          |
+| -------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ground`       | `#FAFAFA`                                                              | Canvas background; `<Background />` dot color `#D7DBDF`                                                                                                                                                                                      |
+| `paper`        | `#FFFFFF`                                                              | Panel / pill / control-cluster surface (same as nodes)                                                                                                                                                                                       |
+| `control`      | `#d0d0d0` (hover `controlHover` `#999`, focused `controlFocus` `#777`) | Border on bordered interactive controls (select, toggle group, outlined buttons); `controlHover` applies to all of them, `controlFocus` only to the select's focused field border — toggles and buttons signal focus via `focusRing` instead |
+| `line`         | `#999`                                                                 | Outer border of floating surfaces (panel, pill, control cluster)                                                                                                                                                                             |
+| `ink`          | `#1F2328`                                                              | Primary text                                                                                                                                                                                                                                 |
+| `ink-muted`    | `#57606A`                                                              | Secondary text (status footer)                                                                                                                                                                                                               |
+| `ok`           | `#1A7F37`                                                              | Parse success only — never decorative                                                                                                                                                                                                        |
+| `error`        | `#CF222E`                                                              | Parse failure only — never decorative                                                                                                                                                                                                        |
+| `selectedFill` | `#e8e8e8` (text `#222`, weight 600)                                    | Selected toggle-button state                                                                                                                                                                                                                 |
+| `hoverFill`    | `#f0f0f0`                                                              | Hover fill for shell chrome buttons                                                                                                                                                                                                          |
+| `focusRing`    | 2 px `#57606A`                                                         | Focus-visible ring on all interactive shell chrome (neutral, not accent)                                                                                                                                                                     |
+| elevation      | `0 1px 2px rgba(31,35,40,.05), 0 4px 12px rgba(31,35,40,.06)`          | Floating chrome only; graph nodes stay flat (no shadow)                                                                                                                                                                                      |
 
-There is no `accent` token: the `#8250DF` purple used by the shipped shell (PR #60) has been
+There is no `accent` token: the purple accent used by the shipped shell (PR #60) has been
 removed. `ok` (green) and `error` (red) are the only semantic, non-gray colors anywhere in the
 shell chrome. Graph nodes keep their existing `1px solid #777` border unchanged — that border
 belongs to NodeShell, not to a shell-chrome token, and node styling is out of scope here.
@@ -213,6 +213,10 @@ belongs to NodeShell, not to a shell-chrome token, and node styling is out of sc
   buttons — uses the app's system sans-serif stack (`system-ui`). Monospace is reserved for
   the status footer (compiler-output feel) and the canvas/graph nodes; it is no longer used
   anywhere in the shell chrome.
+- **Icon-only buttons are deliberately borderless**: the panel collapse button and the canvas
+  control cluster's zoom / fit / reset buttons carry no `control` border of their own — their
+  enclosing surface (panel, pill, cluster) already has one via `line` — and signal
+  hover/focus with `hoverFill` and `focusRing` instead.
 - **Motion**: exactly one animation — the panel ⇄ pill collapse/expand morph (~180 ms
   ease-out) with an animated `fitView` recenter. Disabled under `prefers-reduced-motion`.
 - **Accessibility floor**: 2 px `focusRing` (neutral gray `#57606A`, not accent) on all

--- a/src/components/AppShell/EditorPanel.tsx
+++ b/src/components/AppShell/EditorPanel.tsx
@@ -19,9 +19,10 @@ import {
   SHELL_COLORS,
   SHELL_ELEVATION,
   SHELL_HAIRLINE,
+  SHELL_HOVER_FILL,
   SHELL_MOTION_MS,
   SHELL_RADIUS,
-  cornerChipSx,
+  SHELL_SELECTED_FILL,
   focusRingSx,
 } from "./shellTokens";
 
@@ -60,23 +61,40 @@ const surfaceSx = {
 
 const controlHeight = 26;
 
+/**
+ * Plain sans-serif wordmark. The chrome is intentionally quieter than the
+ * graph nodes, so no chip, no monospace — just a label sitting on the header
+ * baseline next to the controls.
+ */
+const brandSx = {
+  pl: 1,
+  fontSize: "13px",
+  fontWeight: 500,
+  lineHeight: 1,
+  color: "#333",
+  letterSpacing: "0.01em",
+  whiteSpace: "nowrap",
+  userSelect: "none",
+} as const;
+
 const selectSx = {
   height: controlHeight,
-  fontFamily: NODE_FONT_FAMILY,
   fontSize: "12px",
-  color: SHELL_COLORS.ink,
+  color: SHELL_COLORS.inkMuted,
   backgroundColor: SHELL_COLORS.paper,
   borderRadius: SHELL_RADIUS,
-  ".MuiOutlinedInput-notchedOutline": { borderColor: SHELL_COLORS.line },
-  "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: SHELL_COLORS.ink },
+  ".MuiOutlinedInput-notchedOutline": { borderColor: SHELL_COLORS.control },
+  "&:hover .MuiOutlinedInput-notchedOutline": {
+    borderColor: SHELL_COLORS.controlHover,
+  },
   "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-    borderColor: SHELL_COLORS.accent,
+    borderColor: SHELL_COLORS.controlFocus,
     borderWidth: "1px",
   },
   ".MuiSvgIcon-root": { color: SHELL_COLORS.inkMuted, fontSize: "16px" },
   ".MuiSelect-select": { py: "2px", pr: "24px !important", pl: "8px" },
   ".MuiSelect-select:focus-visible": {
-    outline: `2px solid ${SHELL_COLORS.accent}`,
+    outline: `2px solid ${SHELL_COLORS.inkMuted}`,
     outlineOffset: "1px",
     borderRadius: SHELL_RADIUS,
   },
@@ -90,12 +108,12 @@ const toggleGroupSx = {
     py: 0,
     textTransform: "none",
     color: SHELL_COLORS.inkMuted,
-    borderColor: SHELL_COLORS.line,
+    borderColor: SHELL_COLORS.control,
     borderRadius: SHELL_RADIUS,
     "&.Mui-selected": {
-      backgroundColor: SHELL_COLORS.paper,
-      borderColor: SHELL_COLORS.accent,
-      color: SHELL_COLORS.accent,
+      backgroundColor: SHELL_SELECTED_FILL,
+      borderColor: SHELL_COLORS.control,
+      color: "#222",
       fontWeight: 600,
     },
     ...focusRingSx,
@@ -107,14 +125,17 @@ const actionButtonSx = {
   fontSize: "11px",
   textTransform: "none",
   color: SHELL_COLORS.inkMuted,
-  borderColor: SHELL_COLORS.line,
+  borderColor: SHELL_COLORS.control,
   borderRadius: SHELL_RADIUS,
-  "&:hover": { borderColor: SHELL_COLORS.ink, backgroundColor: "#f0f0f0" },
+  "&:hover": {
+    borderColor: SHELL_COLORS.controlHover,
+    backgroundColor: SHELL_HOVER_FILL,
+  },
   ...focusRingSx,
 } as const;
 
 interface EditorPanelProps {
-  /** false collapses the panel to the floating `code` pill. */
+  /** false collapses the panel to the floating "Code" pill. */
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** Narrow mode (§6.5): bottom sheet instead of top-left card, no resizer. */
@@ -141,14 +162,14 @@ interface EditorPanelProps {
 
 /**
  * The floating editor panel (`specs/graph-view.md` §6.2/§6.3): a card at the
- * top-left holding everything that is not the canvas — brand corner chip, mode
+ * top-left holding everything that is not the canvas — the wordmark, mode
  * selector, view toggle, Clear, collapse, the Monaco editor, and the parse
  * status footer. In narrow mode (§6.5) the very same contents are anchored to
  * the bottom edge as a sheet instead; only the geometry changes.
  *
- * Conceptually the panel is itself a graph node: it reuses NodeShell's border,
- * radius, and corner-chip grammar. NodeShell is deliberately not imported —
- * it renders React Flow `Handle`s, which belong to the canvas, not the shell.
+ * The chrome is deliberately quiet — neutral grays and the app's sans-serif —
+ * so it reads as the tool around the graph rather than as another graph node.
+ * The only monospace here is the status footer, which is compiler output.
  */
 export function EditorPanel({
   open,
@@ -189,20 +210,27 @@ export function EditorPanel({
           left: PANEL_MARGIN,
           zIndex: 5,
           display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
           // The pill is the only way back to the editor on a touch screen, so
-          // narrow mode grows the miniature node's body (not its chip) until
-          // the hit target clears ~40 px in both directions.
-          padding: narrow ? "0 24px 20px 0" : "0 8px 4px 0",
+          // narrow mode pads it out until the hit target clears ~40 px in both
+          // directions.
+          padding: narrow ? "11px 20px" : "4px 10px",
+          minWidth: narrow ? 40 : "auto",
+          minHeight: narrow ? 40 : "auto",
           cursor: "pointer",
+          fontFamily: "inherit",
+          fontSize: "13px",
+          fontWeight: 500,
+          lineHeight: 1,
+          color: "#333",
           ...surfaceSx,
           ...morphSx,
           transformOrigin: morphOrigin(narrow),
           ...focusRingSx,
         }}
       >
-        <Box component="span" sx={cornerChipSx}>
-          code
-        </Box>
+        Code
       </Box>
     );
   }
@@ -231,7 +259,7 @@ export function EditorPanel({
         overflow: "hidden",
         ...surfaceSx,
         // The sheet sits on the viewport edge, so only its top corners can
-        // round; the node grammar's border is kept on all four sides.
+        // round; the surface border is kept on all four sides.
         borderRadius: narrow
           ? `${SHELL_RADIUS} ${SHELL_RADIUS} 0 0`
           : SHELL_RADIUS,
@@ -242,12 +270,12 @@ export function EditorPanel({
       <Box
         sx={{
           display: "flex",
-          alignItems: "flex-start",
+          alignItems: "center",
           borderBottom: `1px solid ${SHELL_HAIRLINE}`,
         }}
       >
-        <Box component="span" sx={cornerChipSx}>
-          ir-visualizer
+        <Box component="span" sx={brandSx}>
+          IR Visualizer
         </Box>
 
         <Box
@@ -273,7 +301,7 @@ export function EditorPanel({
               <MenuItem
                 key={irMode.key}
                 value={irMode.key}
-                sx={{ fontFamily: NODE_FONT_FAMILY, fontSize: "12px" }}
+                sx={{ fontSize: "12px" }}
               >
                 {irMode.label}
               </MenuItem>
@@ -319,7 +347,7 @@ export function EditorPanel({
               height: controlHeight,
               borderRadius: SHELL_RADIUS,
               color: SHELL_COLORS.inkMuted,
-              "&:hover": { backgroundColor: "#f0f0f0" },
+              "&:hover": { backgroundColor: SHELL_HOVER_FILL },
               ...focusRingSx,
             }}
           >

--- a/src/components/AppShell/EditorPanel.tsx
+++ b/src/components/AppShell/EditorPanel.tsx
@@ -110,6 +110,7 @@ const toggleGroupSx = {
     color: SHELL_COLORS.inkMuted,
     borderColor: SHELL_COLORS.control,
     borderRadius: SHELL_RADIUS,
+    "&:hover": { borderColor: SHELL_COLORS.controlHover },
     "&.Mui-selected": {
       backgroundColor: SHELL_SELECTED_FILL,
       borderColor: SHELL_COLORS.control,

--- a/src/components/AppShell/shellTokens.ts
+++ b/src/components/AppShell/shellTokens.ts
@@ -1,44 +1,53 @@
 /**
  * Design tokens for the canvas-first shell (`specs/graph-view.md` §6.6).
  *
- * Every floating surface — editor panel, collapsed pill, canvas control
- * cluster — reuses the graph nodes' visual grammar (`Graph/common/NodeShell`):
- * white surface, 1px #777 border, 4px radius, monospace type, corner chips.
- * The shell must not introduce a second visual language, so these constants
- * are the only place shell colors/geometry are defined.
+ * The shell chrome — editor panel, collapsed pill, canvas control cluster — is
+ * deliberately QUIETER than the graph it frames: neutral grays, the app's
+ * system sans-serif, light control borders, a barely-there elevation. The
+ * graph nodes own the loud end of the visual range (monospace, dark borders,
+ * corner chips), so the chrome must never compete with them; the nodes stay
+ * the protagonists and the chrome recedes to the edges of the viewport.
+ *
+ * These constants are the only place shell colors/geometry are defined.
  */
-import { NODE_FONT_FAMILY } from "../Graph/common/nodeTextStyle";
 
 export const SHELL_COLORS = {
   /** Full-viewport canvas background. */
   ground: "#FAFAFA",
   /** React Flow `<Background />` dot color. */
   groundDots: "#D7DBDF",
-  /** Surface of panel / pill / control cluster (identical to graph nodes). */
+  /** Surface of panel / pill / control cluster. */
   paper: "#FFFFFF",
-  /** Border color for all floating chrome (identical to NodeShell). */
-  line: "#777",
+  /** Outer border of the floating surfaces (panel, pill, control cluster). */
+  line: "#999",
+  /** Resting border of an interactive control (select, button, toggle). */
+  control: "#d0d0d0",
+  /** Hovered control border. */
+  controlHover: "#999",
+  /** Focused control border. */
+  controlFocus: "#777",
   ink: "#1F2328",
   inkMuted: "#57606A",
   /** Parse success only — never decorative. */
   ok: "#1A7F37",
   /** Parse failure only — never decorative. */
   error: "#CF222E",
-  /** Focus rings and selected states only. */
-  accent: "#8250DF",
 } as const;
 
-/** Floating chrome only; graph nodes stay flat. */
+/** Floating chrome only; graph nodes stay flat. Kept light on purpose. */
 export const SHELL_ELEVATION =
-  "0 1px 2px rgba(31,35,40,.08), 0 8px 24px rgba(31,35,40,.08)";
+  "0 1px 2px rgba(31,35,40,.05), 0 4px 12px rgba(31,35,40,.06)";
 
 export const SHELL_RADIUS = "4px";
 
-/** Hairline used inside a surface (NodeShell's chip borders use the same). */
+/** Hairline used inside a surface (header rule, footer rule, divider). */
 export const SHELL_HAIRLINE = "#ddd";
 
-/** NodeShell's chip background. */
-export const SHELL_CHIP_BACKGROUND = "#f0f0f0";
+/** Fill for hovered chrome controls and icon buttons. */
+export const SHELL_HOVER_FILL = "#f0f0f0";
+
+/** Fill for a selected chrome control (view toggle). */
+export const SHELL_SELECTED_FILL = "#e8e8e8";
 
 /** Inset of the floating editor panel from the viewport edges, in px. */
 export const PANEL_MARGIN = 16;
@@ -91,33 +100,10 @@ export function buildFitViewPadding(inset: ShellFitViewInset) {
   } as const;
 }
 
-/**
- * NodeShell's corner-chip geometry, reproduced for shell chrome. NodeShell
- * itself cannot be reused here because it renders React Flow `Handle`s.
- * Placed in normal flow (not absolutely positioned) so it can sit as the first
- * item of a flex header row while still hugging the surface's top-left corner.
- */
-export const cornerChipSx = {
-  alignSelf: "flex-start",
-  padding: "2px 6px",
-  backgroundColor: SHELL_CHIP_BACKGROUND,
-  borderTopLeftRadius: SHELL_RADIUS,
-  borderBottomRightRadius: SHELL_RADIUS,
-  borderRight: `1px solid ${SHELL_HAIRLINE}`,
-  borderBottom: `1px solid ${SHELL_HAIRLINE}`,
-  fontFamily: NODE_FONT_FAMILY,
-  fontSize: "12px",
-  fontWeight: "bold",
-  lineHeight: "16px",
-  color: SHELL_COLORS.inkMuted,
-  whiteSpace: "nowrap",
-  userSelect: "none",
-} as const;
-
-/** 2px accent focus ring on every interactive piece of shell chrome. */
+/** Neutral 2px focus ring on every interactive piece of shell chrome. */
 export const focusRingSx = {
   "&:focus-visible, &.Mui-focusVisible": {
-    outline: `2px solid ${SHELL_COLORS.accent}`,
+    outline: `2px solid ${SHELL_COLORS.inkMuted}`,
     outlineOffset: "1px",
   },
 } as const;

--- a/src/components/Graph/CanvasControls.tsx
+++ b/src/components/Graph/CanvasControls.tsx
@@ -2,10 +2,10 @@ import type { ReactNode } from "react";
 import { Panel, useReactFlow, type FitViewOptions } from "@xyflow/react";
 import { Box, IconButton } from "@mui/material";
 import {
-  SHELL_CHIP_BACKGROUND,
   SHELL_COLORS,
   SHELL_ELEVATION,
   SHELL_HAIRLINE,
+  SHELL_HOVER_FILL,
   SHELL_RADIUS,
   focusRingSx,
 } from "../AppShell/shellTokens";
@@ -56,7 +56,7 @@ function ControlButton({
         height: 28,
         borderRadius: SHELL_RADIUS,
         color: SHELL_COLORS.ink,
-        "&:hover": { backgroundColor: SHELL_CHIP_BACKGROUND },
+        "&:hover": { backgroundColor: SHELL_HOVER_FILL },
         ...focusRingSx,
       }}
     >


### PR DESCRIPTION
## What

The canvas-first shell from #60 keeps its layout; only the **visual language of the shell chrome** reverts to the quieter, pre-#60 engineer-tool look.

| Before (#60) | After |
| --- | --- |
| Purple accent `#8250DF` on selected toggle + focus rings | No accent. Selected toggle = gray fill `#e8e8e8` / `#222` / weight 600; neutral `#57606A` focus ring |
| `#777` borders on every control and surface | Controls `#d0d0d0` (hover `#999`, select focus `#777`); floating surfaces `#999`; elevation halved |
| `ir-visualizer` node-style corner chip, flex-start aligned | Centered sans-serif **IR Visualizer** wordmark (also fixes the header baseline jog) |
| Monospace across all chrome | Sans-serif chrome; monospace only in the parse-status footer and on the canvas |
| Collapse pill = miniature node | Collapse pill = plain `Code` button (narrow-mode 40px touch target kept) |

## Why

After living with #60, the "panel is a node" grammar proved too heavy: the chrome carried the same visual weight as the graph nodes and competed with them, and the purple was the only decorated hue in a tool whose real color is the syntax highlighting. The chrome now recedes so the graph stays the protagonist.

Deliberately unchanged: full-bleed canvas, floating panel, collapse pill, bottom-right control cluster, parse-status footer (no snackbar), fitView panel insets, narrow-mode bottom sheet, canvas ground `#FAFAFA`, and all graph node styling.

## Commits

- `859208a` **docs** — plan's design decisions + spec §6 respec'd first (docs-first)
- `ebc9bb0` **feat** — `shellTokens.ts`, `EditorPanel.tsx`, `CanvasControls.tsx`
- `d6bd23b` **fix** — external-audit findings: toggle `controlHover` border state; docs state that `controlFocus` is select-only and that icon-only buttons are deliberately borderless; accent hex literal dropped from prose so tree greps stay clean

## Notes for reviewers

- Styling-only diff — no props, state, event wiring, aria labels, or `data-testid` hooks changed.
- `SHELL_CHIP_BACKGROUND` was renamed to `SHELL_HOVER_FILL` (the old name referred to the deleted chip grammar) and `SHELL_SELECTED_FILL` added; `cornerChipSx` and the `accent` token are gone.
- Verification: unit 512 / e2e 7 / lint / build all pass. Reviewed visually in both wide and narrow modes, including collapse ⇄ expand and toggle hover.
- Reviewed by an independent external audit (fresh context, different model family); both of its findings are addressed in `d6bd23b` and re-verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)