### PR TITLE
docs: rewrite the getting-started UI section for the canvas-first shell

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -8,19 +8,32 @@ example already loaded.
 
 ## The UI
 
+The app is canvas-first: the graph fills the whole viewport, and everything else floats above
+it. There is no app toolbar and no left/right split — just the canvas, one editor panel at the
+top-left, and a control cluster at the bottom-right.
+
 ```
-┌───────────────────────────────────────────────┐
-│ ┌─ Editor panel ─────┐                      │
-│ │ IR Visualizer [Mode ▾]│   Full graph canvas  │
-│ │ [CFG|Use-Def] [Clear]│                      │
-│ │                       │                      │
-│ │ Code editor           │                      │
-│ │                       │      [+−][Fit]│Reset│
-│ │ ✓ parsed · nodes · edges│                      │
-│ └───────────────────────┘                      │
-└───────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ ┌────────────────────────────────────────────────────┐                       │
+│ │ IR Visualizer  [LLVM-IR ▾] [CFG|Use-Def]  Clear  ⌄ │                       │
+│ ├────────────────────────────────────────────────────┤                       │
+│ │ define i32 @f(i32 %a) {                            │                       │
+│ │   %x = add i32 %a, 1                               │← drag to resize       │
+│ │   br label %next                                   │                       │
+│ │ }                                                  │  graph canvas fills   │
+│ │                                                    │  the whole viewport   │
+│ ├────────────────────────────────────────────────────┤  behind the panel     │
+│ │ ✓ parsed · 7 nodes · 8 edges                       │                       │
+│ └────────────────────────────────────────────────────┘                       │
+│                                                                              │
+│                                                                              │
+│                                            [+] [−] [fit]  │  [reset layout]  │
+└──────────────────────────────────────────────────────────────────────────────┘
 ```
 
+- **Editor panel** (floating, top-left): holds everything that isn't the canvas — a header
+  row, the editor itself, and a status footer. Drag its right edge to make it wider or
+  narrower (wide screens only).
 - **Mode selector** (panel header): switch between **LLVM-IR**, **SelectionDAG**, and **Mermaid**.
   Switching loads that mode's example code, so you always start from something that renders.
   See [supported-formats.md](supported-formats.md) for what each mode accepts.
@@ -28,18 +41,26 @@ example already loaded.
   **Use-Def** views of the same code. Unlike switching modes, switching views keeps what you
   typed. See [supported-formats.md](supported-formats.md#llvm-ir).
 - **Editor**: type or paste IR. The graph re-renders about a second after you stop typing.
-  If the input doesn't parse, the panel's status footer shows the full error and the previous
-  graph stays until the input parses again.
-- **Clear**: empties the editor.
-- **Graph view**: scroll/pinch to zoom, drag the background to pan, drag nodes to rearrange
+- **Clear** (panel header): empties the editor.
+- **Collapse** (`⌄`, panel header): collapses the panel to a small **Code** pill when you want
+  the whole viewport for the graph; click the pill to bring the panel back.
+- **Status footer** (bottom of the panel): the only place parse status is reported — no popups
+  over the graph. A successful parse shows `✓ parsed · N nodes · M edges`; a failure shows
+  `error:` followed by the full message, and the previous graph stays on screen until the
+  input parses again.
+- **Graph canvas**: scroll/pinch to zoom, drag the background to pan, drag nodes to rearrange
   them. Node positions survive edits that don't change the graph's structure (e.g. editing an
   instruction inside a block), so your manual arrangement isn't lost while you type.
+- **Canvas controls** (floating, bottom-right): zoom in, zoom out, and fit view, then — past
+  the divider — **Reset Layout**. Fit view accounts for the editor panel, so the graph is
+  centred in the part of the canvas you can actually see.
 - **Reset Layout**: recomputes the automatic layout and re-fits the view — use it after
-  dragging nodes around or when a big edit makes the layout messy.
-- **Collapse**: collapse the panel to a **Code** pill when you want the whole viewport for the
-  graph; use the pill to reopen it.
-- **Narrow screens** (≤ 768 px): the editor becomes a bottom sheet over the full-screen
-  canvas. The same **Code** pill opens it, and the canvas controls move above the sheet.
+  dragging nodes around or when a big edit makes the layout messy. It's separated from the
+  zoom buttons by a divider because it discards your manual node positions.
+- **Narrow screens** (≤ 768 px): the canvas stays full-screen and the editor panel becomes a
+  **bottom sheet** covering roughly the lower half of the viewport. The **Code** pill moves to
+  the bottom-left and opens and closes the sheet, and the canvas controls lift above the sheet
+  while it's open. There's no Code/Graph toggle, and the drag-resize edge is wide-screen only.
 
 ## Reading the graphs
 


### PR DESCRIPTION
## What

Rewrites the "The UI" section of `docs/user/getting-started.md` to describe the canvas-first shell. Documentation only — no code changes.

## Why

The section still described the pre-canvas-first layout: an app toolbar, a left/right Code/Graph split, a drag-resizer between two fixed panes, and a top-right Reset Layout panel. None of that has existed since #60/#61 shipped.

The ASCII diagram was also structurally broken independently of being stale — misaligned box-drawing characters and an editor panel that overlapped the canvas border, so it did not render as a box in a monospace view.

`docs/internal/specs/graph-view.md` §6 was used as the source of truth throughout.

## What changed

- **Diagram** rewritten: full-viewport canvas, floating editor panel at top-left (header = brand, mode selector, view toggle, Clear, collapse), status footer inside the panel, annotated resize edge, and the bottom-right control cluster. Every line is a uniform 80 columns, verified equal-width so it stays square.
- **New bullets** for surfaces §6 specifies but the doc never covered:
  - editor panel as a container, with its wide-mode-only resize edge (§6.2)
  - status footer as the only parse-status channel, errors shown in full, no popup over the graph (§6.3)
  - canvas control cluster: zoom / fit / divider / reset ordering, and panel-aware `fitView` (§6.4)
- **Reset Layout** now states where it lives and why the divider separates it — it discards manual node positions (§2).
- **Narrow mode** corrected against §6.5: bottom sheet at roughly half the viewport height, pill moving to bottom-left, controls lifting above the open sheet, and explicit "no Code/Graph toggle; resize edge is wide-screen only."
- Added a framing sentence above the diagram stating there is no app toolbar and no split pane — the main thing a reader of the old docs needs un-learned.

## Notes for reviewers

- "Reading the graphs" is intentionally untouched: it describes graph grammar rather than shell layout, and contained no references to the old shell.
- The diagram uses `▾`, `⌄`, `✓`, `·`, `←`, `−`, consistent with glyphs already used elsewhere in `docs/`. These are East-Asian-ambiguous width, so alignment can shift in a CJK-width terminal — the same caveat applied to the previous diagram.
- `npm run format`, `npm run lint`, and `npm run test:run` (514 tests, 47 files) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)