### PR TITLE
docs: distill internal docs to single-source, declarative form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,51 +8,30 @@ The graph is rendered using react-flow.
 
 ## Engineering Principles
 
-- Do not preserve backwords compatibility.
+- Do not preserve backwards compatibility.
   Remove obsolete paths instead of adding compatibility layers, migrations.
 - Choose the simplest implementation that fully meets the current requirements.
-  Avoid speculative abstracitions, configuration, and indirection.
-- Keep components modular and converns clearly separated.
+  Avoid speculative abstractions, configuration, and indirection.
+- Keep components modular and concerns clearly separated.
 - Make architecture decisions for the long term.
   Do not accept stopgap that only works for now and is meant to be replaced later.
 
-## How it Works
+## Architecture
 
-See `docs/internal/architecture.md` for the full data-flow diagram and layer map.
+See `docs/internal/architecture.md` for the data-flow diagram and layer map.
 
-- Parses input text into an AST with the active mode's parser (`src/parser/*`). Mermaid and
-  SelectionDAG use Ohm-js grammars; LLVM-IR uses a line-oriented parser.
-- Converts AST into React Flow nodes and edges via `src/graphBuilder`.
-- Renders the graph using `react-flow` and calculates layout and edge routes with ELK (elkjs) `src/utils/layout.ts`.
-- Everything that differs per IR (parser, default code, editor language, node
-  components, edge/layout behavior) is centralized in the IR mode registry
-  (`src/irModes`) — see `docs/internal/contracts/ir-mode-registry.md`. Adding
-  a new IR should mean adding one registry entry plus that IR's own
-  parser/AST/graphBuilder/node-component files, not editing scattered
-  `if (mode === ...)` branches.
+One constraint to uphold: everything that differs per IR (parser, default code, editor language, node components, edge/layout behavior)
+is centralized in the IR mode registry (`src/irModes`) — see `docs/internal/contracts/ir-mode-registry.md`.
+Adding a new IR means adding one registry entry plus that IR's own
+parser/AST/graphBuilder/node-component files, not editing scattered `if (mode === ...)` branches.
 
-## Directory
+## Repository notes
 
-- `docs`: Project documentation (see `docs/README.md` for the structure and rules)
-  - `docs/internal/contracts`: Interface contracts between layers
-  - `docs/internal/specs`: Behavior specifications
-  - `docs/user`: User-facing documentation
-- `src`
-  - `src/ast`: AST definitions
-  - `src/components`: UI components
-    - `src/components/AppShell`: Full-canvas shell and floating editor panel components
-    - `src/components/Editor`: Code editor components
-    - `src/components/Graph`: React Flow graph components, colocated with `*.stories.tsx` files
-  - `src/graphBuilder`: Logic to transform AST into React Flow graph data (nodes and edges)
-  - `src/hooks`: Custom React hooks (e.g., `useGraphData`, `useIRWorkspace`)
-  - `src/irModes`: The IR mode registry — one file per IR plus the aggregating `index.ts`
-  - `src/parser`: Mode-specific parser implementations and Ohm-js grammar files
-  - `src/types`: Global TypeScript type definitions
-  - `src/utils`: Utility functions for layout (ELK), and other helpers
-  - `src/test`: Shared Vitest setup (jest-dom matchers)
-  - `src/__tests__`: Integration tests
-- `e2e`: Playwright smoke end-to-end tests
-- `.storybook`: Storybook configuration (component gallery for graph node components)
+Only the non-obvious conventions; explore `src/` directly for the rest.
+
+- `docs/` has its own structure and rules — see `docs/README.md`.
+- Graph node components in `src/components/Graph` are colocated with their `*.stories.tsx` files.
+- `e2e/` contains Playwright smoke tests only; unit/integration tests live in `src`.
 
 ## Setup commands
 
@@ -67,35 +46,28 @@ See `docs/internal/architecture.md` for the full data-flow diagram and layer map
 
 ## Rules
 
-- Documentation-first: `docs/` is the source of truth. Before changing code, update the relevant document under `docs/` (create it if missing). See `docs/README.md`.
-- Track proposed work and implementation progress in GitHub Issues. Issue titles must be English Conventional Commit messages suitable for the eventual squash commit.
-- Always run tests after making changes.
-- Always run `npm run format` after making changes.
-- Always run `npm run lint` after making changes.
+- Documentation-first: `docs/` is the source of truth.
+  Before changing code, update the relevant document under `docs/` (create it if missing).
+  See `docs/README.md`.
+- Track proposed work and implementation progress in GitHub Issues.
+- After making changes, run `npm run test:run`, `npm run format`, and `npm run lint`.
 
 ## Commits, issues, and pull requests
 
 Two principles govern how changes are named and described.
 
 A change has one name, and that name is its commit message.
-Titles for issues, PRs, and commits alike follow
-[Conventional Commits](https://www.conventionalcommits.org/)
-(e.g. `docs: update config schema`, `feat(match): add typo-tolerant matching`,
-`fix(zle): clear listing on accept-line`)
+Titles for issues, PRs, and commits alike follow [Conventional Commits](https://www.conventionalcommits.org/)
+(e.g. `docs: update config schema`, `feat(match): add typo-tolerant matching`, `fix(zle): clear listing on accept-line`)
 and are written in English so they flow through tooling.
-The issue names the change first;
-the PR reuses that title verbatim,
+The issue names the change first; the PR reuses that title verbatim,
 so it lands on `main` unedited as the commit message on squash merge.
 GitHub appends the ` (#N)` suffix at that point.
 Include a scope once the affected component is known.
 
-An issue body is written for a future reader
-who has no access to the conversation that spawned it.
-Open with one or two paragraphs stating the current state,
-the change or decision being made, and the reason;
-the body should stand on its own from there.
-Use vocabulary the reader can resolve:
+An issue body is written for a future reader who has no access to the conversation that spawned it.
+Open with one or two paragraphs stating the current state, the change or decision being made, and the reason;
+the body should stand on its own from there. Use vocabulary the reader can resolve:
 refer to other issues as `#N` plus a short description,
-and accompany any number used as evidence
-with its measurement environment and reproduction steps.
+and accompany any number used as evidence with its measurement environment and reproduction steps.
 Bodies may be English or Japanese.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,30 @@ See `docs/internal/architecture.md` for the full data-flow diagram and layer map
 - Always run tests after making changes.
 - Always run `npm run format` after making changes.
 - Always run `npm run lint` after making changes.
+
+## Commits, issues, and pull requests
+
+Two principles govern how changes are named and described.
+
+A change has one name, and that name is its commit message.
+Titles for issues, PRs, and commits alike follow
+[Conventional Commits](https://www.conventionalcommits.org/)
+(e.g. `docs: update config schema`, `feat(match): add typo-tolerant matching`,
+`fix(zle): clear listing on accept-line`)
+and are written in English so they flow through tooling.
+The issue names the change first;
+the PR reuses that title verbatim,
+so it lands on `main` unedited as the commit message on squash merge.
+GitHub appends the ` (#N)` suffix at that point.
+Include a scope once the affected component is known.
+
+An issue body is written for a future reader
+who has no access to the conversation that spawned it.
+Open with one or two paragraphs stating the current state,
+the change or decision being made, and the reason;
+the body should stand on its own from there.
+Use vocabulary the reader can resolve:
+refer to other issues as `#N` plus a short description,
+and accompany any number used as evidence
+with its measurement environment and reproduction steps.
+Bodies may be English or Japanese.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,17 @@ This project is an application that displays Intermediate Representation (IR) as
 When you enter text in the editor, the active IR mode parses it and displays the resulting graph.
 The graph is rendered using react-flow.
 
-### How it Works
+## Engineering Principles
+
+- Do not preserve backwords compatibility.
+  Remove obsolete paths instead of adding compatibility layers, migrations.
+- Choose the simplest implementation that fully meets the current requirements.
+  Avoid speculative abstracitions, configuration, and indirection.
+- Keep components modular and converns clearly separated.
+- Make architecture decisions for the long term.
+  Do not accept stopgap that only works for now and is meant to be replaced later.
+
+## How it Works
 
 See `docs/internal/architecture.md` for the full data-flow diagram and layer map.
 

--- a/docs/internal/contracts/edge-routing.md
+++ b/docs/internal/contracts/edge-routing.md
@@ -1,15 +1,12 @@
 # Contract: Edge routing (`routeEdges`)
 
-- **Status:** Implemented (2026-08-09)
-- **Motivation:** edge geometry is a pure function of the live node rectangles, computed
-  at render time by this repo's own orthogonal router. Everything downstream — the one
-  routing pass per graph, `RoutedEdge`'s per-edge lookup, the router's own test suite — is
-  written against a specific module boundary and a specific set of guarantees about what
-  it returns. Both used to live only in a plan file; this contract is their permanent home.
-  The router's internal algorithm (the Hanan grid, the A\* search, the fallback ladder) is
-  an implementation detail behind this boundary and is not reproduced here — see
-  `src/utils/edgeRouter.ts` and its inline documentation for how the guarantees below are
-  achieved.
+Edge geometry is a pure function of the live node rectangles, computed at render time by
+this repo's own orthogonal router. Everything downstream — the one routing pass per graph,
+`RoutedEdge`'s per-edge lookup, the router's own test suite — is written against the
+module boundary and the guarantees defined here. The router's internal algorithm (the
+Hanan grid, the A\* search, the fallback ladder) is an implementation detail behind this
+boundary and is not reproduced here — see `src/utils/edgeRouter.ts` and its inline
+documentation for how the guarantees below are achieved.
 
 ## The frozen boundary
 
@@ -135,4 +132,4 @@ React context; `RoutedEdge` looks up its own entry by edge id and never calls th
 itself. During a drag the hook narrows `requests` to the edges incident to the dragged
 node (still passing the **complete** `nodes` array, since a partial route must still avoid
 every obstacle) and runs a full pass once the drag stops — see `specs/graph-view.md` §4 for
-why that split is required rather than an optimization held in reserve.
+the frame-budget measurement behind that split.

--- a/docs/internal/contracts/graph-data.md
+++ b/docs/internal/contracts/graph-data.md
@@ -1,17 +1,11 @@
 # Contract: GraphData / GraphNode.astData
 
-- **Status:** Implemented (Phase 2, 2026-07-04)
-- **Motivation:** `GraphNode.astData` was `Record<string, any>`, forcing
-  `astData: x as unknown as Record<string, unknown>` casts in every graphBuilder and giving the
-  compiler no way to catch a mismatch between a node's `nodeType` and the shape of its `astData`.
+`GraphData`, `GraphNode`, and `GraphEdge` (`src/types/graph.ts`) are the single graph
+shape used by every IR mode, produced by the graphBuilders and consumed by
+converter/layout. `GraphNode.astData` is typed per `nodeType`, so a graphBuilder pushing
+the wrong AST type under a given `nodeType` is a compile error, not a silent `any`.
 
 ## GraphData / GraphEdge
-
-`GraphData` and `GraphEdge` (`src/types/graph.ts`) are the single graph shape used by every IR mode.
-Previously SelectionDAG had its own `SelectionDAGGraphData`/`SelectionDAGEdge` types purely because
-its edges carry a few extra optional fields (`sourceHandle`, `targetHandle`, `isChainOrGlue`, used to
-connect specific operand/type Handles instead of generic node boundaries). Those fields are now part
-of the single `GraphEdge` interface, always optional:
 
 ```ts
 interface GraphEdge {
@@ -27,13 +21,14 @@ interface GraphEdge {
 }
 ```
 
+The SelectionDAG-only fields connect specific operand/type Handles instead of generic node
+boundaries. They are optional fields on the one shared interface rather than a
+mode-specific edge type — that is what lets `useGraphData` and `layout.ts` run a single
+`updateGraph`/`getLayoutedElements` path for every mode.
+
 `dashed` is mode-agnostic: the standard edge factory (`createReactFlowEdge`) applies a dash
 pattern when it is set. The LLVM Use-Def view sets it on phi incoming-value edges
 (`specs/llvm-use-def-view.md` §3.1).
-
-This is what let `useGraphData` and `layout.ts` collapse their SelectionDAG-specific code paths
-(`updateSelectionDAGGraph`, `getSelectionDAGLayoutedElements`) into the single `updateGraph`/
-`getLayoutedElements` used by every mode.
 
 ## GraphNode.astData
 
@@ -64,28 +59,20 @@ instructions by dataflow; compound nodes were rejected because estimated contain
 from rendered sizes and React Flow parent clamping caused child overlap.
 
 The `llvm-useDef*` astData shapes (`LLVMUseDefInstructionData`, `LLVMUseDefValueData`) are
-view-data shapes living in `src/ast/llvmAST.ts` next to `LLVMFunctionHeaderData`, which set
-the precedent: not AST nodes of their own, just the typed payload a renderer expects.
-Conversion rules: `specs/llvm-use-def-view.md`.
+view-data shapes living in `src/ast/llvmAST.ts` next to `LLVMFunctionHeaderData`: not AST
+nodes of their own, just the typed payload a renderer expects. Conversion rules:
+`specs/llvm-use-def-view.md`.
 
-**What this buys:** a graphBuilder pushing `{ ..., nodeType: "llvm-globalVariable", astData: gVar }`
-is checked against the `LLVMGlobalVariable` shape at the call site — no cast needed, and pushing the
-wrong AST type under a given `nodeType` is now a compile error instead of a silent `any`.
+## Boundaries this contract does not type
 
-**What this does not buy:** React Flow's own `Node.data` (the object actually handed to a rendered
-node component as `NodeProps.data`) is untyped (`Record<string, unknown>`) by React Flow's own
-`Node<T>` generic not being threaded through this codebase's node arrays. Each node component (e.g.
-`LLVMBasicBlockNode`) still does one cast at that boundary — `data.astData as LLVMBasicBlock` — same
-as before. That cast is a single, narrow boundary cast consuming a third-party API's loose typing;
-it is not the systemic hole this contract closes (the hole was in _our own_ `GraphNode`/`GraphData`
-types, used across graphBuilder → converter → layout).
-
-## Consequences for helper code that doesn't know the concrete `nodeType`
-
-Code that looks up a node by a runtime string (e.g. a test helper's
-`findNodeByType(nodes, nodeType: string)`) gets back a `GraphNode` whose `astData` is still the full
-union — TypeScript can't narrow on a value it only sees at runtime. Call sites that need a specific
-shape cast through `unknown` (`node.astData as unknown as SelectionDAGNode`), same as they would for
-any other union that doesn't overlap enough for a direct assertion. This is expected and fine: it's
-an explicit, visible cast at the one place that generically doesn't know the type, not a silent `any`
-threaded through the whole pipeline.
+- React Flow's own `Node.data` (the object actually handed to a rendered node component as
+  `NodeProps.data`) is `Record<string, unknown>` — React Flow's `Node<T>` generic is not
+  threaded through this codebase's node arrays. Each node component (e.g.
+  `LLVMBasicBlockNode`) does one cast at that boundary — `data.astData as LLVMBasicBlock`.
+  That is a single, narrow cast consuming a third-party API's loose typing, not a hole in
+  this contract.
+- Code that looks up a node by a runtime string (e.g. a test helper's
+  `findNodeByType(nodes, nodeType: string)`) gets back a `GraphNode` whose `astData` is
+  still the full union — TypeScript cannot narrow on a value it only sees at runtime. Such
+  call sites cast through `unknown` (`node.astData as unknown as SelectionDAGNode`): an
+  explicit, visible cast at the one place that generically doesn't know the type.

--- a/docs/internal/contracts/ir-mode-registry.md
+++ b/docs/internal/contracts/ir-mode-registry.md
@@ -1,10 +1,9 @@
 # Contract: IR mode registry
 
-- **Status:** Implemented (Phase 2, 2026-07-04)
-- **Motivation:** before the registry, adding a 4th IR required editing roughly 14 scattered
-  dispatch sites. This contract defines the single
-  interface an IR mode must implement so that adding one only means adding one registry
-  entry (plus the mode's own parser/AST/node-component files).
+Everything that differs per IR (parser, default code, editor language, node components,
+edge/layout behavior) is centralized in one registry entry per IR. Adding an IR means
+adding one entry plus that IR's own parser/AST/graphBuilder/node-component files — never
+editing scattered per-mode dispatch sites.
 
 ## The interface
 
@@ -44,14 +43,13 @@ interface IRViewDefinition {
 Rules:
 
 - `views` is optional. A mode without it has a single implicit view built from
-  its top-level `parse`/`edgeBuilder`/`layoutOptions` (Mermaid and SelectionDAG
-  stay exactly as they were).
+  its top-level `parse`/`edgeBuilder`/`layoutOptions`.
 - When present, `views` has ≥ 2 entries and `views[0]` is the **default view**;
   it must behave identically to the mode's top-level fields (share the same
   function references — don't duplicate logic).
 - `useIRWorkspace` owns the active view key. Switching **views keeps the editor
   code** (that is the point of views); switching **modes resets** the view to the
-  default and replaces the code with `defaultCode`, as before.
+  default and replaces the code with `defaultCode`.
 - The editor panel renders a view `ToggleButtonGroup` only when the active mode has
   `views`.
 - A mode's `nodeTypes` covers every view's node renderers (GraphViewer merges
@@ -61,7 +59,7 @@ Rules:
   switches (`specs/graph-view.md` §2).
 
 The layout-relevant half of a mode is named separately so a view-resolved value
-can be passed where a mode used to be:
+can be passed wherever layout behavior is needed:
 
 ```ts
 type IRLayoutBehavior = Pick<IRModeDefinition, "edgeBuilder" | "layoutOptions">;
@@ -81,11 +79,10 @@ interface IREdgeBuilder {
 ```
 
 - LLVM/Mermaid (`codeGraphEdgeBuilder`) build `type: "routed"` edges; the ELK layout
-  attaches each edge's back-edge flag to `edge.data` afterwards, and the edge's geometry is
-  computed at render time from the live node rectangles (`specs/graph-view.md` §4). A
-  builder therefore contributes no geometry at all. There is no position-based
-  classification anymore — whether an edge is a back edge is derived from the final layout
-  geometry, not chosen up front.
+  attaches each edge's back-edge flag to `edge.data` afterwards (derived from the final
+  layout geometry, not chosen by the builder), and the edge's geometry is computed at
+  render time from the live node rectangles (`specs/graph-view.md` §4). A builder
+  therefore contributes no geometry at all.
 - SelectionDAG (`selectionDAGEdgeBuilder`) builds React Flow built-in `default` (bezier)
   edges connecting specific operand/type Handles; routing does not apply to them.
 
@@ -106,7 +103,7 @@ All three current modes live in `src/irModes/`: `llvmMode.ts`, `mermaidMode.ts`,
 ## Adding a 4th IR mode
 
 1. Add the parser/AST/graphBuilder files for the new IR under `src/parser`, `src/ast`,
-   `src/graphBuilder` (unchanged from before this contract — this part was never the problem).
+   `src/graphBuilder`.
 2. Add the mode's node component(s) under `src/components/Graph/<NewMode>/`.
 3. Write `src/irModes/newMode.ts` implementing `IRModeDefinition`. Reuse `codeGraphEdgeBuilder`
    unless the new IR needs custom edge semantics like SelectionDAG.

--- a/docs/internal/specs/graph-view.md
+++ b/docs/internal/specs/graph-view.md
@@ -4,9 +4,9 @@ Behavior specification for everything the app does around the per-IR pipelines: 
 cycle, graph updating, layout, node sizing, and the shell UI. Per-IR input syntax and
 conversion rules live in `specs/llvm-ir.md`, `specs/mermaid.md`, `specs/selectiondag.md`.
 
-Conventions: every normative statement carries a **Pinned by** reference to the test(s) that
-fix the behavior. Statements marked _observed, untested_ describe current behavior with no
-covering test.
+Conventions: every normative statement is covered by a **Pinned by** reference to the test
+file(s) that fix the behavior. Statements marked _observed, untested_ describe current
+behavior with no covering test.
 
 ## 1. Parse cycle
 
@@ -14,23 +14,20 @@ covering test.
   active view after a **750 ms debounce** (`PARSE_DEBOUNCE_MS` in `useIRWorkspace`);
   intermediate keystrokes cancel the pending parse.
 - On success the graph updates and any error clears. On failure the **previous graph stays**
-  and the error message is shown in the editor panel's status footer (§6), in full — it is
-  **not truncated**.
+  and the error message is shown, untruncated, in the editor panel's status footer (§6).
 - Switching modes replaces the editor content with the new mode's `defaultCode` and resets
   the active view to the mode's default view.
 - Switching views (modes with `views`, see `contracts/ir-mode-registry.md`) **keeps the
   editor content** and re-parses it with the new view's `parse`.
 
-> Pinned by (end-to-end): `e2e/smoke.spec.ts` — "editing the code updates the graph",
-> "invalid code shows a parse error" (targets the status footer), the two mode-switching
-> tests. The exact debounce value and the untruncated rendering are _observed, untested_.
+> Pinned by: `e2e/smoke.spec.ts`. The exact debounce value and the untruncated rendering
+> are _observed, untested_.
 
 ## 2. Graph updates — topology signature
 
 `useGraphData.updateGraph(graph, behavior)` (where `behavior` is the active view's
-`edgeBuilder`/`layoutOptions`, structurally satisfied by a mode object — see
-`contracts/ir-mode-registry.md`) computes a **topology signature**:
-`direction | sorted node ids | sorted source-target pairs`.
+`edgeBuilder`/`layoutOptions` — see `contracts/ir-mode-registry.md`) computes a **topology
+signature**: `direction | sorted node ids | sorted source-target pairs`.
 
 - **Signature changed** (first parse, node/edge added or removed, direction changed):
   full **asynchronous** ELK re-layout; all node positions are recomputed. A layout that
@@ -44,24 +41,19 @@ covering test.
   node's rendered _size_ is reflected immediately, with no re-layout needed.
 - Switching views always changes the signature (the two projections emit different node id
   namespaces), so each view switch performs a full re-layout; **positions are not preserved
-  across view switches**. This is intended: the two projections have unrelated topologies, so
-  there is nothing meaningful to carry over.
-
-> Pinned by: `src/hooks/__tests__/useGraphData.test.ts` (layout on first call, position
-> preservation, re-layout on topology change, SelectionDAG position/edge-type stability)
+  across view switches** — the projections' topologies are unrelated, so there is nothing
+  to carry over.
 
 **Reset Layout** re-runs the full (async) layout for the last parsed graph (using the active
-mode's edge builder and layout options) and is a no-op before the first parse; the viewer then
-re-fits the viewport (after a 50 ms delay — _observed, untested_).
+view's edge builder and layout options) and is a no-op before the first parse; the viewer
+then re-fits the viewport (after a 50 ms delay — _observed, untested_).
 
-> Pinned by: `useGraphData.test.ts` ("resetLayout ...")
+> Pinned by: `src/hooks/__tests__/useGraphData.test.ts`
 
 ## 3. Layout (ELK — node placement)
 
-Node placement is computed by ELK (`elkjs`, layered algorithm). ELK is the single placement
-engine because its ports, cycle handling and layer ordering keep node geometry connected to
-what React Flow renders. It computes **placement only** — edge geometry is not taken from it
-(§4).
+Node placement is computed by ELK (`elkjs`, layered algorithm). ELK computes **placement
+only** — edge geometry is not taken from it (§4).
 
 - `getLayoutedElements` is **async**: the elkjs bundle is dynamically imported on first use
   and layout runs on the main thread (graphs are small; no worker).
@@ -71,145 +63,47 @@ what React Flow renders. It computes **placement only** — edge geometry is not
   nodes within a layer and it therefore improves **placement**. The route points ELK
   produces are **discarded**: they are not stored on the React Flow edges.
 - Per-mode `layoutOptions` (ELK option map) merge into the root options (e.g. Use-Def's
-  tighter spacing, SelectionDAG's layer spacing).
+  tighter spacing, SelectionDAG's layer spacing). _(merging: observed, untested)_
 - Node boxes given to ELK use the estimated dimensions from §5, so spacing reflects real
   rendered sizes. Use-Def instruction nodes additionally declare `FIXED_POS` ports at
   operand text offsets (`specs/llvm-use-def-view.md` §4); the ports shape placement and
-  decide which handle an edge attaches to, which is what the router then routes between
-  — _(observed, untested)_.
+  decide which handle an edge attaches to. _(observed, untested)_
 - The layout is also where the structural back-edge flag is decided (§4).
 
-> Pinned by: `src/utils/__tests__/layout.test.ts` (positions assigned, direction respected,
-> no overlapping positions, back-edge flagging, no geometry attached to edges).
-> `layoutOptions` merging: _observed, untested_.
+> Pinned by: `src/utils/__tests__/layout.test.ts`
 
 ## 4. Edge routing and rendering
 
 Every LLVM/Mermaid edge is rendered by one custom edge type, `routed` (`RoutedEdge.tsx`).
 **Edge geometry is a pure function of the live node rectangles**, computed at render time
-by this repo's own orthogonal router (`src/utils/edgeRouter.ts`; the module boundary and
-its guarantees are frozen in `contracts/edge-routing.md`). There is exactly one geometry
-generator: no stored geometry, no second path shape that appears once a node moves, and no
-notion of geometry that can go out of date.
+by this repo's own orthogonal router. There is exactly one geometry generator: no stored
+geometry, and no notion of geometry that can go out of date. The router's module boundary,
+its guarantees (orthogonality, determinism, exact endpoints, the self-loop shape, the
+no-path fallback, no immediate reversals, missing-node omission), and its option defaults
+are frozen in `contracts/edge-routing.md`; the algorithm behind those guarantees is
+documented in `src/utils/edgeRouter.ts` itself.
 
 - **Inputs** are React Flow's measured rects (`internals.positionAbsolute`,
   `measured.width` / `measured.height`) and the live handle positions. Because those track
   the current DOM, an edge follows its node while the node is dragged, and follows a size
   change caused by a content-only edit (§2), with no re-layout involved.
-- **One pass per graph.** `routeEdges` takes all nodes and all requests at once, so it is
-  not called per edge. `src/hooks/useEdgeRoutes.ts` reads React Flow's store, calls the
-  router once per pass, and publishes the resulting `Map<edgeId, Point[]>` through a React
-  context; `RoutedEdge` looks up its own entry by edge id.
-- **Algorithm:** a sparse Hanan grid over node rects inflated by `nodeMargin` (default 12),
-  seeded per edge from the rect lines plus that edge's own endpoints. A grid segment is
-  traversable when it does not cross the interior of an inflated rect. The endpoint-node
-  exemption is **per endpoint**: the source node's rect is exempt only for the segments
-  incident to the pushed source point, the target node's only for those incident to the
-  pushed target point, and every other segment treats both as obstacles — so a **searched**
-  route never crosses the interior of its own endpoint nodes. That clearance is a property
-  of searched routes only, and of their **routed** segments only: the fallback below is
-  exempt **entirely** — its connector does no obstacle avoidance by design, being the last
-  resort once the search has proved no clear path exists — and a searched route's two
-  mandated stubs are exempt too, since with overlapping node rects one node's stub
-  necessarily lies inside the other's. Where the tighter rule leaves no path, the
-  fallback applies. The route is the cheapest grid path under `length + bendPenalty * turns`
-  (`bendPenalty` default 30), with turns counted over the whole polyline, stubs included.
-  Endpoints are pushed `nodeMargin` outward along their handle's side before joining the
-  grid.
-- **Endpoints are exact:** the polyline starts exactly at the source handle position and
-  ends exactly at the target handle position. The `nodeMargin`-pushed point is an interior
-  bend, never `points[0]` or the last point, so a drawn edge always touches its handle.
-  Collinear interior points are collapsed to their bends, but the two pushed points are
-  never collapsed away. **Self-loops are the one exception** — see below.
-- Every route is **orthogonal** and has **≥ 2 points**, and routing is **deterministic**:
-  identical input rects produce identical points, with no dependence on iteration order.
-  **Ties are broken by a fixed total order** — lowest total cost, then fewest bends, then
-  the point sequence compared lexicographically by `(x, y)` — so the chosen shape is a
-  documented property, not an implementation accident.
-- **No path found** yields a fully determined orthogonal fallback, built as a skeleton
-  `sourcePoint → S → P1 → connector → P2 → T → targetPoint`. `S` and `T` are the handles
-  pushed `nodeMargin` outward along their sides; `P1` and `P2` are pushed a further
-  `selfLoopGap` out, so the polyline always leaves straight and always approaches the
-  target from outside — which is what makes the no-reversal rule hold at both stubs
-  unconditionally. The connector is chosen from a fixed ladder (straight run, two-segment
-  elbow continuing along the exit axis, then three-segment lateral dog-legs ordered
-  +x, +y, −x, −y, then a four-segment rectangle for coincident handles), taking the first
-  candidate that satisfies the no-reversal rule; consecutive duplicate points are dropped.
-  **Two connector segments are provably not always enough:** when the source and target
-  normals lie on the same axis pointing opposite ways and the displacement runs backwards
-  along it (e.g. a `bottom → top` pair where the target sits above the source), both
-  two-segment orderings reverse at one of the two stubs, so a three-segment dog-leg is
-  required there — the longer candidates in the ladder are a minimum, not a convenience.
-  The fallback's connector does **no obstacle avoidance whatsoever, by design**: it picks a
-  shape from the endpoint geometry alone and never consults the node rects, because it is
-  reached only after the grid search has already proved no clear path exists — a shape that
-  avoided obstacles is not on offer at that point, only a determined shape that may clip or
-  no edge at all.
-  **Known limitations,** both accepted rather than fixed since the alternatives are a stale
-  route or a second geometry generator:
-  - Because the fallback does no obstacle avoidance, a fallback edge in overlapping-rect
-    geometry can visibly thread between the two boxes. Reachable only by dragging one node
-    onto or nearly onto another — ELK's placement does not produce two _directly connected_
-    nodes whose inflated boxes overlap. _(observed, untested)_
-  - ELK's placement can still leave two _unrelated_ node rects closer than `2 × nodeMargin`
-    apart with no drag at all, closing the corridor a third edge would otherwise route
-    through and forcing that edge to the fallback — a layout-constant question, not a router
-    defect. _(observed, untested)_
-- **No immediate reversals:** no returned polyline — searched, self-loop or fallback — has
-  an interior vertex whose arriving and leaving segments run along the same axis in
-  opposite directions. This is the checkable form of "never a degenerate hook", and it is
-  the rule's only form: "perpendicular segments and `points[i-1] !== points[i+1]`" is not
-  equivalent and must not be substituted. The search satisfies it by never doubling back
-  and by refusing to finish at the target along the target side's outward normal (an edge
-  that leaves unreachable falls back instead); the self-loop and the fallback satisfy it by
-  construction.
-- **Self-loops** are synthesized on the node's **right** side rather than routed, and are
-  the only edges exempt from the exact-endpoint rule: they are built from the node rect
-  alone, so the request's source and target handle positions are ignored (React Flow's
-  default bottom handle is centred, not at 75 %). For a rect `(x, y, w, h)` with
-  `laneX = x + w + selfLoopGap` (default 24), the polyline is exactly six points —
-  `(x + 0.75w, y + h)` on the bottom edge, `(x + 0.75w, y + h + nodeMargin)`,
-  `(laneX, y + h + nodeMargin)`, `(laneX, y - nodeMargin)`,
-  `(x + 0.75w, y - nodeMargin)`, and `(x + 0.75w, y)` on the top edge. The two
-  `nodeMargin` steps are what keep the horizontal runs off the node's own bottom and top
-  borders.
-- **Missing nodes:** a routing request whose source or target id is **not present in the
-  `nodes` array** produces **no entry** in the returned map — the router does not throw and
-  does not substitute a default rect, it omits the request (self-loops included).
-- **Unmeasured endpoints** follow from that rule: `useEdgeRoutes` omits nodes React Flow
-  has not measured yet from the rects it passes in, so their edges resolve to no entry and
+- **One pass per graph:** `src/hooks/useEdgeRoutes.ts` reads React Flow's store, calls
+  `routeEdges` once per pass, and publishes the resulting `Map<edgeId, Point[]>` through a
+  React context; `RoutedEdge` looks up its own entry by edge id and never calls the router
+  itself.
+- **Unmeasured endpoints:** the hook omits nodes React Flow has not measured yet from the
+  rects it passes in; per the contract's missing-node rule their edges get no map entry and
   are **not drawn** for that frame, appearing once measurement lands. There is deliberately
-  no placeholder shape — one would reintroduce the second geometry generator this design
-  removes.
-- **Obstacles are node rectangles only.** Edge labels and other edges are not obstacles,
-  and there is no edge-crossing penalty.
-- **During a drag**, routes recompute continuously, throttled to animation frames, and
-  only the edges incident to a moved node are re-routed; a full pass runs on drag stop.
-  That split is required rather than opportunistic: a full pass overruns the 16.7 ms frame
-  budget from roughly 180 nodes, which the Use-Def view can reach since it emits one node
-  per instruction.
-- **Performance:** a full routing pass over a synthetic 60-node / 80-edge graph completes
-  in under 50 ms, measured out of band (bare Node, warm, median of N). Routing cost depends
-  on graph shape as well as size — the repo's own test graph measures ~6–14 ms at that size,
-  an adjacent-layer graph of the same size ~2–4 ms — so the figure is a budget, not a
-  constant. The in-suite timing test is a catastrophic-regression guard at 300 ms, not a
-  check of this budget: inside a parallel test runner the number measures contention as
-  much as the router. Measured scaling on an ELK-layered-shaped CFG (bare Node, warm,
-  median of N, 2026-08-09):
-
-  | nodes | edges | median ms |
-  | ----- | ----- | --------- |
-  | 60    | 117   | 2.9       |
-  | 120   | 245   | 7.6       |
-  | 180   | ~370  | ~16       |
-  | 260   | 542   | 31.1      |
-  | 400   | 840   | 71.8      |
-
-  This is the basis for the ~180-node threshold above: the 16.7 ms animation-frame budget
-  — the one that matters, since a full pass runs per frame during a drag — is exceeded
-  around there, which is what makes the incident-edges-only drag path required rather than
-  an optimization held in reserve.
-
+  no placeholder shape — one would reintroduce a second geometry generator.
+- **During a drag**, routes recompute continuously, throttled to animation frames, and only
+  the edges incident to a moved node are re-routed (still against the complete obstacle
+  set); a full pass runs on drag stop. The split is required, not opportunistic: a full
+  pass exceeds the 16.7 ms animation-frame budget from roughly **180 nodes**, which the
+  Use-Def view can reach since it emits one node per instruction. Measured out of band on
+  an ELK-layered-shaped CFG (bare Node, warm, median of N, 2026-08-09): 60 nodes / 117
+  edges ≈ 3 ms, 180 / ~370 ≈ 16 ms, 400 / 840 ≈ 72 ms; cost depends on graph shape as
+  well as size. The in-suite 300 ms timing test is a catastrophic-regression guard, not a
+  check of this budget.
 - **Rendering:** `RoutedEdge` draws the returned points as an orthogonal polyline with
   **rounded corners**; edge labels (phi) render at the polyline's arc-length midpoint.
 - **Back edges:** after layout, an edge is flagged `data.isBackEdge` when it is a self-loop
@@ -217,41 +111,34 @@ notion of geometry that can go out of date.
   decided once from ELK's placement geometry and never re-derived from live rects — so
   colors do not flicker while a node is dragged; only geometry is live. Back edges render
   in the loop accent color (muted purple `#8250df`, matching arrowhead) — "colored + upward
-  = loop-carried". This accent is graph grammar, not shell chrome (§6.6 still has no accent
+  = loop-carried". This accent is graph grammar, not shell chrome (§6.6 has no accent
   token).
+- **Known limitations,** both accepted since the alternatives are a stale route or a second
+  geometry generator: the no-path fallback does no obstacle avoidance
+  (`contracts/edge-routing.md`), so dragging one node onto or nearly onto another can make
+  a fallback edge visibly thread between the two boxes; and ELK's placement can leave two
+  _unrelated_ node rects closer than `2 × nodeMargin` apart, closing the corridor a third
+  edge would otherwise route through and forcing that edge to the fallback — a
+  layout-constant question, not a router defect. _(observed, untested)_
 - **Reset layout** (§2) re-runs ELK placement and nothing else. It has no role in edge
   rendering: edge geometry is always current, dragged or not.
-- **SelectionDAG**: unaffected by routing — its edges connect per-operand/type Handles
-  and keep the handle-anchored bezier look via React Flow's built-in `default` edge with
+- **SelectionDAG**: unaffected by routing — its edges connect per-operand/type Handles and
+  keep the handle-anchored bezier look via React Flow's built-in `default` edge with
   `pathOptions.curvature`. Chain/glue edges render dashed (see `specs/selectiondag.md`
   §3). SelectionDAG edges place the arrow marker at the **start** (pointing at the
   source), LLVM/Mermaid at the **end**.
 
-> Pinned by: `src/utils/__tests__/edgeRouter.test.ts` (orthogonality, ≥ 2 points, exact
-> endpoints, obstacle avoidance including that a searched route never crosses the interior
-> of its own endpoint nodes, tie-breaking and determinism, the six-point right-side
-> self-loop and its exemption from the exact-endpoint rule,
-> the no-path fallback skeleton and its connector ladder, the no-immediate-reversal rule
-> across searched, self-loop and fallback routes,
-> omission of requests naming a node absent from
-> `nodes`, and a 300 ms catastrophic-regression guard on the 60-node / 80-edge graph),
-> `src/utils/__tests__/layout.test.ts` (back-edge / self-loop
-> flagging,
-> no geometry stored on edges), `src/hooks/__tests__/useGraphData.test.ts` (back-edge flag
-> inherited on content-only updates), `src/utils/__tests__/converter.test.ts` (dashed
-> chain/glue, markerStart/markerEnd).
+> Pinned by: `src/utils/__tests__/edgeRouter.test.ts` (the contract's guarantees),
+> `src/utils/__tests__/layout.test.ts` (back-edge / self-loop flagging, no geometry stored
+> on edges), `src/hooks/__tests__/useGraphData.test.ts` (back-edge flag inherited on
+> content-only updates), `src/utils/__tests__/converter.test.ts` (dashed chain/glue,
+> markerStart/markerEnd).
 >
-> _(observed, untested)_: that edges track the live DOM rects — following a node while it
-> is dragged and following a size change from a content-only edit — since no named test
-> drives a drag; the one-pass-per-graph `useEdgeRoutes` hook and its context; that
-> `useEdgeRoutes` omits unmeasured nodes from the rects it passes in, and that an edge with
-> no map entry is not drawn; the rounded corners; the midpoint label placement; the accent
-> color; the animation-frame throttling during a drag and the incident-edges-only drag
-> pass; that turns are counted over the whole polyline including the stubs; and the 50 ms
-> budget itself, which is measured out of band rather than by any test in the suite.
-> The **no-immediate-reversal** rule now holds for all three route kinds and is
-> additionally verified out of band (0 violations across a 40,401-position sweep, a
-> 4,096-case grid over all 16 side pairs, and 30,000 random all-sides graphs).
+> _(observed, untested)_: live-rect tracking while dragging and after content edits, the
+> one-pass `useEdgeRoutes` hook and its context, the unmeasured-node omission, the rounded
+> corners, the midpoint label placement, the accent color, and the drag-time
+> throttling/incident-edges pass. The frame-budget figures are measured out of band, not by
+> the test suite.
 
 ## 5. Node dimension estimation
 
@@ -271,18 +158,14 @@ ELK needs node sizes before React renders anything, so `converter.ts` estimates 
   2 px, header band 20 px), with `SelectionDAG/selectionDAGStyleConstants.ts` and
   `CodeFragment.tsx`'s exported paddings for their structures. When changing node styling,
   change the constant, never a literal, or layout spacing silently drifts from rendering.
-- Every LLVM node body and the Use-Def instruction card render their code line(s) through
-  `HighlightedCode.tsx`, which wraps Shiki's own `<pre>` output (block mode; SelectionDAG's
-  `CodeFragment.tsx` uses the same component in `inline` mode instead, which strips the
-  `<pre>`/`<code>` tags entirely, so it never carries this margin). Shiki's `<pre>` carries
-  the user-agent default block margin (12 px top/bottom, observed in this app's rendering);
-  `HighlightedCode.tsx` resets it to `0` on the generated HTML before mounting it, because the
-  estimate above assumes no margin. Mermaid nodes render plain text (`MermaidNode.tsx`, no
-  `HighlightedCode` involved) and were never affected.
+- LLVM node bodies and the Use-Def instruction card render their code line(s) through
+  `HighlightedCode.tsx`, which resets the user-agent block margin on Shiki's `<pre>` output
+  to `0` before mounting it — the estimate above assumes no margin. (Inline mode, used by
+  SelectionDAG's `CodeFragment.tsx`, strips the `<pre>`/`<code>` tags entirely; Mermaid
+  nodes render plain text and are unaffected.)
 
-> Pinned by: `src/utils/__tests__/converter.test.ts` (mermaid/LLVM/wrapping/header-offset/
-> empty-label cases), `src/components/Graph/common/__tests__/HighlightedCode.test.tsx` (the
-> rendered `<pre>` carries no margin in block mode; inline mode still strips the tag).
+> Pinned by: `src/utils/__tests__/converter.test.ts`,
+> `src/components/Graph/common/__tests__/HighlightedCode.test.tsx`
 
 ## 6. Shell UI (canvas-first shell)
 
@@ -304,34 +187,32 @@ controls remain available as overlays.
 A single overlay card at the **top-left**, inset from the viewport edges, holding everything
 that is not the canvas.
 
-- **Header**, left to right: the brand title ("IR Visualizer", small sans-serif, ~13 px,
-  `#333`), the **mode selector**, the **view toggle**, a **Clear** action, and a **collapse**
-  button.
+- **Header**, left to right: the brand title ("IR Visualizer", small sans-serif, ~13 px),
+  the **mode selector**, the **view toggle**, a **Clear** action, and a **collapse** button.
 - **Mode selector** lists the registry modes in `IR_MODES` insertion order
   (LLVM-IR, SelectionDAG, Mermaid).
-  > Pinned by: `e2e/smoke.spec.ts` (selects each mode by visible label). Order:
-  > _observed, untested_.
 - **View toggle**: when the active mode defines `views`, a `ToggleButtonGroup` next to the
   mode selector lists them in registry order (LLVM-IR: CFG, Use-Def) with the active view
   selected; it is absent for single-view modes. It lives in the panel header, not in the
   canvas control cluster: it selects what is projected, not how the viewport is framed.
-  > Pinned by: `e2e/smoke.spec.ts` ("LLVM-IR use-def view").
 - **Clear** empties the editor (the subsequent parse of the empty string follows §1: e.g.
   an empty module is valid LLVM-IR, but empty Mermaid input is a parse error).
-  _(observed, untested)_
 - **Body / Editor**: Monaco with Shiki `github-light` highlighting; the language follows
   `mode.editorLanguage` (`llvm` for LLVM-IR and SelectionDAG, `mermaid` for Mermaid). The
-  editor surface is fully opaque. _(observed, untested)_
+  editor surface is fully opaque.
 - **Event containment**: the panel is a DOM sibling of the React Flow canvas (not a React
   Flow `<Panel>`), so canvas pan/zoom gestures do not reach it; a `stopPropagation` wheel
-  handler on the panel root is an additional safety net. _(observed, untested)_
+  handler on the panel root is an additional safety net.
 - **Resize**: right-edge drag via `usePaneResize` — min 280 px, max 60 vw, initial 420 px.
-  Wide mode only. _(observed, untested)_
+  Wide mode only.
 - **Collapse**: the panel collapses to a small floating pill styled as a plain small button
   with a sans-serif `Code` label, giving the graph the full viewport. The state is a
   session-local `panelOpen: boolean` (no persistence); the same flag drives wide and narrow
   mode. The pill sits **top-left in wide mode** and **bottom-left in narrow mode**.
-  _(observed, untested)_
+
+> Pinned by: `e2e/smoke.spec.ts` (mode selection by visible label, the CFG/Use-Def
+> toggle). Everything else in this subsection, including the mode order: _observed,
+> untested_.
 
 ### 6.3 Status footer
 
@@ -342,13 +223,13 @@ is the only place parse status is reported; there is no snackbar over the graph.
 - Failure: `error: <full message>` with a 2 px left rule in `error`. The message is **not
   truncated**; long messages wrap and scroll inside the footer, which caps at roughly 8
   lines. The error clears on the next successful parse (§1).
-  > Pinned by: `e2e/smoke.spec.ts` ("invalid code shows a parse error"). The exact success
-  > wording, the line cap, and the absence of truncation are _observed, untested_.
+
+> Pinned by: `e2e/smoke.spec.ts` (a parse error reaches the footer). The exact success
+> wording, the line cap, and the absence of truncation are _observed, untested_.
 
 ### 6.4 Canvas control cluster
 
-A single floating row at the **bottom-right**, replacing React Flow's default `<Controls />`
-and the ad-hoc top-right Reset Layout `<Panel>`: zoom in, zoom out, fit view, a 1 px divider,
+A single floating row at the **bottom-right**: zoom in, zoom out, fit view, a 1 px divider,
 then reset layout. The divider separates viewport operations from the position-destroying
 reset (§2).
 
@@ -371,45 +252,42 @@ drag-resizer is wide-mode-only. _(observed, untested)_
 
 ### 6.6 Visual grammar and design tokens
 
-Floating chrome — editor panel, collapsed pill, control cluster — uses the quiet gray
-language: neutral grays, sans-serif type, and light borders, distinct from the graph nodes'
-own grammar in `src/components/Graph/common/NodeShell.tsx` (`1px solid #777` border, `2px`
-radius, white surface, dense 12 px monospace, full-width header band). That NodeShell grammar — including the header
-band — remains exclusively a graph-node affordance; the shell chrome does not borrow it, and
-the editor panel is chrome around the canvas, not a node itself.
+Floating chrome — editor panel, collapsed pill, control cluster — uses a quiet gray
+language: neutral grays, sans-serif type, and light borders. Graph nodes keep their own
+grammar in `src/components/Graph/common/NodeShell.tsx` (`1px solid #777` border, `2px`
+radius, white surface, dense 12 px monospace, full-width header band); the shell chrome
+never borrows it — including the header band — because the editor panel is chrome around
+the canvas, not a node.
 
-| Token          | Value                                                                  | Use                                                                                                                                                                                                                                          |
-| -------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ground`       | `#FAFAFA`                                                              | Canvas background; `<Background />` dot color `#D7DBDF`                                                                                                                                                                                      |
-| `paper`        | `#FFFFFF`                                                              | Panel / pill / control-cluster surface (same as nodes)                                                                                                                                                                                       |
-| `control`      | `#d0d0d0` (hover `controlHover` `#999`, focused `controlFocus` `#777`) | Border on bordered interactive controls (select, toggle group, outlined buttons); `controlHover` applies to all of them, `controlFocus` only to the select's focused field border — toggles and buttons signal focus via `focusRing` instead |
-| `line`         | `#999`                                                                 | Outer border of floating surfaces (panel, pill, control cluster)                                                                                                                                                                             |
-| `ink`          | `#1F2328`                                                              | Primary text                                                                                                                                                                                                                                 |
-| `ink-muted`    | `#57606A`                                                              | Secondary text (status footer)                                                                                                                                                                                                               |
-| `ok`           | `#1A7F37`                                                              | Parse success only — never decorative                                                                                                                                                                                                        |
-| `error`        | `#CF222E`                                                              | Parse failure only — never decorative                                                                                                                                                                                                        |
-| `selectedFill` | `#e8e8e8` (text `#222`, weight 600)                                    | Selected toggle-button state                                                                                                                                                                                                                 |
-| `hoverFill`    | `#f0f0f0`                                                              | Hover fill for shell chrome buttons                                                                                                                                                                                                          |
-| `focusRing`    | 2 px `#57606A`                                                         | Focus-visible ring on all interactive shell chrome (neutral, not accent)                                                                                                                                                                     |
-| elevation      | `0 1px 2px rgba(31,35,40,.05), 0 4px 12px rgba(31,35,40,.06)`          | Floating chrome only; graph nodes stay flat (no shadow)                                                                                                                                                                                      |
+| Token          | Value                                                                  | Use                                                                                                                                                          |
+| -------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ground`       | `#FAFAFA`                                                              | Canvas background; `<Background />` dot color `#D7DBDF`                                                                                                      |
+| `paper`        | `#FFFFFF`                                                              | Panel / pill / control-cluster surface (same as nodes)                                                                                                       |
+| `control`      | `#d0d0d0` (hover `controlHover` `#999`, focused `controlFocus` `#777`) | Border on bordered interactive controls; `controlFocus` applies only to the select's focused field border — toggles and buttons signal focus via `focusRing` |
+| `line`         | `#999`                                                                 | Outer border of floating surfaces (panel, pill, control cluster)                                                                                             |
+| `ink`          | `#1F2328`                                                              | Primary text                                                                                                                                                 |
+| `ink-muted`    | `#57606A`                                                              | Secondary text (status footer)                                                                                                                               |
+| `ok`           | `#1A7F37`                                                              | Parse success only — never decorative                                                                                                                        |
+| `error`        | `#CF222E`                                                              | Parse failure only — never decorative                                                                                                                        |
+| `selectedFill` | `#e8e8e8` (text `#222`, weight 600)                                    | Selected toggle-button state                                                                                                                                 |
+| `hoverFill`    | `#f0f0f0`                                                              | Hover fill for shell chrome buttons                                                                                                                          |
+| `focusRing`    | 2 px `#57606A`                                                         | Focus-visible ring on all interactive shell chrome (neutral, not accent)                                                                                     |
+| elevation      | `0 1px 2px rgba(31,35,40,.05), 0 4px 12px rgba(31,35,40,.06)`          | Floating chrome only; graph nodes stay flat (no shadow)                                                                                                      |
 
-There is no `accent` token: the purple accent used by the shipped shell (PR #60) has been
-removed. `ok` (green) and `error` (red) are the only semantic, non-gray colors anywhere in the
-shell chrome. Graph nodes keep their existing `1px solid #777` border unchanged — that border
-belongs to NodeShell, not to a shell-chrome token, and node styling is out of scope here.
-
+- There is no `accent` token: `ok` (green) and `error` (red) are the only semantic,
+  non-gray colors in the shell chrome. The muted purple on back edges (§4) is graph
+  grammar, not a shell token.
 - **No translucency and no backdrop blur**: every surface is fully opaque.
-- **Typography**: no webfonts. All shell chrome — brand title, mode selector, view toggle,
-  buttons — uses the app's system sans-serif stack (`system-ui`). Monospace is reserved for
-  the status footer (compiler-output feel) and the canvas/graph nodes; it is no longer used
-  anywhere in the shell chrome.
-- **Icon-only buttons are deliberately borderless**: the panel collapse button and the canvas
-  control cluster's zoom / fit / reset buttons carry no `control` border of their own — their
-  enclosing surface (panel, pill, cluster) already has one via `line` — and signal
-  hover/focus with `hoverFill` and `focusRing` instead.
+- **Typography**: no webfonts. All shell chrome uses the app's system sans-serif stack
+  (`system-ui`). Monospace is reserved for the status footer (compiler-output feel) and
+  the canvas/graph nodes.
+- **Icon-only buttons are borderless**: the panel collapse button and the control cluster's
+  zoom / fit / reset buttons carry no `control` border of their own — their enclosing
+  surface already has one via `line` — and signal hover/focus with `hoverFill` and
+  `focusRing`.
 - **Motion**: exactly one animation — the panel ⇄ pill collapse/expand morph (~180 ms
   ease-out) with an animated `fitView` recenter. Disabled under `prefers-reduced-motion`.
-- **Accessibility floor**: 2 px `focusRing` (neutral gray `#57606A`, not accent) on all
-  interactive chrome, keyboard operability, WCAG AA contrast for status-footer text.
+- **Accessibility floor**: 2 px `focusRing` on all interactive chrome, keyboard
+  operability, WCAG AA contrast for status-footer text.
 
 _(§6.6 as a whole: observed, untested — the tokens are enforced by review, not by tests.)_

--- a/docs/internal/specs/llvm-ir.md
+++ b/docs/internal/specs/llvm-ir.md
@@ -6,9 +6,9 @@ parser accepts (`src/parser/llvm/`) and how the AST becomes a control-flow graph
 line-oriented pipeline over full LLVM conformance: it extracts only the structure needed by
 the CFG and Use-Def views and preserves the rest as source text. This spec pins that behavior.
 
-Conventions: every normative statement carries a **Pinned by** reference to the test(s) that
-fix the behavior. Statements marked _observed, untested_ describe current behavior with no
-covering test.
+Conventions: every normative statement is covered by a **Pinned by** reference to the test
+file(s) that fix the behavior. Statements marked _observed, untested_ describe current
+behavior with no covering test.
 
 ## 1. Input model
 
@@ -19,20 +19,16 @@ line is **classified** by its leading keyword, and classified lines are **assemb
 exactly once; there is no backtracking. One bad line inside a function degrades to an opaque
 instruction instead of failing the whole parse (see §3.4).
 
-> Pinned by: `src/parser/llvm/__tests__/logicalLines.test.ts`,
-> `src/parser/llvm/__tests__/classify.test.ts` ("totality"),
-> `src/parser/llvm/__tests__/module.test.ts`
-
 `;` comments are stripped anywhere, string-aware: a `;` inside a string literal is data,
 not a comment. Blank and comment-only lines produce no logical line.
-
-> Pinned by: `logicalLines.test.ts` ("blank and comment-only lines"),
-> `src/parser/__tests__/llvm/errors.test.ts` ("semicolon comments")
 
 `; <label>:N` comments are stripped like any comment, but their `N` is retained as a
 block-boundary hint for implicit block numbering (§3.3).
 
-> Pinned by: `logicalLines.test.ts` ("label hints")
+> Pinned by: `src/parser/llvm/__tests__/logicalLines.test.ts`,
+> `src/parser/llvm/__tests__/classify.test.ts`,
+> `src/parser/llvm/__tests__/module.test.ts`,
+> `src/parser/__tests__/llvm/errors.test.ts`
 
 **Version coverage:** the parser accepts printer output from LLVM ~2.x through current —
 typed pointers and the `unwind` terminator (2.x), `; <label>:N` unnamed blocks and old-style
@@ -64,16 +60,14 @@ A module is a sequence of the following, in any order and any count:
 Entries are classified into dedicated arrays on `LLVMModule`; multiple functions keep their
 source order. Any other non-blank top-level line throws (§3.4).
 
+Note the "rest of line" pattern: most non-function entries are captured **textually**, not
+structurally. Their bodies are never re-parsed; node components render `originalText` as-is.
+
 > Pinned by: `src/parser/__tests__/llvm/topLevelDecls.test.ts`,
 > `src/parser/__tests__/llvm/moduleStructure.test.ts`,
 > `src/parser/__tests__/llvm/invariants.test.ts`,
-> `module.test.ts` ("top-level entries (legacy shapes)", "should drop them without
-> diagnostics"), `classify.test.ts` ("classifyTopLevel"); the quoted `#"string"`
-> attribute-group form by `classify.test.ts` (the `attributes #"a b"` table row) and
-> `module.test.ts` ("attribute group id is a quoted string")
-
-Note the "rest of line" pattern: most non-function entries are captured **textually**, not
-structurally. Their bodies are never re-parsed; node components render `originalText` as-is.
+> `src/parser/llvm/__tests__/module.test.ts`,
+> `src/parser/llvm/__tests__/classify.test.ts`
 
 ## 3. Functions, blocks, instructions
 
@@ -82,28 +76,27 @@ structurally. Their bodies are never re-parsed; node components render `original
   the end of the define line (§3.4 otherwise). Parameters are split at top-level commas;
   each keeps its raw type text and its `%name` (or `name: null` for unnamed and `...`
   parameters). `LLVMFunction.definition` is the single-spaced define line without the `{`.
-  > Pinned by: `module.test.ts` ("define line parsing"),
-  > `moduleStructure.test.ts` ("defines parameters")
 - The body is one entry block (label optional; id per §3.3) followed by further blocks,
   each started by a label line (`ident:`, `"quoted":`, or numeric `7:`) or — after a
   terminator — implicitly by the next instruction line. Block order is preserved; the entry
   block is also stored as `LLVMFunction.entry`.
-  > Pinned by: `moduleStructure.test.ts`, `invariants.test.ts` ("entry block inside parsed
-  > blocks"), `classify.test.ts` ("classifyBody labels"), `module.test.ts` ("implicit block
-  > numbering (§3.3)")
 - Block items are instructions or debug records (`#dbg_*` lines, kept as raw text). Every
   block must end with a terminator (§3.2); a missing one is either a structural error or
   the label-recovery case of §3.4.
-  > Pinned by: `src/parser/__tests__/llvm/terminators.test.ts`,
-  > `classify.test.ts` ("classifyBody debug records and fallback")
 - Non-terminator instructions are parsed into loose categories: `store`/`cmpxchg`/`atomicrmw`
   (operand-scanned, write-target heuristics), calls (`[%dst =] [tail|musttail|notail] call ...`,
   callee = last `@x`/`%x` before the **last** top-level paren group, which also covers the
   2.x fn-pointer-type form), assignments (`%x = <opcode> ...`), and generic instructions.
   All keep `originalText`; operand extraction is heuristic and per-token (globals `@x`,
   locals `%x`, metadata `!x`, everything else is `Other`).
-  > Pinned by: `src/parser/llvm/__tests__/instructions.test.ts`,
-  > `src/parser/__tests__/llvm/instructions.test.ts`
+
+> Pinned by: `src/parser/llvm/__tests__/module.test.ts`,
+> `src/parser/llvm/__tests__/classify.test.ts`,
+> `src/parser/llvm/__tests__/instructions.test.ts`,
+> `src/parser/__tests__/llvm/moduleStructure.test.ts`,
+> `src/parser/__tests__/llvm/invariants.test.ts`,
+> `src/parser/__tests__/llvm/terminators.test.ts`,
+> `src/parser/__tests__/llvm/instructions.test.ts`
 
 ### 3.1 Logical-line joining
 
@@ -113,11 +106,8 @@ Applied only inside a function body, after comment stripping:
    following lines until balanced — this joins the multi-line `switch` case list (LLVM
    prints one case per line) and multi-line `callbr`/`indirectbr` target lists. A `[` still
    open at `}` or EOF is a structural error (§3.4).
-   > Pinned by: `logicalLines.test.ts` ("bracket continuation", "unbalanced brackets"),
-   > `module.test.ts` ("should escalate the reader diagnostic to a throw")
 2. **`to`-continuation.** A line whose successor starts with `to label` or `unwind label`
    absorbs that successor — this joins the modern two-line `invoke` printing.
-   > Pinned by: `logicalLines.test.ts` ("to-continuation in a function body")
 3. Nothing else joins. In particular, `landingpad` clause lines printed on their own line
    (`cleanup`, `catch …`, `filter …`) do not join; each becomes a separate opaque
    instruction, which is harmless for the CFG (_observed, untested — the corpus landingpads
@@ -126,8 +116,9 @@ Applied only inside a function body, after comment stripping:
 Joined logical lines keep the 1-based line number of their first physical line;
 `originalText` keeps every physical line, trimmed and newline-joined.
 
-> Pinned by: `logicalLines.test.ts` ("should skip the joined lines in its lineNumber"),
-> `src/parser/llvm/__tests__/instructions.test.ts` ("originalText")
+> Pinned by: `src/parser/llvm/__tests__/logicalLines.test.ts`,
+> `src/parser/llvm/__tests__/module.test.ts`,
+> `src/parser/llvm/__tests__/instructions.test.ts`
 
 ### 3.2 Terminators
 
@@ -137,16 +128,10 @@ for `invoke`/`callbr` only:
 `ret`, `br`, `switch`, `indirectbr`, `invoke`, `callbr`, `resume`, `unreachable`,
 `cleanupret`, `catchret`, `catchswitch`, `unwind` (the LLVM ≤ 2.x terminator).
 
-> Pinned by: `classify.test.ts` ("classifyBody terminators" — including the exactly-12 pin
-> and the `%x = <non-invoke>` exclusion)
-
 **Uniform successor rule (normative):** the successors of any terminator are the ordered
 occurrences of the token pair `label %x` in its logical line; string literals are single
 opaque tokens, so `label` text inside them never counts, and `unwind to caller` has no
 `label` token and thus no successor.
-
-> Pinned by: `src/parser/llvm/__tests__/terminators.test.ts` ("opaque terminators (uniform
-> successor rule)")
 
 Per-opcode structure, on top of that rule:
 
@@ -160,23 +145,20 @@ Per-opcode structure, on top of that rule:
 | `callbr`, `indirectbr`, `cleanupret`, `catchret`, `catchswitch` | `LLVMOpaqueTerminator`: opcode + uniform-rule `successors`                                                                                       |
 | `unreachable`, `resume`, `unwind`                               | `LLVMOpaqueTerminator` with `successors: []` — they are not returns and get no exit edge (§4)                                                    |
 
-> Pinned by: `src/parser/llvm/__tests__/terminators.test.ts` (one describe per row, each
-> with and without trailing metadata), `errors.test.ts` ("unreachable"),
-> `corpus.test.ts` (probe-04/06/13/14/20, era-2x/era-cpp-eh/era-switch-heavy)
-
 **Degradation:** a `br`/`switch`/`invoke` whose expected structure cannot be found (missing
 targets, missing case brackets, missing `to label`/`unwind label` clause) degrades to an
 `LLVMOpaqueTerminator` that keeps the opcode and the uniform-rule successors — never a throw,
 never a structured node with fabricated fields. Consumers must therefore dispatch on field
 presence, not opcode (§4).
 
-> Pinned by: `terminators.test.ts` ("should degrade to an opaque terminator" cases),
-> `errors.test.ts` ("switch has no case bracket group")
-
 Trailing `, !dbg !7`-style metadata after the recognized structure is ignored and can never
 fail the parse. `parseTerminator` is total: it never throws, on any input.
 
-> Pinned by: `terminators.test.ts` (metadata variants, "totality")
+> Pinned by: `src/parser/llvm/__tests__/classify.test.ts`,
+> `src/parser/llvm/__tests__/terminators.test.ts`,
+> `src/parser/__tests__/llvm/terminators.test.ts`,
+> `src/parser/__tests__/llvm/errors.test.ts`,
+> `src/parser/__tests__/llvm/corpus.test.ts`
 
 ### 3.3 Implicit block numbering
 
@@ -199,15 +181,11 @@ incoming-block reference `[ v, %N ]`; numeric instruction results (`%1 = ...`) d
 count. Otherwise the entry takes the counter value (e.g. `0`, or `3` after three unnamed
 parameters).
 
-> Pinned by: `module.test.ts` ("implicit block numbering (§3.3)" — one case per rule above),
-> `corpus.test.ts` (probe-21 pins `entry` for a numeric-results-only body;
-> era-3x and era-current-clang-o0 pin the counter/hint ids)
-
 Every terminator target that no block id claims produces a diagnostic — never a throw,
 never a silent dangling edge.
 
-> Pinned by: `module.test.ts` ("terminator targets a label no block claims",
-> "every dangling case should be reported")
+> Pinned by: `src/parser/llvm/__tests__/module.test.ts`,
+> `src/parser/__tests__/llvm/corpus.test.ts`
 
 ### 3.4 Error policy
 
@@ -218,63 +196,55 @@ never a silent dangling edge.
 | Structural error (no terminator before `}`, `}` without `define`, unclosed function at EOF, `define` without `{`, empty body, unbalanced `[`) | Throw, with a message naming the 1-based source line and the problem in plain words (`Line N: …`) |
 | Recoverable oddity (implicit-id fallback, dangling terminator target, label after an unterminated block)                                      | Recorded in `LLVMModule.diagnostics` (present only when non-empty), not thrown                    |
 
-> Pinned by: `errors.test.ts` (top-level garbage via both entry points, in-body garbage,
-> structural-message quality), `module.test.ts` ("error policy (§3.4)" — one case per
-> structural error and per diagnostic kind)
-
 **Label-after-unterminated-block recovery:** when a label line arrives while the previous
 block has no terminator, the parser does not throw and does not absorb the label. The
 previous block is closed with a synthetic empty terminator (`opcode: ""`, no successors —
 so it contributes no CFG edge), a diagnostic is recorded, and the label starts its block
 normally.
 
-> Pinned by: `module.test.ts` ("label follows an unterminated block"); the no-edge half
-> follows from the empty-successors rule in §4
-
 `LLVMModule.diagnostics` entries carry a 1-based `line` and a `message`. The editor does not
 surface them yet; that work is tracked by
 [Issue #64](https://github.com/himadajin/ir-visualizer/issues/64).
 
-> Pinned by: `module.test.ts` (diagnostic cases assert line and message)
+> Pinned by: `src/parser/__tests__/llvm/errors.test.ts`,
+> `src/parser/llvm/__tests__/module.test.ts`
 
 ### 3.5 Use-def foundation
 
 Every instruction and terminator parsed from a source line carries two extra fields,
 `defs` and `uses` (possibly empty arrays of sigil-free local names). The consumer is the
 **Use-Def view** (`specs/llvm-use-def-view.md`, built by
-`src/graphBuilder/llvmUseDefGraphBuilder.ts`); the CFG graphBuilder described in §4 still ignores
+`src/graphBuilder/llvmUseDefGraphBuilder.ts`); the CFG graphBuilder described in §4 ignores
 both fields. SSA values only — memory dependence (store→load) is out of scope,
 permanently. The one node without the fields is the synthetic empty terminator of the
 §3.4 label recovery, which has no source line (and, having neither defs nor uses, gets no
 Use-Def node either).
 
-> Pinned by: `src/parser/llvm/__tests__/useDef.test.ts` ("attachment coverage",
-> "corpus-wide properties")
-
 **`defs`** is the `%x =` assignment result exactly: 0 or 1 entry, including invoke and
 callbr results. Globals are never defs.
-
-> Pinned by: `useDef.test.ts` ("defs (assignment result exactly)"); the defs-equals-result
-> consistency corpus-wide by "corpus-wide properties"
 
 **`uses`** are the local value names the line actually READS, deduplicated in
 first-occurrence order:
 
-| Rule                                                                                                                                                                                                                        | Pinned by (`useDef.test.ts`)                        |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| Block labels are not uses: any `label %x` pair (br/switch targets, invoke `to`/`unwind`, callbr/indirectbr lists)                                                                                                           | "labels are not uses", "defs" (invoke/callbr cases) |
-| phi incoming VALUES are uses; incoming-block refs (`[ v, %bb ]` second slot) are not                                                                                                                                        | "phi lines"                                         |
-| Type-alias names (`%struct.T`) are excluded via a module-wide `%T = type …` name table, position-independent (an alias printed after the function still applies); the alias lines themselves stay dropped from the AST (§2) | "type-alias table"                                  |
-| Globals (`@g`) are never uses (locals only); string contents (`c"%d"`) never match — strings are opaque tokens                                                                                                              | "defs" (global case), "string contents"             |
-| The line's own def is never a use                                                                                                                                                                                           | "dedup and self-reference"                          |
-| br/switch conditions, ret values, call/invoke arguments, and operands of generic instructions are uses                                                                                                                      | "labels are not uses", "ret", "calls"               |
-| A local callee (`%fp(...)`) is a use — the function pointer is read                                                                                                                                                         | "calls"                                             |
-| **Store-pointer decision:** the pointer a `store` writes through IS a use — the address itself is read to perform the store; only the pointed-to memory is written                                                          | "store pointer decision"                            |
+- Block labels are not uses: any `label %x` pair (br/switch targets, invoke `to`/`unwind`,
+  callbr/indirectbr lists).
+- phi incoming VALUES are uses; incoming-block refs (`[ v, %bb ]` second slot) are not.
+- Type-alias names (`%struct.T`) are excluded via a module-wide `%T = type …` name table,
+  position-independent (an alias printed after the function still applies); the alias
+  lines themselves stay dropped from the AST (§2).
+- Globals (`@g`) are never uses (locals only); string contents (`c"%d"`) never match —
+  strings are opaque tokens.
+- The line's own def is never a use.
+- br/switch conditions, ret values, call/invoke arguments, and operands of generic
+  instructions are uses.
+- A local callee (`%fp(...)`) is a use — the function pointer is read.
+- **Store-pointer decision:** the pointer a `store` writes through IS a use — the address
+  itself is read to perform the store; only the pointed-to memory is written.
 
-Extraction is total (never throws) and token-based; it does not validate SSA form.
+Extraction is total (never throws) and token-based; it does not validate SSA form. Every
+corpus file parses with well-formed defs/uses on every node.
 
-> Pinned by: `useDef.test.ts` ("corpus-wide properties" — every corpus file parses with
-> well-formed defs/uses on every node)
+> Pinned by: `src/parser/llvm/__tests__/useDef.test.ts`
 
 ## 4. CFG construction rules
 
@@ -303,31 +273,24 @@ Edge rules:
 8. A terminator with empty `successors` (`unreachable`, `resume`, `unwind`) → no edges and
    no exit node.
 
-> Pinned by: `src/graphBuilder/__tests__/llvm/edges.test.ts` (one case per rule),
-> `src/graphBuilder/__tests__/llvm/nodes.test.ts`
-
 The dispatch narrows on the **shape** of the terminator (presence of `condition`,
 `destination`, `defaultTarget`, `normalTarget`, `successors`), not on its opcode: a degraded
 `switch` still has opcode `"switch"` but no `cases` field and must fall through to the
 uniform-successor rule instead of crashing.
 
-> Pinned by: `edges.test.ts` ("degraded switch"), `errors.test.ts` ("switch has no case
-> bracket group" — end-to-end through `parseLLVM`)
-
 `parseLLVM(input)` is exactly `convertASTToGraph(parseLLVMToAST(input))`.
-
-> Pinned by: `src/parser/__tests__/llvm/graphData.test.ts`
 
 ID namespacing: node ids embed the function name (`func_<name>_block_<label>` etc.) so
 multiple functions can reuse block labels (`entry`, numeric labels) without collision; ids
 are unique across the whole graph.
 
-> Pinned by: `src/graphBuilder/__tests__/llvm/invariants.test.ts`
-
 The produced graph always has `direction: "TD"`.
 
-> Pinned by: `src/graphBuilder/__tests__/llvm/invariants.test.ts`,
-> `src/parser/__tests__/llvm/graphData.test.ts`
+> Pinned by: `src/graphBuilder/__tests__/llvm/edges.test.ts`,
+> `src/graphBuilder/__tests__/llvm/nodes.test.ts`,
+> `src/graphBuilder/__tests__/llvm/invariants.test.ts`,
+> `src/parser/__tests__/llvm/graphData.test.ts`,
+> `src/parser/__tests__/llvm/errors.test.ts`
 
 ## 5. Known limitations
 
@@ -338,24 +301,20 @@ The produced graph always has `direction: "TD"`.
   through the uniform successor rule: their edges are unlabeled and carry no per-opcode
   semantics (e.g. a `callbr` fallthrough edge is not distinguished from its indirect
   targets).
-  > Pinned by: `terminators.test.ts` ("opaque terminators"), `edges.test.ts` ("successors")
 - `landingpad` clause continuation lines (`cleanup` / `catch …` / `filter …` printed on
   their own line) become separate opaque instructions in the block (_observed, untested_);
   single-line landingpads — what the corpus contains — parse as one instruction.
 - `phi` instructions do not contribute CFG edges (they are generic instructions textually).
   The Use-Def view recovers their incoming pairs by scanning `originalText`
   (`specs/llvm-use-def-view.md` §3.1).
-  > Pinned by: `classify.test.ts` ("when a phi uses bracketed block refs, should classify
-  > instruction")
 - Operand classification is heuristic, and only the write-target marking of
   `store`/`cmpxchg`/`atomicrmw` is exercised; use-def consumers should read the dedicated
-  `defs`/`uses` fields (§3.5) instead of operands. The callee-extraction heuristic (§3) is
-  deliberately unchanged from the legacy parser.
+  `defs`/`uses` fields (§3.5) instead of operands.
 - The type-alias exclusion in `uses` (§3.5) is name-based: a local _value_ that shares its
   name with a declared type alias would be excluded too (_observed, untested_ — printer
   output does not produce such collisions).
 - Comments (`;`) are stripped and not preserved anywhere (label hints excepted, §1).
-- `LLVMModule.diagnostics` is recorded but not surfaced in the UI.
+- `LLVMModule.diagnostics` is recorded but not surfaced in the UI
+  ([Issue #64](https://github.com/himadajin/ir-visualizer/issues/64)).
 - Extracting declaration names is still not done (`LLVMDeclaration.name` is always the
   literal `"declaration"`).
-  > Pinned by: `module.test.ts` ("top-level entries (legacy shapes)")

--- a/docs/internal/specs/llvm-use-def-view.md
+++ b/docs/internal/specs/llvm-use-def-view.md
@@ -5,10 +5,9 @@ of the `llvm-ir` mode (`views: [cfg, use-def]`), selected by the editor panel's 
 toggle. Input syntax is unchanged from `specs/llvm-ir.md`; this spec covers only
 the AST → `GraphData` conversion performed by
 `src/graphBuilder/llvmUseDefGraphBuilder.ts`, which consumes the §3.5
-`defs`/`uses` fields (the consumer that §3.5 deferred).
+`defs`/`uses` fields.
 
-Conventions: every normative statement carries a **Pinned by** reference to the
-test(s) that fix the behavior. Unqualified test names refer to
+Conventions: unless noted otherwise, every normative statement in this spec is pinned by
 `src/graphBuilder/__tests__/llvm/useDefGraph.test.ts`. Statements marked
 _observed, untested_ describe current behavior with no covering test.
 
@@ -16,36 +15,25 @@ _observed, untested_ describe current behavior with no covering test.
 
 SSA dataflow, per function: one node per instruction line that participates in
 dataflow, one edge per (defining line → reading line) relationship. The graph is
-**flat** — there are no container nodes and no `parentId`, so ELK's layered layout ranks
-instruction nodes directly by their use-def edges and vertical position means dataflow
-depth. A compound-node prototype was rejected because estimated container sizes drifted
-from rendered sizes and React Flow parent clamping cascaded children into overlap.
-Basic-block membership is carried on the instruction node itself as a colored badge (§2),
-not by geometry.
+**flat** — no container nodes and no `parentId` (`contracts/graph-data.md`) — so ELK's
+layered layout ranks instruction nodes directly by their use-def edges and vertical
+position means dataflow depth. Basic-block membership is carried on the instruction node
+itself as a colored badge (§2), not by geometry.
 
 Control flow is **not** shown: a `br` contributes at most the read of its
 condition, never an edge to another block. Module-level items that never
 participate in SSA dataflow — globals, metadata, attribute groups, declarations,
 targets, debug records — produce **no nodes**.
 
-> Pinned by: "module-level items produce no nodes"
-
 ## 2. Nodes
 
 All ids are namespaced by function, using the same `func_<name>` prefixing
 convention as the CFG builder, so identical block labels or value names across
-functions cannot collide. Quoted identifiers are an exception: `uniqueId`
-removes every `@`, `%`, and `"` character anywhere in the name (a global
-strip, not just the leading sigil and surrounding quotes), so a quoted name
-whose _contents_ include `@`, `%`, or `"` can still collide with an unrelated
-name after stripping (e.g. `@"a@b"` and `@ab` both prefix to `func_ab`) — a
-pre-existing encoding gap shared with the CFG builder (`llvmGraphBuilder.ts`);
-fixing it is follow-up work outside this spec (_observed, untested_).
-
-> Pinned by: "node and edge ids stay unique across functions with identical
-> labels, defs, params, and external names" (instruction, argument, external
-> node ids and edge ids together, across functions); per-node-type
-> namespacing is further pinned in §2.1 and §2.2.
+functions cannot collide. Quoted identifiers are an exception: `uniqueId` strips every
+`@`, `%`, and `"` character anywhere in the name, so a quoted name whose _contents_
+include those characters can still collide with an unrelated name after stripping
+(e.g. `@"a@b"` and `@ab` both prefix to `func_ab`) — an encoding gap shared with the CFG
+builder (`llvmGraphBuilder.ts`) (_observed, untested_).
 
 ### 2.1 Instruction nodes
 
@@ -59,14 +47,8 @@ dataflow** — that is, whose `defs` or `uses` is non-empty. A line with an empt
 a `ret void`, or an `unreachable` would otherwise be an isolated dot with no
 incident edge.
 
-> Pinned by: "one node per instruction with defs or uses",
-> "lines with neither defs nor uses get no node",
-> "terminators that read or define values get nodes"
-
 Debug records (`#dbg_*`) and the §3.4 synthetic empty terminator (no source
 line, `originalText === ""`, no `defs`/`uses`) never produce a node.
-
-> Pinned by: "debug records and the synthetic empty terminator get no node"
 
 `astData` is
 `{ text, def, uses, isTerminator, blockLabel, blockIndex }`:
@@ -78,15 +60,7 @@ line, `originalText === ""`, no `defs`/`uses`) never produce a node.
 | `uses`         | the §3.5 use names (sigil-free, deduplicated) — drives the per-operand target ports (§4)                                                    |
 | `isTerminator` | whether the line is the block's terminator                                                                                                  |
 | `blockLabel`   | the block's **display** label: `"entry"` for a first block whose label is `null`, otherwise the block's label, falling back to its block id |
-| `blockIndex`   | the block's 0-based position within its function, in AST block order                                                                        |
-
-`blockIndex` exists to drive the badge tint (§4); it is a rendering input, not a
-semantic ordering claim.
-
-> Pinned by: "instruction node ids are namespaced per function",
-> "instruction astData carries text, def and isTerminator",
-> "blockLabel is entry for the unlabeled entry block",
-> "blockIndex is the block's position in its function"
+| `blockIndex`   | the block's 0-based position within its function, in AST block order — a rendering input for the badge tint (§4), not a semantic ordering   |
 
 ### 2.2 Value nodes
 
@@ -103,10 +77,6 @@ semantic ordering claim.
   (§3.5), so edge construction must be total rather than throwing on an
   unresolved name.
 
-> Pinned by: "one argument node per named parameter",
-> "unnamed parameters get no argument node",
-> "external value node for names with no known def"
-
 ## 3. Edges
 
 For every emitted node `N` and every name `v` in `N.uses`, one edge from the
@@ -116,8 +86,8 @@ argument value node for `v`, else a lazily created external value node — to `N
 - `id`: `e-<sourceId>-<targetId>-<v>`.
 - `targetHandle`: `"u-<v>"` — the edge lands on the target card's per-operand
   port for `v` (§4). Sources use the defining node's single source handle.
-- **No label.** The defined name is already visible in the source node's text,
-  so a `%v` label would be redundant. Only phi edges are labeled (§3.1).
+- **No label.** The defined name is already visible in the source node's text.
+  Only phi edges are labeled (§3.1).
 - `uses` is already deduplicated per line (§3.5), so a line reading `%v` twice
   gets one edge.
 - Self-reference cannot occur: §3.5 excludes a line's own def from its `uses`.
@@ -125,17 +95,12 @@ argument value node for `v`, else a lazily created external value node — to `N
   values are uses; `invoke`/`callbr` results are defs that source edges into
   other blocks.
 
-> Pinned by: "one edge per use, from the defining node",
-> "plain use-def edges carry no label", "edge ids embed the value name",
-> "a value read twice on one line gets one edge",
-> "uses of parameters connect to the argument node"
-
 ### 3.1 phi edges
 
 For a `phi` line, the incoming `[ value, %block ]` pairs are re-extracted
 **textually** from `originalText`: the AST keeps phi generic (`specs/llvm-ir.md`
-§5, "phi instructions do not contribute edges") and `src/graphBuilder` must not
-import from `src/parser`, so the builder scans the text itself.
+§5) and `src/graphBuilder` must not import from `src/parser`, so the builder
+scans the text itself.
 
 An edge whose value name appears as a local incoming value gets `dashed: true`
 and the label `%v (%bb)` naming the incoming block. When the same value arrives
@@ -146,43 +111,36 @@ edge — they are not in `uses`.
 Quoted local names inside phi incoming lists are not matched by the textual scan
 and fall back to a plain (solid, unlabeled) edge — _observed, untested_.
 
-> Pinned by: "phi incoming edges are dashed and labeled with the incoming block",
-> "a value arriving from several blocks gets one edge listing them",
-> "constant phi incoming values contribute no edge"
-
 ## 4. Layout and rendering behavior
 
 - `GraphData.direction` is `"TD"`, and **no node carries `parentId`** — the view
   deliberately produces a flat graph so that the layered layout's ranking is the
-  dataflow order. Containers are excluded for the sizing and clamping reasons in §1.
+  dataflow order (§1).
 - The view supplies its own `layoutOptions` (_observed, untested_) and reuses
   the standard `codeGraphEdgeBuilder`: edge geometry comes from the live
-  orthogonal router `src/utils/edgeRouter.ts` (`specs/graph-view.md` §4), not
-  from ELK, and a loop-carried phi edge — whose source ends
-  up at or below its target — is flagged and styled as a back edge from the
-  final layout geometry without any special casing here.
-- **Per-operand ports**: an
-  instruction card exposes one target `Handle` (id `u-<name>`) per entry in
-  `uses`, horizontally positioned at the first occurrence of `%name` in the
-  monospace text (measured with the same `getFontMetrics` char width the size
-  estimator uses, shifted right by the inline badge's width plus its gap), on
-  the card's top edge; and a source `Handle` under the `def` name on the
-  bottom edge. A name that cannot be located in the text falls back to the
-  default centered handle. The layout declares the same offsets as ELK
-  `FIXED_POS` ports so routed edges aim at the exact operand slot — a phi's
-  incoming edges visibly land on their own `[ %v, %bb ]` operands.
-  _(observed, untested — visual)_
-- Instruction nodes render as single-row code cards: a block badge chip
-  showing `blockLabel` sits inline to the **left** of the code line, tinted from an 8-color muted
-  palette indexed by `blockIndex % 8`. The badge is what preserves the CFG
-  correspondence in the absence of containers.
+  orthogonal router (`specs/graph-view.md` §4), not from ELK, and a loop-carried
+  phi edge — whose source ends up at or below its target — is flagged and styled
+  as a back edge from the final layout geometry without any special casing here.
+- **Per-operand ports**: an instruction card exposes one target `Handle`
+  (id `u-<name>`) per entry in `uses`, horizontally positioned at the first
+  occurrence of `%name` in the monospace text (measured with the same
+  `getFontMetrics` char width the size estimator uses, shifted right by the
+  inline badge's width plus its gap), on the card's top edge; and a source
+  `Handle` under the `def` name on the bottom edge. A name that cannot be
+  located in the text falls back to the default centered handle. The layout
+  declares the same offsets as ELK `FIXED_POS` ports so routed edges aim at the
+  exact operand slot — a phi's incoming edges visibly land on their own
+  `[ %v, %bb ]` operands. _(observed, untested — visual)_
+- Instruction nodes render as single-row code cards: a block badge chip showing
+  `blockLabel` sits inline to the **left** of the code line, tinted from an
+  8-color muted palette indexed by `blockIndex % 8`. The badge is what preserves
+  the CFG correspondence in the absence of containers.
+  _(observed, untested — visual, covered by Storybook stories only)_
 - Value nodes render as pills; `argument` and `external` are styled differently
   so a dangling reference is visibly not a parameter.
+  _(observed, untested — visual)_
 - `dashed` edges render with a dash pattern via the standard edge factory
   (`contracts/graph-data.md`).
-
-> Pinned by: "direction is TD", "no node carries parentId"; the rendering
-> details are _observed, untested_ (visual, covered by Storybook stories only).
 
 ## 5. Non-goals
 

--- a/docs/internal/specs/mermaid.md
+++ b/docs/internal/specs/mermaid.md
@@ -4,9 +4,9 @@ Behavior specification for the `mermaid` mode: the accepted Mermaid-flowchart su
 (`src/parser/mermaid.ohm` / `mermaid.ts`) and the flowchart-to-graph conversion
 (`src/graphBuilder/mermaidGraphBuilder.ts`).
 
-Conventions: every normative statement carries a **Pinned by** reference to the test(s) that
-fix the behavior. Statements marked _observed, untested_ describe current behavior with no
-covering test.
+Conventions: every normative statement is covered by a **Pinned by** reference to the test
+file(s) that fix the behavior. Statements marked _observed, untested_ describe current
+behavior with no covering test.
 
 ## 1. Input model
 
@@ -20,11 +20,9 @@ header), `parse` throws an `Error` with Ohm's match diagnostic.
 - **Header** (required, first non-separator content): `graph <dir>` or `flowchart <dir>` where
   `<dir>` is `TB | TD | BT | RL | LR`. The direction string is carried into
   `GraphData.direction` as-is.
-  > Pinned by: `headerAndDirection.test.ts`
 - **Statements** after the header, separated by newlines and/or `;`:
   - Node declaration: `Id` with an optional label (see shapes below).
   - Edge: `Node Link Node`.
-    > Pinned by: `statements.test.ts` (multiple statements, semicolons, branching pattern)
 - **Node ids** are alphanumeric (`alnum+`). **Shapes** by label bracket:
 
   | Syntax     | `shape`  | Rendered as (see `MermaidNode.tsx`) |
@@ -34,13 +32,15 @@ header), `parse` throws an `Error` with Ohm's match diagnostic.
   | `A{text}`  | `curly`  | dashed border                       |
   | (no label) | —        | label falls back to the node id     |
 
-  > Pinned by: `nodes.test.ts`
-
 - **Links**: `-->` (arrow) and `---` (line), each optionally labeled `-->|text|`, plus the
   middle-text forms `--text-->` / `--text---`. The arrow/line distinction is stored on the AST
   edge (`edgeType`) but does not currently change rendering. _(rendering distinction: observed,
   untested)_
-  > Pinned by (parsing): `edges.test.ts`
+
+> Pinned by: `src/parser/__tests__/mermaid/headerAndDirection.test.ts`,
+> `src/parser/__tests__/mermaid/statements.test.ts`,
+> `src/parser/__tests__/mermaid/nodes.test.ts`,
+> `src/parser/__tests__/mermaid/edges.test.ts`
 
 ## 3. Node deduplication and label back-fill
 
@@ -48,8 +48,9 @@ A node may appear in any number of declarations and edges; it is created once, k
 If a node was first seen without a label (label === id) and a later occurrence carries a label,
 the label and shape are back-filled.
 
-> Pinned by: `statements.test.ts` ("deduplicate nodes"), `invariants.test.ts`
-> ("unique node ids"), `nodes.test.ts` ("edge node labels")
+> Pinned by: `src/parser/__tests__/mermaid/statements.test.ts`,
+> `src/parser/__tests__/mermaid/invariants.test.ts`,
+> `src/parser/__tests__/mermaid/nodes.test.ts`
 
 ## 4. Conversion rules
 
@@ -68,11 +69,12 @@ These are current, test-pinned behavior — changing them is a spec change:
 
 1. **Edge labels keep their pipe delimiters.** `A -->|Yes| B` produces the label string
    `"|Yes|"`, not `"Yes"`, and it renders that way in the graph.
-   > Pinned by: `edges.test.ts` ("should preserve delimiters in label")
 2. **Double-quoted labels keep their quotes.** `A["Quoted"]` parses as a `square` node whose
    label is `"Quoted"` including the quotes — the grammar's `squareQuote` alternative is
    unreachable because the plain `square` rule matches first.
-   > Pinned by: `nodes.test.ts` ("double-quoted")
+
+> Pinned by: `src/parser/__tests__/mermaid/edges.test.ts`,
+> `src/parser/__tests__/mermaid/nodes.test.ts`
 
 ## 6. Known limitations
 
@@ -80,7 +82,7 @@ These are current, test-pinned behavior — changing them is a spec change:
   handlers, other node shapes (`((...))`, `>...]`, `[/.../]`, ...), multi-link chains
   (`A --> B --> C`), and `&`-lists are not in the grammar; input using them throws.
   _(observed, untested)_
-- **`%%` comment lines crash the parser at runtime** ("Missing semantic action for 'comment'"):
-  the grammar accepts them as statements but the semantics has no action for the `comment` rule.
-  Known bug; fix is queued as a follow-up task (add the semantic action + pinning test, then move
-  this entry to §2).
+- **`%%` comment lines crash the parser at runtime** ("Missing semantic action for
+  'comment'"): the grammar accepts them as statements but the semantics has no action for
+  the `comment` rule. Tracked by
+  [Issue #75](https://github.com/himadajin/ir-visualizer/issues/75).

--- a/docs/internal/specs/selectiondag.md
+++ b/docs/internal/specs/selectiondag.md
@@ -4,9 +4,9 @@ Behavior specification for the `selectionDAG` mode: the accepted LLVM SelectionD
 (`src/parser/selectionDAG.ohm` / `selectionDAG.ts`) and the DAG construction
 (`src/graphBuilder/selectionDAGGraphBuilder.ts`).
 
-Conventions: every normative statement carries a **Pinned by** reference to the test(s) that
-fix the behavior. Statements marked _observed, untested_ describe current behavior with no
-covering test.
+Conventions: every normative statement is covered by a **Pinned by** reference to the test
+file(s) that fix the behavior. Statements marked _observed, untested_ describe current
+behavior with no covering test.
 
 ## 1. Input model — line-based, tolerant
 
@@ -23,14 +23,14 @@ This tolerance is intentional (real `llc` dumps mix header text with node lines)
 "Known behavior difference" section of `contracts/ir-mode-registry.md`.
 
 > Pinned by: `src/parser/__tests__/selectionDAG/errorsAndFallbacks.test.ts`,
-> `fullParse.test.ts`, `invariants.test.ts`
+> `src/parser/__tests__/selectionDAG/fullParse.test.ts`,
+> `src/parser/__tests__/selectionDAG/invariants.test.ts`
 
 ## 2. Node-line syntax
 
 A node line is `<nodeId>: <types> = <rhs>` with optional leading indentation.
 
 - **nodeId**: `t<digits>` (current format) or `0x<hex>` (old LLVM dumps).
-  > Pinned by: `nodeSyntax.test.ts` (minimal node, old-format hex node)
 - **types**: comma-separated list, e.g. `i64,ch` — each type is an identifier
   (`i32`, `ch`, `glue`, `v4f32`, ...).
 - **rhs**: either the special form `ValueType: <ty>` (parsed as opName `ValueType` with
@@ -46,8 +46,6 @@ reassoc nofpexcept`.
     bare capitalized name (Bare).
   - **verbose**: an `[ORD=N]`-style bracket group, accepted before or after the operands
     (old-format dumps).
-    > Pinned by: `nodeSyntax.test.ts`, `operandsAndDetails.test.ts`,
-    > `registerAndValueType.test.ts`
 
 - **operands**: comma-separated; each is one of
 
@@ -59,32 +57,32 @@ reassoc nofpexcept`.
   | immediate   | `-?digits`                            | `immediate`                 |
   | null        | `<null>`                              | `null`                      |
 
-  > Pinned by: `operandsAndDetails.test.ts`, `nodeSyntax.test.ts` ("wrapped")
+> Pinned by: `src/parser/__tests__/selectionDAG/nodeSyntax.test.ts`,
+> `src/parser/__tests__/selectionDAG/operandsAndDetails.test.ts`,
+> `src/parser/__tests__/selectionDAG/registerAndValueType.test.ts`
 
 ## 3. DAG construction rules
 
 - Each parsed node becomes one `GraphNode` with `nodeType: "selectionDAG-node"`,
   `language: "llvm"`, the AST node as `astData`, and a compact one-line label (used only for
   fallback sizing). Comment entries produce nothing.
-  > Pinned by: `src/graphBuilder/__tests__/selectionDAG/{nodes,metadata}.test.ts`
 - Edges are generated **from operands**: for every operand of kind `node` whose id refers to a
   node present in the same dump, one edge goes _from the referenced node to the referencing
   node_ (dataflow direction). Inline, immediate, and null operands, and references to unknown
   ids, produce no edge.
-  > Pinned by: `src/graphBuilder/__tests__/selectionDAG/edges.test.ts`
 - Edges attach to specific **Handles** instead of generic node borders:
   `sourceHandle = "<srcId>-type-<resultIndex>"` (the operand's `:N` index, default 0) and
   `targetHandle = "<dstId>-operand-<operandIndex>"`. These ids must match the Handle ids that
   `SelectionDAGNode.tsx` renders per type cell / operand cell.
-  > Pinned by: `edges.test.ts` ("target handles", "source index")
 - If the referenced result type at that index is `ch` or `glue`, the edge is flagged
   `isChainOrGlue` and renders **dashed** (see `createSelectionDAGReactFlowEdge`).
-  > Pinned by: `edges.test.ts` ("chain or glue"),
-  > `src/utils/__tests__/converter.test.ts` ("dashed edge")
 - The graph is always `direction: "TD"`; SelectionDAG layout uses
   `elk.layered.spacing.nodeNodeBetweenLayers: 50` (`selectionDAGMode.layoutOptions`,
-  an ELK option — see `specs/graph-view.md` §3).
-  > Pinned by: `invariants.test.ts` (direction); the spacing value: _observed, untested_
+  an ELK option — see `specs/graph-view.md` §3). _(the spacing value: observed, untested)_
+
+> Pinned by: `src/graphBuilder/__tests__/selectionDAG/{nodes,edges,metadata}.test.ts`,
+> `src/parser/__tests__/selectionDAG/invariants.test.ts`,
+> `src/utils/__tests__/converter.test.ts`
 
 ## 4. Node rendering
 
@@ -114,6 +112,5 @@ The left-column color encodes an opName **category**
   signal that a line the user intended as a node was skipped.
 - Nodes referenced by operands but not defined in the dump produce no edge and no placeholder
   node.
-  > Pinned by: `edges.test.ts` ("unknown node")
 - Related feature request: [#42](https://github.com/himadajin/ir-visualizer/issues/42) —
   optionally inlining constant/register nodes that old-LLVM dumps emit as separate nodes.

--- a/docs/user/supported-formats.md
+++ b/docs/user/supported-formats.md
@@ -34,15 +34,11 @@ else:
 **Version coverage:** parsing is line-oriented and only reads the structure the graph
 needs — block labels and terminators; instruction bodies are kept as text. That makes the
 parser insensitive to most syntax differences between LLVM releases, so printer output from
-LLVM ~2.x through current is accepted:
-
-| LLVM version | Era-specific syntax that is accepted                                                                                                                                        |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ~2.x         | typed pointers (`i8*`), function-pointer call types, one-line `invoke`, the old `unwind` terminator                                                                         |
-| 3.x–6.x      | unnamed blocks printed only as `; <label>:N` comments, old-style `load i8* %p` / `getelementptr` (no separate pointee type), `!llvm.loop` / `!prof` suffixes on terminators |
-| 7.x–13.x     | printed numeric block labels (`7:`), explicit pointee types                                                                                                                 |
-| 14+          | opaque `ptr`, `#dbg_value(...)` debug records, `callbr`                                                                                                                     |
-| any          | `comdat`, `module asm`, `uselistorder` — accepted and ignored                                                                                                               |
+LLVM ~2.x through current is accepted: typed pointers and the old `unwind` terminator
+(2.x), `; <label>:N` unnamed blocks and old-style `load`/`getelementptr` (3.x–6.x),
+printed numeric block labels (7.x–13.x), opaque `ptr`, `#dbg_*` debug records, and
+`callbr` (14+). `comdat`, `module asm`, and `uselistorder` are accepted and ignored. The
+per-era details live in the [LLVM-IR spec](../internal/specs/llvm-ir.md).
 
 **Views:** LLVM-IR has two views, switched by the CFG / Use-Def toggle in the editor panel. The
 editor content is kept when switching views (only switching _mode_ replaces it with that


### PR DESCRIPTION
Closes #76.

Distills `docs/` so each fact has exactly one home and the prose states current behavior declaratively. 9 files, −520/+291 lines (docs total: 1,857 → 1,628).

- `specs/graph-view.md` §4 (170 → 65 lines): algorithm details (Hanan grid, fallback ladder, self-loop six-point table) removed; `contracts/edge-routing.md` and `src/utils/edgeRouter.ts` are now the sole homes for the boundary, guarantees, and algorithm, as the contract already prescribed. Only mode-level behavior stays (structural back-edge flag, incident-edges drag pass, SelectionDAG exception). The performance table is compressed to the ~180-node frame-budget threshold plus measurement conditions.
- Contracts: `Status: Implemented (Phase N)` headers and change-delta prose ("Previously…", "What this buys", PR #60 references) rewritten as present-tense statements.
- All specs: "Pinned by" references coarsened from test-name to test-file granularity so anchors survive test renames (`llvm-use-def-view.md` uses a single blanket pin).
- `specs/mermaid.md`: the `%%` crash entry now links #75 instead of an untracked "fix is queued" note.
- `user/supported-formats.md`: the duplicated LLVM version table replaced with a summary paragraph; the spec keeps the per-era details.

Note on scope: #76 estimated a 600–700 line cut; the actual cut is 229. The remaining content (terminator tables, error policy, use-def extraction rules) is dense normative material not derivable from code, so cutting further would trade spec value for line count. The structural goals — single source per fact, declarative register, rename-tolerant pins — are fully met.

Verification: `npm run test:run` (541 passed), `npm run format`, `npm run lint` (remaining lint errors are pre-existing and confined to the gitignored `storybook-static/` build output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBQ6Dhbhz4JbtNCA3CA2bv