### PR TITLE
fix(edge-routing): quantize router coordinates to an integer lattice

### DIFF
--- a/docs/internal/contracts/edge-routing.md
+++ b/docs/internal/contracts/edge-routing.md
@@ -59,25 +59,142 @@ there is no notion of edges, labels, or anything else blocking a route.
 
 ### Defaults
 
-| option        | default | meaning                                                     |
-| ------------- | ------- | ----------------------------------------------------------- |
-| `nodeMargin`  | `12`    | clearance kept around every node rect, px                   |
-| `bendPenalty` | `30`    | price of one bend, in px of path length                     |
-| `selfLoopGap` | `24`    | distance from a node's right edge to its self-loop lane, px |
+| option        | default | meaning                                                               |
+| ------------- | ------- | --------------------------------------------------------------------- |
+| `nodeMargin`  | `12`    | clearance kept around every node rect, px — rounded (see below)       |
+| `bendPenalty` | `30`    | price of one bend, in px of path length — a cost, never a coordinate  |
+| `selfLoopGap` | `24`    | distance from a node's right edge to its self-loop lane, px — rounded |
+
+`nodeMargin` and `selfLoopGap` are distances that end up added to coordinates, so they are
+quantized like every other input. That is what makes the integer guarantee below
+unconditional instead of a promise kept only for callers that happen to pass integers.
+`bendPenalty` is not a coordinate: it is a term in the cost function, compared against path
+lengths and never added to a position, so it is left alone and a fractional `bendPenalty`
+stays meaningful.
+
+## Input quantization
+
+Every coordinate the router is given is snapped to an integer lattice at the entry of
+`routeEdges`, before the obstacle set is built and before any search runs. No coordinate
+behind that boundary is ever the fractional value that was passed in.
+
+The reason is that the router's inputs are DOM measurements. Measured rects and live handle
+positions arrive with fractional parts as a matter of course — browser zoom alone produces
+them — and fractional inputs put fractions into the output: routes whose last decimals
+differ between two visually identical states, segments a fraction of a pixel long, and
+turning corners whose radius has collapsed to zero. Quantizing at the boundary removes that
+class of output _by construction_ rather than by cleaning it up afterwards: no route is
+rounded on its way out — the only rounding applied to a coordinate behind the boundary is
+the self-loop's 75 %-of-width offset, rounded where it is formed (see Self-loops) — and no
+geometric comparison needs a tolerance, because any two coordinates the router emits are
+either equal or a whole pixel apart.
+
+Rounding is `Math.round` throughout — ties go toward positive infinity (`0.5 → 1`,
+`-1.5 → -1`) — and a resulting `-0` is normalized to `0`, so no returned coordinate is
+ever negative zero.
+
+- **Node rects are quantized by their boundaries, not field by field.** What lands on the
+  lattice is the four edges of the rect: `x' = round(x)`,
+  `width' = round(x + width) - round(x)`, and correspondingly `y' = round(y)`,
+  `height' = round(y + height) - round(y)`. Rounding `x` and `width` independently is a
+  different and wrong operation — it can move the rect's right edge by up to a whole pixel,
+  so the obstacle would no longer cover what was measured. Under the rule above the left
+  edge lands on `round(x)` and the right edge on `round(x + width)`, each within 0.5 px of
+  the measurement.
+- **Request points are quantized per component.** `sourcePoint` and `targetPoint` have their
+  `x` and `y` rounded independently. A handle position is a point, not an interval, so there
+  is no companion field whose consistency has to be preserved.
+- **Options.** `nodeMargin` and `selfLoopGap` are rounded, `bendPenalty` is not, as described
+  under Defaults above.
+- Everything else in the input is not a coordinate and is untouched: `RouteRequest.id`,
+  `source`, `target`, `sourceSide`, `targetSide` and `RouteNodeRect.id` pass through
+  unchanged.
+
+For a caller that already passes integers, quantization is the identity **on the input**:
+every rect, point and option reaches the router unchanged, so the obstacle set and the
+search see exactly what they saw before. Two behavioral changes still reach such a caller,
+both of them in self-loops (see Self-loops). The stub offset is now rounded, so a node whose
+integer width is not a multiple of 4 has its loop leave and re-enter at `round(x + 0.75w)`,
+up to half a pixel from where it did before — a quarter of a pixel for a width that is odd,
+half a pixel for one that is even but not a multiple of 4. And a self-loop's consecutive
+duplicate vertices are now collapsed, which a caller passing `nodeMargin: 0` or
+`selfLoopGap: 0` can observe.
+
+### Degenerate input
+
+Quantization is total — nothing is rejected, and none of the cases below is handled by a
+guard of its own.
+
+- A rect thinner than a pixel can collapse to zero width or height
+  (`round(x + width) === round(x)`). A collapsed rect is still an obstacle: every rect is
+  inflated by `nodeMargin` before the obstacle set is built, so a rect of no extent keeps a
+  band of that width clear around where it sits, exactly as a full-size one does. Only when
+  `nodeMargin` rounds to `0` as well does it stop blocking anything — the inflated rect then
+  has no interior, and the obstacle test is strict-interior.
+- Two values that were distinct can round to the same value. For rect boundaries that
+  produces a duplicate candidate coordinate, which the router already folds when it builds
+  its grid. For handle positions it means two request points less than a pixel apart can
+  become one point — `10.2` and `10.4` do, `10.4` and `10.6` do not. For the options it
+  means a `nodeMargin` or `selfLoopGap` anywhere in `[-0.5, 0.5)` becomes exactly `0`, which
+  can make two vertices of a polyline coincide. Consecutive duplicates are collapsed
+  wherever they arise (see Self-loops); what is promised once a clearance has reached `0` is
+  bounded by the note below.
+- Rounding is monotonic, so no ordering between boundaries can invert: what was to the left
+  of something else is afterwards to the left of it or coincident with it, never to the right
+  of it. Nothing that depends on an ordering can change sign because of quantization.
+
+**Clearance that rounds to zero is outside the domain.** A `nodeMargin` or `selfLoopGap` of
+`0` asks for geometry with no room in it, and such a shape has degenerated rather than
+merely lost precision. A self-loop is asked to leave its node, go around it and come back
+across no distance at all: on a narrow enough rect the lane coincides with the stub, the
+loop has nowhere to run, and what is left of it doubles back on itself. A routed edge is
+asked for something equally impossible when its two request points quantize to the same
+point and `nodeMargin` is `0` — what comes back can then be nothing but that one point,
+twice. Three of the guarantees below are therefore stated for a `nodeMargin` and a
+`selfLoopGap` that round to at least `1`: **Orthogonality**, **≥ 2 points** and **no
+immediate reversals**. What the router returns outside that domain is left unspecified here
+on purpose — a follow-up issue covers making these shapes well defined at zero clearance,
+and pinning values now would pin values that issue is going to change.
+
+The remaining guarantees are unconditional. **Integer coordinates**, **determinism**, the
+**tie-break order**, **missing-node omission** and **duplicate-id handling** hold whatever
+the options are, fractional or zero — fractional options are exactly the input this
+quantization exists to serve, so the bound must not touch them. The bound itself is a
+property of asking for geometry with no room to exist, not of quantization: an exactly-zero
+option reaches the same corner with no rounding involved, and quantization only widens the
+set of inputs that land there from `{0}` to the half-open interval `[-0.5, 0.5)` that rounds
+to it. `bendPenalty` carries no such bound either: it is a cost, not a clearance, and zero
+or fractional values of it are ordinary input.
 
 ## Guarantees callers may rely on
 
 - **Orthogonality.** Every returned polyline is axis-aligned: consecutive points always
-  share exactly one coordinate.
-- **≥ 2 points.** Every entry in the returned map has at least two points, even in
-  degenerate input.
-- **Endpoints are exact.** A routed (non-self-loop) polyline starts exactly at
-  `RouteRequest.sourcePoint` and ends exactly at `RouteRequest.targetPoint`. The
-  `nodeMargin`-pushed point is an interior bend (`points[1]` and the second-to-last point),
-  never the first or last point, so a drawn edge always visually touches its handle and no
-  other layer has to close a gap. **Self-loops are exempt from this rule**: they are
-  synthesized from the node rect alone (see below), so `sourcePoint`/`targetPoint` play no
-  part in their shape at all.
+  share exactly one coordinate. Stated within the clearance domain above (`nodeMargin` and
+  `selfLoopGap` rounding to at least `1`): at a `nodeMargin` of `0`, two request points that
+  quantize to the same point can leave nothing to return but that point twice.
+- **Integer coordinates.** Every `x` and every `y` of every point in every returned
+  polyline is an integer — searched routes, self-loops and fallback routes alike, for any
+  finite input. This is a consequence of the quantization above rather than of a rounding
+  step on the way out: every coordinate the router emits is a quantized rect boundary, a
+  quantized request point or a quantized option, combined by sums, differences, min/max and
+  multiplication by an integer (the fallback steps out along a `±1` direction sign), all of
+  which integers are closed under. The one value on that path that is not an integer — the
+  self-loop's 75 %-of-width offset, a multiplication by `0.75` — is rounded where it is
+  formed (see Self-loops below). Callers therefore never have to round router output, and no
+  returned coordinate is `-0`.
+- **≥ 2 points.** Every entry in the returned map has at least two points, however
+  degenerate the rects and the requests are. Stated within the clearance domain above.
+- **Endpoints are exact on the quantized points.** A routed (non-self-loop) polyline starts
+  exactly at the quantized `RouteRequest.sourcePoint` and ends exactly at the quantized
+  `RouteRequest.targetPoint` — that is, at `(round(x), round(y))` of each, with `-0`
+  normalized to `0`. The `nodeMargin`-pushed point is an interior bend (`points[1]` and the
+  second-to-last point), never the first or last point, so a drawn edge always visually
+  touches its handle and no other layer has to close a gap. What a caller passing fractional
+  points gives up is absolute equality with the values it passed: the drawn endpoint may sit
+  up to 0.5 px away on each axis from the requested point. That trade is deliberate — half a
+  pixel at a handle is invisible, and it buys output with no sub-pixel geometry anywhere in
+  it. **Self-loops are exempt from this rule**: they are synthesized from the node rect alone
+  (see below), so `sourcePoint`/`targetPoint` play no part in their shape at all.
 - **Determinism.** Identical input rects and requests always produce byte-identical
   points, with no dependence on the iteration order of either the `nodes` array or the
   `requests` array — reordering either changes no individual route.
@@ -91,7 +208,10 @@ there is no notion of edges, labels, or anything else blocking a route.
   fallback alike: no interior vertex has its arriving and leaving segments running along
   the same axis in opposite directions. This is the precise, checkable form of "never a
   degenerate hook"; `points[i - 1] !== points[i + 1]` is _not_ an equivalent test (an
-  out-16-then-back-48 detour satisfies it while being exactly the shape banned).
+  out-16-then-back-48 detour satisfies it while being exactly the shape banned). Stated
+  within the clearance domain above, for the reason given there: a shape with no room to
+  exist has nothing but a doubling-back left in it. A `selfLoopGap` of `0` reaches this for
+  fallback routes as well as for self-loops, since the fallback's detours are sized by it.
 - **Missing nodes.** A `RouteRequest` whose `source` or `target` id is **not present** in
   the `nodes` array produces **no entry** in the returned map. `routeEdges` does not throw
   and does not substitute a default rect — it simply omits that request. Self-loops are
@@ -105,17 +225,53 @@ there is no notion of edges, labels, or anything else blocking a route.
 ## Self-loops (right side, six points)
 
 A self-loop request (`source === target`) is synthesized rather than searched. For a node
-rect `(x, y, w, h)` the polyline is always exactly these six points, with
-`laneX = x + w + selfLoopGap`:
+rect `(x, y, w, h)` — the **quantized** rect, so `x`, `y`, `w` and `h` are integers — the
+polyline runs through these six points in this order, subject to the collapse described
+below, with
 
-| #   | point                             |                            |
-| --- | --------------------------------- | -------------------------- |
-| 0   | `(x + 0.75w, y + h)`              | leaves the **bottom** edge |
-| 1   | `(x + 0.75w, y + h + nodeMargin)` | steps clear of the node    |
-| 2   | `(laneX, y + h + nodeMargin)`     | runs **right** to the lane |
-| 3   | `(laneX, y - nodeMargin)`         | runs **up** past the node  |
-| 4   | `(x + 0.75w, y - nodeMargin)`     | comes back **left**        |
-| 5   | `(x + 0.75w, y)`                  | re-enters the **top** edge |
+- `stubX = round(x + 0.75w)`, the offset along the bottom and top edges where the loop
+  leaves and re-enters, and
+- `laneX = x + w + selfLoopGap`, the vertical lane to the right of the node:
+
+| #   | point                         |                            |
+| --- | ----------------------------- | -------------------------- |
+| 0   | `(stubX, y + h)`              | leaves the **bottom** edge |
+| 1   | `(stubX, y + h + nodeMargin)` | steps clear of the node    |
+| 2   | `(laneX, y + h + nodeMargin)` | runs **right** to the lane |
+| 3   | `(laneX, y - nodeMargin)`     | runs **up** past the node  |
+| 4   | `(stubX, y - nodeMargin)`     | comes back **left**        |
+| 5   | `(stubX, y)`                  | re-enters the **top** edge |
+
+`laneX` needs no rounding of its own — `x`, `w` and `selfLoopGap` are all integers by the
+time it is formed — and neither do the four `y` values. `stubX` is the only non-integer
+value that can reach the output: three quarters of a width is fractional whenever the width
+is not a multiple of 4, so the sum is rounded there and the integer guarantee holds for
+self-loops too. For example `w = 100` gives `stubX = x + 75`, `w = 101` gives
+`x + 75.75 → x + 76`, and `w = 102` gives `x + 76.5 → x + 77` (ties round up). `w = 103`
+gives `x + 77.25 → x + 77`. Because `x` is an integer, rounding the
+sum and rounding only the `0.75w` term give the same result once `-0` is normalized (they
+differ only in the sign of zero, e.g. `x = -1, w = 1`).
+
+**Consecutive duplicate vertices are collapsed.** The table gives the shape; what is
+returned is that shape with every pair of identical consecutive points folded into one. This
+is required behavior, not an incidental detail, and it is the same duplicate collapse that
+searched and fallback routes already pass through — self-loops are no longer the exception.
+It is load-bearing because an option can round to zero: a `nodeMargin` in `[-0.5, 0.5)`
+makes points 0 and 1 coincide (and 4 and 5), and a `selfLoopGap` in `[-0.5, 0.5)` makes
+`stubX === laneX` on a rect that quantizes to `w ≤ 2`, which makes 1 coincide with 2 and 3
+with 4. Two identical consecutive points share both coordinates rather than exactly one, so
+leaving them in the output would break Orthogonality.
+
+A self-loop therefore returns **at most** six points, and can return fewer when a clearance
+rounds to zero — whether it does depends on the rect, and a `selfLoopGap` of `0` folds
+nothing unless the rect is narrow enough for the lane to reach the stub. What is returned in
+that case is left unspecified here, since those inputs are outside the domain the guarantees
+are given for (see "Clearance that rounds to zero" above). What the collapse does buy is
+that **a self-loop is orthogonal at any clearance**: no two consecutive returned points are
+ever identical, so every consecutive pair shares exactly one coordinate, in domain or out of
+it. Within the domain there is nothing to fold — with `nodeMargin` and `selfLoopGap` of `1`
+or more, no two _consecutive_ vertices of the six coincide — so the collapse is only ever
+observable outside it.
 
 The side is the **right** side, always — not chosen per node and not derived from free
 space. Points 1 and 4 are load-bearing, not decoration: without them the first/last

--- a/docs/internal/specs/graph-view.md
+++ b/docs/internal/specs/graph-view.md
@@ -78,10 +78,11 @@ Every LLVM/Mermaid edge is rendered by one custom edge type, `routed` (`RoutedEd
 **Edge geometry is a pure function of the live node rectangles**, computed at render time
 by this repo's own orthogonal router. There is exactly one geometry generator: no stored
 geometry, and no notion of geometry that can go out of date. The router's module boundary,
-its guarantees (orthogonality, determinism, exact endpoints, the self-loop shape, the
-no-path fallback, no immediate reversals, missing-node omission), and its option defaults
-are frozen in `contracts/edge-routing.md`; the algorithm behind those guarantees is
-documented in `src/utils/edgeRouter.ts` itself.
+its guarantees (orthogonality, integer coordinates from quantized inputs, determinism,
+endpoints exact on the quantized handle points, the self-loop shape, the no-path fallback,
+no immediate reversals, missing-node omission), and its option defaults are frozen in
+`contracts/edge-routing.md`; the algorithm behind those guarantees is documented in
+`src/utils/edgeRouter.ts` itself.
 
 - **Inputs** are React Flow's measured rects (`internals.positionAbsolute`,
   `measured.width` / `measured.height`) and the live handle positions. Because those track

--- a/src/utils/__tests__/edgeRouter.test.ts
+++ b/src/utils/__tests__/edgeRouter.test.ts
@@ -173,6 +173,88 @@ function hasImmediateReversal(points: Point[]): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Quantization helpers (contract "Input quantization"). `q` restates the
+// contract's own rounding rule — `Math.round`, with `-0` normalized to `0` —
+// so a test can name the quantized input without importing anything from the
+// router. The rest are plain predicates over returned points.
+// ---------------------------------------------------------------------------
+
+/** `Math.round` with `-0` normalized to `0`. */
+function q(value: number): number {
+  const rounded = Math.round(value);
+  return rounded === 0 ? 0 : rounded;
+}
+
+/** True when every coordinate of every point is an integer. */
+function allCoordinatesAreIntegers(points: Point[]): boolean {
+  return points.every((p) => Number.isInteger(p.x) && Number.isInteger(p.y));
+}
+
+/**
+ * True when any coordinate is negative zero. `Number.isInteger(-0)` is `true`,
+ * so `allCoordinatesAreIntegers` cannot see this on its own — the contract
+ * ("Rounding is `Math.round` throughout") bans `-0` separately.
+ */
+function hasNegativeZeroCoordinate(points: Point[]): boolean {
+  return points.some((p) => Object.is(p.x, -0) || Object.is(p.y, -0));
+}
+
+/**
+ * True when two consecutive points are identical. Such a pair shares *both*
+ * coordinates rather than exactly one, which `isOrthogonalPolyline` cannot
+ * detect (it only rejects pairs sharing *neither*). The contract's self-loop
+ * section makes the absence of these unconditional: "no two consecutive
+ * returned points are ever identical … in domain or out of it".
+ */
+function hasConsecutiveDuplicatePoint(points: Point[]): boolean {
+  for (let i = 1; i < points.length; i++) {
+    if (points[i].x === points[i - 1].x && points[i].y === points[i - 1].y) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Length of the shortest run, or `Infinity` when there is no segment at all.
+ * Segments are axis-aligned, so `|dx| + |dy|` is the run length.
+ */
+function shortestSegmentLength(points: Point[]): number {
+  let shortest = Infinity;
+  for (let i = 1; i < points.length; i++) {
+    const run =
+      Math.abs(points[i].x - points[i - 1].x) +
+      Math.abs(points[i].y - points[i - 1].y);
+    if (run < shortest) shortest = run;
+  }
+  return shortest;
+}
+
+/** Total Manhattan length of an orthogonal polyline. */
+function polylineLength(points: Point[]): number {
+  let total = 0;
+  for (let i = 1; i < points.length; i++) {
+    total +=
+      Math.abs(points[i].x - points[i - 1].x) +
+      Math.abs(points[i].y - points[i - 1].y);
+  }
+  return total;
+}
+
+/**
+ * A deterministic stream of fractions in [0, 1) with three decimals, used by
+ * the fractional sweeps below. A plain LCG rather than `Math.random` so that a
+ * failure is reproducible and the suite cannot pass or fail by luck.
+ */
+function fractionStream(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) % 2147483648;
+    return (state % 1000) / 1000;
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Shared fixtures
 // ---------------------------------------------------------------------------
 
@@ -1180,6 +1262,1133 @@ describe("routeEdges — no immediate reversal / never a degenerate hook (arbitr
     }
 
     expect(failures).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// Input quantization (contract "Input quantization", issue #89).
+//
+// Everything below is derived from `docs/internal/contracts/edge-routing.md`,
+// not from the router source. Every fixture in this file above this point uses
+// integer coordinates, where quantization is the identity; the fixtures below
+// are deliberately fractional, which is the only way the rule is observable.
+// ===========================================================================
+
+/**
+ * One fractional scenario: two node-sized rects with an obstacle between them,
+ * every coordinate carrying a fraction, plus a routed request and a self-loop.
+ * Shapes and spacing are those of a CFG basic block (~120x50, ~150px apart) so
+ * the sweep exercises the geometry the router actually sees, and the obstacle
+ * is placed to force a real detour rather than a straight run.
+ */
+function fractionalScenario(next: () => number, i: number) {
+  const aRect: RouteNodeRect = {
+    id: "A",
+    x: next(),
+    y: next(),
+    width: 120 + next(),
+    height: 50 + next(),
+  };
+  const obstacle: RouteNodeRect = {
+    id: "OBS",
+    x: -30 + (i % 5) * 25 + next(),
+    y: 100 + next(),
+    width: 100 + next(),
+    height: 40 + next(),
+  };
+  // B's column is offset from A's by a multiple of 30 px *plus a fraction*, so
+  // one case in seven has the two blocks sharing a column to within a fraction
+  // of a pixel — the CFG geometry that produces sub-pixel jogs in the app.
+  const bRect: RouteNodeRect = {
+    id: "B",
+    x: aRect.x - 60 + (i % 7) * 30 + next(),
+    y: 210 + next(),
+    width: 120 + next(),
+    height: 50 + next(),
+  };
+  const edge: RouteRequest = {
+    id: "e-A-B",
+    source: "A",
+    target: "B",
+    sourcePoint: sideCenterPoint(aRect, "bottom"),
+    targetPoint: sideCenterPoint(bRect, "top"),
+    sourceSide: "bottom",
+    targetSide: "top",
+  };
+  const loop: RouteRequest = {
+    id: "loop-A",
+    source: "A",
+    target: "A",
+    sourcePoint: sideCenterPoint(aRect, "bottom"),
+    targetPoint: sideCenterPoint(aRect, "top"),
+    sourceSide: "bottom",
+    targetSide: "top",
+  };
+  // Fractional options too: the contract makes the integer guarantee
+  // unconditional by rounding `nodeMargin` and `selfLoopGap`. Both stay in the
+  // stated clearance domain (they round to 12/13 and 24/25, never to 0), so
+  // orthogonality and no-immediate-reversal are in force here.
+  const options = {
+    nodeMargin: 12 + next(),
+    selfLoopGap: 24 + next(),
+    bendPenalty: 30 + next(),
+  };
+  return { nodes: [aRect, obstacle, bRect], requests: [edge, loop], options };
+}
+
+describe("routeEdges — quantization: integer coordinates (contract 'Integer coordinates')", () => {
+  // "Every `x` and every `y` of every point in every returned polyline is an
+  // integer — searched routes, self-loops and fallback routes alike, for any
+  // finite input." Catches the whole class of no-quantization implementations,
+  // and (via the self-loop half) one that quantizes rects and request points
+  // but forgets the 75%-of-width offset.
+
+  it("returns only integer coordinates for searched routes and self-loops across a sweep of fractional rects, handles and options", () => {
+    const next = fractionStream(89);
+    const failures: string[] = [];
+
+    for (let i = 0; i < 60; i++) {
+      const { nodes, requests, options } = fractionalScenario(next, i);
+      const routes = routeEdges(nodes, requests, options);
+
+      for (const request of requests) {
+        const points = routes.get(request.id)!;
+        if (!allCoordinatesAreIntegers(points)) {
+          failures.push(
+            `case ${i} ${request.id}: non-integer coordinate in ${JSON.stringify(points)}`,
+          );
+        }
+        if (hasNegativeZeroCoordinate(points)) {
+          failures.push(`case ${i} ${request.id}: contains -0`);
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("returns only integer coordinates for fallback routes on fractional input", () => {
+    // Same forced-no-path technique as the fallback describe block above, with
+    // every rect and handle carrying a fraction. The fallback inherits
+    // quantization from the quantized request and options — it does no
+    // rounding of its own — so this is the half of the guarantee an
+    // implementation that quantized only the obstacle set would miss.
+    const wall: RouteNodeRect = {
+      id: "WALL",
+      x: -1000.3,
+      y: -1000.4,
+      width: 3000.4,
+      height: 3000.9,
+    };
+    const a: RouteNodeRect = {
+      id: "A",
+      x: -900.2,
+      y: -900.7,
+      width: 10.4,
+      height: 10.4,
+    };
+    const b: RouteNodeRect = {
+      id: "B",
+      x: 900.6,
+      y: 900.2,
+      width: 10.9,
+      height: 10.1,
+    };
+    const nodes = [a, b, wall];
+
+    const configs: {
+      label: string;
+      sourcePoint: Point;
+      targetPoint: Point;
+      sourceSide: RouteSide;
+      targetSide: RouteSide;
+    }[] = [
+      {
+        label: "direct rung",
+        sourcePoint: { x: 40.4, y: 20.2 },
+        targetPoint: { x: 399.5, y: 19.7 },
+        sourceSide: "right",
+        targetSide: "left",
+      },
+      {
+        label: "L rung",
+        sourcePoint: { x: 20.3, y: 40.9 },
+        targetPoint: { x: 300.7, y: 170.4 },
+        sourceSide: "bottom",
+        targetSide: "left",
+      },
+      {
+        label: "dog-leg rung",
+        sourcePoint: { x: 0.4, y: -0.3 },
+        targetPoint: { x: 200.6, y: 0.2 },
+        sourceSide: "bottom",
+        targetSide: "top",
+      },
+      {
+        label: "rectangle rung (coincident quantized handles)",
+        sourcePoint: { x: 0.2, y: 0.4 },
+        targetPoint: { x: -0.3, y: -0.4 },
+        sourceSide: "bottom",
+        targetSide: "bottom",
+      },
+    ];
+
+    const failures: string[] = [];
+    for (const config of configs) {
+      const request: RouteRequest = {
+        id: "e-A-B",
+        source: "A",
+        target: "B",
+        sourcePoint: config.sourcePoint,
+        targetPoint: config.targetPoint,
+        sourceSide: config.sourceSide,
+        targetSide: config.targetSide,
+      };
+      const points = routeEdges(nodes, [request], {
+        nodeMargin: 12.4,
+        selfLoopGap: 23.6,
+      }).get(request.id)!;
+
+      if (!allCoordinatesAreIntegers(points)) {
+        failures.push(`${config.label}: ${JSON.stringify(points)}`);
+      }
+      if (hasNegativeZeroCoordinate(points)) {
+        failures.push(`${config.label}: contains -0`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("builds the fallback skeleton from the quantized request and the quantized options", () => {
+    // The exact "direct" rung, hand-computed from the *quantized* values:
+    // sourcePoint (40.4, 20.2) -> (40, 20); targetPoint (399.5, 19.7) ->
+    // (400, 20) (ties round toward +infinity); nodeMargin 12.4 -> 12;
+    // selfLoopGap 23.6 -> 24. dy is then 0, so the direct rung applies:
+    // 40 -> S=52 -> P1=76 -> P2=364 -> T=388 -> 400.
+    // An implementation that quantized rects but left the request points or
+    // the options fractional produces a different polyline on every vertex.
+    const wall: RouteNodeRect = {
+      id: "WALL",
+      x: -1000.3,
+      y: -1000.4,
+      width: 3000.4,
+      height: 3000.9,
+    };
+    const a: RouteNodeRect = {
+      id: "A",
+      x: -900.2,
+      y: -900.7,
+      width: 10.4,
+      height: 10.4,
+    };
+    const b: RouteNodeRect = {
+      id: "B",
+      x: 900.6,
+      y: 900.2,
+      width: 10.9,
+      height: 10.1,
+    };
+    const request: RouteRequest = {
+      id: "e-A-B",
+      source: "A",
+      target: "B",
+      sourcePoint: { x: 40.4, y: 20.2 },
+      targetPoint: { x: 399.5, y: 19.7 },
+      sourceSide: "right",
+      targetSide: "left",
+    };
+
+    const points = routeEdges([a, b, wall], [request], {
+      nodeMargin: 12.4,
+      selfLoopGap: 23.6,
+    }).get(request.id)!;
+
+    expect(points).toEqual([
+      { x: 40, y: 20 },
+      { x: 52, y: 20 },
+      { x: 76, y: 20 },
+      { x: 364, y: 20 },
+      { x: 388, y: 20 },
+      { x: 400, y: 20 },
+    ]);
+  });
+});
+
+describe("routeEdges — quantization: no sub-pixel runs (issue #89 acceptance criterion)", () => {
+  // The visible defect this change exists to remove. Integer coordinates plus
+  // the duplicate collapse mean "any two coordinates the router emits are
+  // either equal or a whole pixel apart" (contract, "Input quantization"), so
+  // no run can be shorter than 1 px. The first case below is the discriminating
+  // one — it reproduces the app's jog and fails against an unquantized router.
+  // The two sweeps that follow are breadth: they catch the residue an integer
+  // check alone cannot see, a run of length *zero* left behind when two
+  // distinct fractional coordinates round onto the same lattice point and the
+  // duplicate collapse does not fold the resulting pair.
+
+  it("removes the sub-pixel jog between two blocks whose measured columns differ by a fraction of a pixel", () => {
+    // The shape the issue is about, reduced to its smallest form: two
+    // basic-block-sized nodes stacked in what looks like one column, whose
+    // measured x differs by delta < 1 px — exactly what browser zoom produces.
+    // Their bottom/top handle centres are then delta apart, so the edge
+    // between them contains a horizontal run delta px long: a jog that renders
+    // as a kink at a corner radius of zero. Verified against the pre-change
+    // router, which returns runs of exactly delta here for every delta below.
+    // Quantization makes both handle columns land on the same integer (or a
+    // whole pixel apart), so the jog is either gone or a full pixel wide.
+    const failures: string[] = [];
+
+    for (const delta of [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]) {
+      const aRect: RouteNodeRect = {
+        id: "A",
+        x: 0.4,
+        y: 0.4,
+        width: 120.4,
+        height: 50.4,
+      };
+      const obstacle: RouteNodeRect = {
+        id: "OBS",
+        x: 95.2,
+        y: 100.6,
+        width: 100.8,
+        height: 40.4,
+      };
+      const bRect: RouteNodeRect = {
+        id: "B",
+        x: 0.4 + delta,
+        y: 210.9,
+        width: 120.4,
+        height: 50.5,
+      };
+      const request: RouteRequest = {
+        id: "e-A-B",
+        source: "A",
+        target: "B",
+        sourcePoint: sideCenterPoint(aRect, "bottom"),
+        targetPoint: sideCenterPoint(bRect, "top"),
+        sourceSide: "bottom",
+        targetSide: "top",
+      };
+
+      const points = routeEdges([aRect, obstacle, bRect], [request], {
+        nodeMargin: 12.8,
+        selfLoopGap: 24,
+      }).get(request.id)!;
+
+      const shortest = shortestSegmentLength(points);
+      if (shortest < 1) {
+        failures.push(
+          `delta=${delta}: run of ${shortest} in ${JSON.stringify(points)}`,
+        );
+      }
+      if (!allCoordinatesAreIntegers(points)) {
+        failures.push(`delta=${delta}: non-integer coordinate`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("emits no run shorter than 1 px across a sweep of fractional rects, handles and options", () => {
+    const next = fractionStream(1789);
+    const failures: string[] = [];
+
+    for (let i = 0; i < 60; i++) {
+      const { nodes, requests, options } = fractionalScenario(next, i);
+      const routes = routeEdges(nodes, requests, options);
+
+      for (const request of requests) {
+        const points = routes.get(request.id)!;
+        const shortest = shortestSegmentLength(points);
+        if (shortest < 1) {
+          failures.push(
+            `case ${i} ${request.id}: shortest run ${shortest} in ${JSON.stringify(points)}`,
+          );
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("keeps orthogonality and the no-reversal invariant on fractional input", () => {
+    // Both guarantees are stated for a `nodeMargin` and `selfLoopGap` that
+    // round to at least 1, which every option this sweep generates does.
+    const next = fractionStream(4211);
+    const failures: string[] = [];
+
+    for (let i = 0; i < 60; i++) {
+      const { nodes, requests, options } = fractionalScenario(next, i);
+      const routes = routeEdges(nodes, requests, options);
+
+      for (const request of requests) {
+        const points = routes.get(request.id)!;
+        if (points.length < 2)
+          failures.push(`case ${i} ${request.id}: < 2 pts`);
+        if (!isOrthogonalPolyline(points)) {
+          failures.push(`case ${i} ${request.id}: not orthogonal`);
+        }
+        if (hasConsecutiveDuplicatePoint(points)) {
+          failures.push(`case ${i} ${request.id}: consecutive duplicate point`);
+        }
+        if (hasImmediateReversal(points)) {
+          failures.push(`case ${i} ${request.id}: immediate reversal`);
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+});
+
+describe("routeEdges — quantization: the rounding rule (contract 'Rounding is Math.round throughout')", () => {
+  // "ties go toward positive infinity (`0.5 -> 1`, `-1.5 -> -1`) — and a
+  // resulting `-0` is normalized to `0`". Each case below is falsifiable only
+  // against one specific wrong rule: `Math.floor`/`Math.trunc`, or a
+  // `Math.round` whose `-0` is left alone.
+
+  it("rounds a .5 tie toward positive infinity, not down", () => {
+    const nodes: RouteNodeRect[] = [
+      { id: "A", x: 0, y: 0, width: 40, height: 40 },
+      { id: "B", x: 200, y: 0, width: 40, height: 40 },
+    ];
+    const request: RouteRequest = {
+      id: "e-A-B",
+      source: "A",
+      target: "B",
+      // 19.5 is the tie: Math.round -> 20, Math.floor/trunc -> 19.
+      sourcePoint: { x: 40, y: 19.5 },
+      targetPoint: { x: 200, y: 19.5 },
+      sourceSide: "right",
+      targetSide: "left",
+    };
+
+    const points = routeEdges(nodes, [request]).get(request.id)!;
+
+    expect(points[0]).toEqual({ x: 40, y: 20 });
+    expect(points[points.length - 1]).toEqual({ x: 200, y: 20 });
+  });
+
+  it("rounds a negative tie toward positive infinity (-1.5 -> -1)", () => {
+    const nodes: RouteNodeRect[] = [
+      { id: "A", x: 0, y: -21.5, width: 40, height: 40 },
+      { id: "B", x: 200, y: -21.5, width: 40, height: 40 },
+    ];
+    const request: RouteRequest = {
+      id: "e-A-B",
+      source: "A",
+      target: "B",
+      // Math.round(-1.5) === -1; a "round half away from zero" rule gives -2.
+      sourcePoint: { x: 40, y: -1.5 },
+      targetPoint: { x: 200, y: -1.5 },
+      sourceSide: "right",
+      targetSide: "left",
+    };
+
+    const points = routeEdges(nodes, [request]).get(request.id)!;
+
+    expect(points[0]).toEqual({ x: 40, y: -1 });
+    expect(points[points.length - 1]).toEqual({ x: 200, y: -1 });
+  });
+
+  it("normalizes -0 to 0 on a coordinate that rounds out of [-0.5, 0)", () => {
+    // The only inputs `Math.round` turns into `-0`. A's rect is placed so its
+    // right-side centre handle is exactly (-0.3, -0.4): the rect spans
+    // x -40.3..-0.3 and y -20.4..19.6, both of whose quantized right/centre
+    // values sit in that interval. Vitest's toEqual/toBe/toStrictEqual all
+    // distinguish -0 from 0, and Object.is makes the intent explicit.
+    const nodes: RouteNodeRect[] = [
+      { id: "A", x: -40.3, y: -20.4, width: 40, height: 40 },
+      { id: "B", x: 200, y: -20, width: 40, height: 40 },
+    ];
+    const request: RouteRequest = {
+      id: "e-A-B",
+      source: "A",
+      target: "B",
+      sourcePoint: { x: -0.3, y: -0.4 },
+      targetPoint: { x: 200, y: 0 },
+      sourceSide: "right",
+      targetSide: "left",
+    };
+
+    const points = routeEdges(nodes, [request]).get(request.id)!;
+
+    expect(points[0]).toEqual({ x: 0, y: 0 });
+    expect(Object.is(points[0].x, 0)).toBe(true);
+    expect(Object.is(points[0].y, 0)).toBe(true);
+    expect(hasNegativeZeroCoordinate(points)).toBe(false);
+  });
+});
+
+describe("routeEdges — quantization: node rects are quantized by boundary (contract 'Node rects are quantized by their boundaries, not field by field')", () => {
+  // "`width' = round(x + width) - round(x)` … Rounding `x` and `width`
+  // independently is a different and wrong operation — it can move the rect's
+  // right edge by up to a whole pixel". Both cases below use x = 100.4 with
+  // width = 39.4: the boundary rule gives x' = 100 and a right edge at
+  // round(139.8) = 140, while rounding the fields independently gives
+  // 100 + round(39.4) = 139. One whole pixel, and both cases pin the
+  // consequence rather than the arithmetic.
+
+  it("puts the obstacle's inflated right boundary a whole pixel where field-by-field rounding would not", () => {
+    // LEFTWALL's inflated rect reaches x = 92 and OBS's reaches x = 88, so the
+    // two overlap and the band y in [88, 152] is sealed everywhere left of
+    // OBS. The only way from S down to T is around OBS's right inflated
+    // boundary, which is the single grid line the two rounding rules disagree
+    // about: 140 + 12 = 152 under the boundary rule, 139 + 12 = 151 under the
+    // wrong one. Verified against integer-coordinate rects of width 40 and 39,
+    // which reproduce 152 and 151 respectively.
+    const obstacle: RouteNodeRect = {
+      id: "OBS",
+      x: 100.4,
+      y: 100,
+      width: 39.4,
+      height: 40,
+    };
+    const nodes: RouteNodeRect[] = [
+      { id: "S", x: 100, y: 0, width: 40, height: 40 },
+      { id: "T", x: 100, y: 240, width: 40, height: 40 },
+      obstacle,
+      { id: "LEFTWALL", x: -400, y: -400, width: 480, height: 1000 },
+    ];
+    const request: RouteRequest = {
+      id: "e-S-T",
+      source: "S",
+      target: "T",
+      sourcePoint: { x: 120, y: 40 },
+      targetPoint: { x: 120, y: 240 },
+      sourceSide: "bottom",
+      targetSide: "top",
+    };
+
+    const points = routeEdges(nodes, [request]).get(request.id)!;
+
+    expect(points.some((p) => p.x === 152)).toBe(true);
+    expect(points.some((p) => p.x === 151)).toBe(false);
+    // The quantized obstacle, inflated by the default nodeMargin: nothing may
+    // cross its interior, which a route hugging x = 151 would.
+    expect(
+      anySegmentCrossesRectInterior(points, {
+        x: 88,
+        y: 88,
+        width: 64,
+        height: 64,
+      }),
+    ).toBe(false);
+  });
+
+  it("derives a self-loop from the boundary-quantized rect on all four edges", () => {
+    // A self-loop reads the rect and nothing else, so it exposes all four
+    // quantized boundaries at once. Rect (100.4, 200.4, 39.4, 49.4) quantizes
+    // to x 100..140 and y 200..250, i.e. w = 40 and h = 50. Field-by-field
+    // rounding would give w = 39 and h = 49 and move four of the six vertices.
+    const rect: RouteNodeRect = {
+      id: "A",
+      x: 100.4,
+      y: 200.4,
+      width: 39.4,
+      height: 49.4,
+    };
+    const request: RouteRequest = {
+      id: "loop-A",
+      source: "A",
+      target: "A",
+      sourcePoint: { x: 120.1, y: 249.8 },
+      targetPoint: { x: 120.1, y: 200.4 },
+      sourceSide: "bottom",
+      targetSide: "top",
+    };
+
+    const points = routeEdges([rect], [request]).get(request.id)!;
+
+    // stubX = round(100 + 0.75 * 40) = 130; laneX = 100 + 40 + 24 = 164;
+    // the node's own edges are y = 200 and y = 250, margin 12 either side.
+    expect(points).toEqual([
+      { x: 130, y: 250 },
+      { x: 130, y: 262 },
+      { x: 164, y: 262 },
+      { x: 164, y: 188 },
+      { x: 130, y: 188 },
+      { x: 130, y: 200 },
+    ]);
+  });
+});
+
+describe("routeEdges — quantization: a rect that collapses to zero extent still blocks (contract 'Degenerate input')", () => {
+  // "A collapsed rect is still an obstacle: every rect is inflated by
+  // `nodeMargin` before the obstacle set is built, so a rect of no extent keeps
+  // a band of that width clear around where it sits, exactly as a full-size one
+  // does." Unconditional — not one of the three guarantees bounded to a
+  // clearance of at least 1, and not left unspecified.
+  //
+  // The wrong implementation is the tempting one: drop rects whose quantized
+  // extent is zero from the obstacle set, on the reasoning that a rect of no
+  // area cannot contain anything. It would silently unblock every real node
+  // that happens to measure sub-pixel-thin, and nothing else in this file
+  // notices, because every other fixture uses a rect with extent to spare.
+  //
+  // What is asserted is the contract's own property — the band stays clear —
+  // rather than "the route differs from a control", which is only its symptom.
+  // The obstacle is neither source nor target, so no stub exemption applies and
+  // the full-polyline check is the right one.
+  const nodeMargin = 12; // default
+
+  const aRect: RouteNodeRect = { id: "A", x: 0, y: 0, width: 40, height: 40 };
+  const bRect: RouteNodeRect = { id: "B", x: 200, y: 0, width: 40, height: 40 };
+  const request: RouteRequest = {
+    id: "e-A-B",
+    source: "A",
+    target: "B",
+    sourcePoint: { x: 40, y: 20 },
+    targetPoint: { x: 200, y: 20 },
+    sourceSide: "right",
+    targetSide: "left",
+  };
+
+  // Each rect is sub-pixel-thin on one or both axes and sits squarely on the
+  // straight line from A's right handle to B's left handle. `band` is the
+  // quantized rect inflated by `nodeMargin`, hand-computed: a zero-extent rect
+  // still inflates to a band `2 * nodeMargin` wide with a non-empty interior.
+  const collapsed: { label: string; rect: RouteNodeRect; band: Rect }[] = [
+    {
+      label: "zero height (y 19.8..20.2 -> 20..20)",
+      rect: { id: "THIN", x: 100, y: 19.8, width: 40, height: 0.4 },
+      band: { x: 88, y: 8, width: 64, height: 2 * nodeMargin },
+    },
+    {
+      label: "zero width (x 119.8..120.2 -> 120..120)",
+      rect: { id: "THIN", x: 119.8, y: 0, width: 0.4, height: 40 },
+      band: { x: 108, y: -12, width: 2 * nodeMargin, height: 64 },
+    },
+    {
+      label: "zero on both axes",
+      rect: { id: "THIN", x: 119.8, y: 19.8, width: 0.4, height: 0.4 },
+      band: { x: 108, y: 8, width: 2 * nodeMargin, height: 2 * nodeMargin },
+    },
+  ];
+
+  it("keeps a nodeMargin-wide band clear around a rect whose quantized extent is zero", () => {
+    const failures: string[] = [];
+
+    for (const { label, rect, band } of collapsed) {
+      const points = routeEdges([aRect, bRect, rect], [request]).get(
+        request.id,
+      )!;
+
+      if (anySegmentCrossesRectInterior(points, band)) {
+        failures.push(
+          `${label}: crosses the inflated band ${JSON.stringify(band)} — ${JSON.stringify(points)}`,
+        );
+      }
+      // The endpoints stay exact while the route goes around it: the clearance
+      // is bought with a detour, not by moving the handles.
+      if (points[0].x !== 40 || points[0].y !== 20) {
+        failures.push(`${label}: source endpoint moved`);
+      }
+      if (!allCoordinatesAreIntegers(points)) {
+        failures.push(`${label}: non-integer coordinate`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("control: with the collapsed rect absent, the route runs straight through that same band", () => {
+    // Without this, the assertion above could be satisfied by a band the route
+    // was never going to enter anyway. A's and B's handles are both at y = 20,
+    // so with nothing in between the route is a straight horizontal run — and
+    // it crosses the interior of all three bands.
+    const points = routeEdges([aRect, bRect], [request]).get(request.id)!;
+
+    expect(points).toEqual([
+      { x: 40, y: 20 },
+      { x: 52, y: 20 },
+      { x: 188, y: 20 },
+      { x: 200, y: 20 },
+    ]);
+    for (const { band } of collapsed) {
+      expect(anySegmentCrossesRectInterior(points, band)).toBe(true);
+    }
+  });
+});
+
+describe("routeEdges — quantization: endpoints are exact on the quantized points (contract 'Endpoints are exact on the quantized points')", () => {
+  // "A routed (non-self-loop) polyline starts exactly at the quantized
+  // `RouteRequest.sourcePoint` and ends exactly at the quantized
+  // `RouteRequest.targetPoint` … the drawn endpoint may sit up to 0.5 px away
+  // on each axis from the requested point."
+
+  it("starts and ends on the quantized request points, not the fractional ones", () => {
+    const nodes: RouteNodeRect[] = [
+      { id: "A", x: -0.3, y: -0.4, width: 40.2, height: 40.4 },
+      { id: "B", x: 199.6, y: 0.2, width: 40.3, height: 40.1 },
+    ];
+    const request: RouteRequest = {
+      id: "e-A-B",
+      source: "A",
+      target: "B",
+      sourcePoint: { x: 39.9, y: 19.5 },
+      targetPoint: { x: 199.6, y: 20.4 },
+      sourceSide: "right",
+      targetSide: "left",
+    };
+
+    const points = routeEdges(nodes, [request]).get(request.id)!;
+    const last = points[points.length - 1];
+
+    expect(points[0]).toEqual({ x: 40, y: 20 });
+    expect(last).toEqual({ x: 200, y: 20 });
+    // …and emphatically not the values the caller passed.
+    expect(points[0]).not.toEqual(request.sourcePoint);
+    expect(last).not.toEqual(request.targetPoint);
+  });
+
+  it("never moves an endpoint more than 0.5 px on either axis, across the fractional sweep", () => {
+    // The documented price of the guarantee. A quantizer using a coarser
+    // lattice, or scaling before rounding, would break this bound long before
+    // it broke the integer guarantee.
+    const next = fractionStream(3607);
+    const failures: string[] = [];
+
+    for (let i = 0; i < 60; i++) {
+      const { nodes, requests, options } = fractionalScenario(next, i);
+      const routes = routeEdges(nodes, requests, options);
+      const edge = requests[0]; // requests[1] is the self-loop, which is exempt
+      const points = routes.get(edge.id)!;
+      const last = points[points.length - 1];
+
+      const expectedFirst = {
+        x: q(edge.sourcePoint.x),
+        y: q(edge.sourcePoint.y),
+      };
+      const expectedLast = {
+        x: q(edge.targetPoint.x),
+        y: q(edge.targetPoint.y),
+      };
+
+      if (points[0].x !== expectedFirst.x || points[0].y !== expectedFirst.y) {
+        failures.push(
+          `case ${i}: first point ${JSON.stringify(points[0])} !== ${JSON.stringify(expectedFirst)}`,
+        );
+      }
+      if (last.x !== expectedLast.x || last.y !== expectedLast.y) {
+        failures.push(
+          `case ${i}: last point ${JSON.stringify(last)} !== ${JSON.stringify(expectedLast)}`,
+        );
+      }
+      if (
+        Math.abs(points[0].x - edge.sourcePoint.x) > 0.5 ||
+        Math.abs(points[0].y - edge.sourcePoint.y) > 0.5 ||
+        Math.abs(last.x - edge.targetPoint.x) > 0.5 ||
+        Math.abs(last.y - edge.targetPoint.y) > 0.5
+      ) {
+        failures.push(`case ${i}: endpoint moved more than 0.5 px`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+});
+
+describe("routeEdges — quantization: options (contract 'Defaults' and 'Options')", () => {
+  // "`nodeMargin` and `selfLoopGap` are rounded, `bendPenalty` is not."
+
+  it("rounds nodeMargin: the pushed points sit at the rounded distance", () => {
+    // points[1] is sourcePoint pushed outward by nodeMargin (the guarantee
+    // "Endpoints are exact" already pins its role), so it reads the option
+    // back directly. 11.6 and 12.4 both round to 12; truncation would give 11
+    // for the first and no rounding at all 11.6.
+    const { nodes, request } = simpleTwoNodeCase();
+
+    for (const nodeMargin of [11.6, 12.4]) {
+      const points = routeEdges(nodes, [request], { nodeMargin }).get(
+        request.id,
+      )!;
+      expect(points[1]).toEqual({ x: 52, y: 20 });
+      expect(points[points.length - 2]).toEqual({ x: 188, y: 20 });
+    }
+
+    // A second, different margin, so the assertion cannot be satisfied by an
+    // implementation that ignores the option and always uses the default 12.
+    for (const nodeMargin of [19.6, 20.4]) {
+      const points = routeEdges(nodes, [request], { nodeMargin }).get(
+        request.id,
+      )!;
+      expect(points[1]).toEqual({ x: 60, y: 20 });
+      expect(points[points.length - 2]).toEqual({ x: 180, y: 20 });
+    }
+  });
+
+  it("rounds selfLoopGap: the lane sits at the rounded distance from the node's right edge", () => {
+    const rect: RouteNodeRect = { id: "A", x: 0, y: 0, width: 100, height: 50 };
+    const request: RouteRequest = {
+      id: "loop-A",
+      source: "A",
+      target: "A",
+      sourcePoint: { x: 50, y: 50 },
+      targetPoint: { x: 50, y: 0 },
+      sourceSide: "bottom",
+      targetSide: "top",
+    };
+
+    for (const selfLoopGap of [23.6, 24.4]) {
+      const points = routeEdges([rect], [request], { selfLoopGap }).get(
+        request.id,
+      )!;
+      // laneX = x + w + round(selfLoopGap) = 0 + 100 + 24 = 124.
+      expect(points).toEqual([
+        { x: 75, y: 50 },
+        { x: 75, y: 62 },
+        { x: 124, y: 62 },
+        { x: 124, y: -12 },
+        { x: 75, y: -12 },
+        { x: 75, y: 0 },
+      ]);
+    }
+  });
+
+  it("does not round bendPenalty: two fractional values inside one rounding bucket still choose different routes", () => {
+    // Two walls, each with a slit on the opposite side of the straight line
+    // from A to B. Threading both slits is short and bendy; dropping below
+    // both walls in one sweep is longer and straighter. Measured on this
+    // fixture: the slit route is 928 px with 6 bends, the under route 944 px
+    // with 4 bends, so the two costs cross at bendPenalty = (944 - 928) / 2 =
+    // 8 exactly. 7.6 and 8.4 sit either side of that crossing and *both round
+    // to 8* — an implementation that quantized bendPenalty along with the
+    // coordinates would return the same route for both, which is precisely
+    // what this asserts against. All coordinates here are integers, so
+    // quantization is the identity and the crossing point cannot move.
+    const nodes: RouteNodeRect[] = [
+      { id: "A", x: 0, y: 0, width: 40, height: 40 },
+      { id: "B", x: 600, y: 0, width: 40, height: 40 },
+      // Wall 1, spanning y -200..200 with a slit at y 100..160.
+      { id: "W1a", x: 200, y: -200, width: 40, height: 300 },
+      { id: "W1b", x: 200, y: 160, width: 40, height: 40 },
+      // Wall 2, spanning y -200..200 with a slit at y -120..-60.
+      { id: "W2a", x: 400, y: -200, width: 40, height: 80 },
+      { id: "W2b", x: 400, y: -60, width: 40, height: 260 },
+    ];
+    const request: RouteRequest = {
+      id: "e-A-B",
+      source: "A",
+      target: "B",
+      sourcePoint: { x: 40, y: 20 },
+      targetPoint: { x: 600, y: 20 },
+      sourceSide: "right",
+      targetSide: "left",
+    };
+
+    const cheapBends = routeEdges(nodes, [request], { bendPenalty: 7.6 }).get(
+      request.id,
+    )!;
+    const dearBends = routeEdges(nodes, [request], { bendPenalty: 8.4 }).get(
+      request.id,
+    )!;
+
+    expect(cheapBends).not.toEqual(dearBends);
+    // …and in the documented direction: a cheaper bend buys a shorter path.
+    expect(polylineLength(cheapBends)).toBeLessThan(polylineLength(dearBends));
+  });
+
+  it("treats a fractional bendPenalty as ordinary input: the output is still integral and orthogonal", () => {
+    const next = fractionStream(9001);
+    const failures: string[] = [];
+
+    for (let i = 0; i < 20; i++) {
+      const { nodes, requests } = fractionalScenario(next, i);
+      const routes = routeEdges(nodes, requests, { bendPenalty: 30.5 });
+      for (const request of requests) {
+        const points = routes.get(request.id)!;
+        if (!allCoordinatesAreIntegers(points)) {
+          failures.push(`case ${i} ${request.id}: non-integer coordinate`);
+        }
+        if (!isOrthogonalPolyline(points)) {
+          failures.push(`case ${i} ${request.id}: not orthogonal`);
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+});
+
+describe("routeEdges — quantization: the self-loop stub offset is rounded (contract 'Self-loops')", () => {
+  // "`stubX = round(x + 0.75w)` … three quarters of a width is fractional
+  // whenever the width is not a multiple of 4". Every self-loop fixture above
+  // this point uses a width that *is* a multiple of 4, where the offset is
+  // already an integer and the rounding is invisible.
+
+  it("rounds the 75%-of-width offset for widths that are not a multiple of 4", () => {
+    // The contract's own worked examples: w = 100 -> x + 75, w = 101 ->
+    // x + 75.75 -> x + 76, w = 102 -> x + 76.5 -> x + 77 (tie, rounds up),
+    // w = 103 -> x + 77.25 -> x + 77.
+    const expectedStubX: Record<number, number> = {
+      100: 75,
+      101: 76,
+      102: 77,
+      103: 77,
+    };
+
+    const failures: string[] = [];
+    for (const width of [100, 101, 102, 103]) {
+      const rect: RouteNodeRect = { id: "A", x: 0, y: 0, width, height: 50 };
+      const request: RouteRequest = {
+        id: "loop-A",
+        source: "A",
+        target: "A",
+        sourcePoint: { x: rect.width / 2, y: 50 },
+        targetPoint: { x: rect.width / 2, y: 0 },
+        sourceSide: "bottom",
+        targetSide: "top",
+      };
+      const points = routeEdges([rect], [request]).get(request.id)!;
+      const stubX = expectedStubX[width];
+
+      if (points[0].x !== stubX || points[points.length - 1].x !== stubX) {
+        failures.push(
+          `w=${width}: expected stubX ${stubX}, got ${points[0].x} / ${points[points.length - 1].x}`,
+        );
+      }
+      if (!allCoordinatesAreIntegers(points)) {
+        failures.push(`w=${width}: non-integer coordinate`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("produces the full six-point table for the tie case w = 102", () => {
+    const rect: RouteNodeRect = { id: "A", x: 0, y: 0, width: 102, height: 50 };
+    const request: RouteRequest = {
+      id: "loop-A",
+      source: "A",
+      target: "A",
+      sourcePoint: { x: 51, y: 50 },
+      targetPoint: { x: 51, y: 0 },
+      sourceSide: "bottom",
+      targetSide: "top",
+    };
+
+    const points = routeEdges([rect], [request]).get(request.id)!;
+
+    // stubX = round(0 + 76.5) = 77; laneX = 0 + 102 + 24 = 126.
+    expect(points).toEqual([
+      { x: 77, y: 50 },
+      { x: 77, y: 62 },
+      { x: 126, y: 62 },
+      { x: 126, y: -12 },
+      { x: 77, y: -12 },
+      { x: 77, y: 0 },
+    ]);
+  });
+
+  it("normalizes the stub offset's -0, which only a negative x can produce", () => {
+    // The contract's own example: x = -1, w = 1 gives round(-1 + 0.75) =
+    // round(-0.25) = -0, the one case where rounding the sum and rounding only
+    // the 0.75w term differ — in the sign of zero. Both must come back as +0.
+    const rect: RouteNodeRect = { id: "A", x: -1, y: 0, width: 1, height: 20 };
+    const request: RouteRequest = {
+      id: "loop-A",
+      source: "A",
+      target: "A",
+      sourcePoint: { x: -0.5, y: 20 },
+      targetPoint: { x: -0.5, y: 0 },
+      sourceSide: "bottom",
+      targetSide: "top",
+    };
+
+    const points = routeEdges([rect], [request]).get(request.id)!;
+
+    expect(points).toEqual([
+      { x: 0, y: 20 },
+      { x: 0, y: 32 },
+      { x: 24, y: 32 },
+      { x: 24, y: -12 },
+      { x: 0, y: -12 },
+      { x: 0, y: 0 },
+    ]);
+    expect(hasNegativeZeroCoordinate(points)).toBe(false);
+    expect(Object.is(points[0].x, 0)).toBe(true);
+  });
+});
+
+describe("routeEdges — quantization: the self-loop duplicate collapse (contract 'Consecutive duplicate vertices are collapsed')", () => {
+  // The collapse "is only ever observable outside" the clearance domain, so
+  // this block is the one place a clearance rounding to 0 is exercised. What
+  // the contract promises there is exactly three things and no more: integer
+  // coordinates, no consecutive duplicate vertices, and — as a consequence —
+  // that every consecutive pair shares exactly one coordinate. The point
+  // count and the point values are documented as unspecified at zero
+  // clearance and are deliberately not asserted. Without the collapse, two
+  // identical consecutive points would share *both* coordinates and break
+  // orthogonality, which is the failure this catches.
+
+  it("never returns two identical consecutive vertices, at any clearance", () => {
+    const rects: RouteNodeRect[] = [
+      { id: "A", x: 0, y: 0, width: 1, height: 20 },
+      { id: "A", x: 0, y: 0, width: 2, height: 20 },
+      { id: "A", x: 0, y: 0, width: 3, height: 20 },
+      { id: "A", x: -3, y: -3, width: 2.4, height: 20.6 },
+      { id: "A", x: 10, y: 10, width: 120, height: 50 },
+    ];
+    // Every clearance in [-0.5, 0.5) rounds to 0; 24 and 12 are in-domain
+    // controls that must behave identically.
+    const optionSets = [
+      { nodeMargin: 0, selfLoopGap: 0 },
+      { nodeMargin: 0.4, selfLoopGap: 0.3 },
+      { nodeMargin: -0.4, selfLoopGap: 0.49 },
+      { nodeMargin: 0.4, selfLoopGap: 24 },
+      { nodeMargin: 12, selfLoopGap: 0.3 },
+    ];
+
+    const failures: string[] = [];
+    for (const rect of rects) {
+      for (const options of optionSets) {
+        const request: RouteRequest = {
+          id: "loop-A",
+          source: "A",
+          target: "A",
+          sourcePoint: { x: rect.x + rect.width / 2, y: rect.y + rect.height },
+          targetPoint: { x: rect.x + rect.width / 2, y: rect.y },
+          sourceSide: "bottom",
+          targetSide: "top",
+        };
+        const points = routeEdges([rect], [request], options).get(request.id)!;
+        const label = `w=${rect.width} ${JSON.stringify(options)}`;
+
+        if (hasConsecutiveDuplicatePoint(points)) {
+          failures.push(`${label}: duplicate in ${JSON.stringify(points)}`);
+        }
+        if (!isOrthogonalPolyline(points)) {
+          failures.push(`${label}: not orthogonal`);
+        }
+        if (!allCoordinatesAreIntegers(points)) {
+          failures.push(`${label}: non-integer coordinate`);
+        }
+        if (hasNegativeZeroCoordinate(points)) {
+          failures.push(`${label}: contains -0`);
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("has nothing to fold inside the clearance domain: the six-point shape survives intact", () => {
+    // "Within the domain there is nothing to fold — with `nodeMargin` and
+    // `selfLoopGap` of 1 or more, no two *consecutive* vertices of the six
+    // coincide". A collapse implemented too eagerly (folding collinear points
+    // rather than identical ones) would shorten this to four.
+    const rect: RouteNodeRect = { id: "A", x: 0, y: 0, width: 2, height: 20 };
+    const request: RouteRequest = {
+      id: "loop-A",
+      source: "A",
+      target: "A",
+      sourcePoint: { x: 1, y: 20 },
+      targetPoint: { x: 1, y: 0 },
+      sourceSide: "bottom",
+      targetSide: "top",
+    };
+
+    const points = routeEdges([rect], [request], {
+      nodeMargin: 1,
+      selfLoopGap: 1,
+    }).get(request.id)!;
+
+    // stubX = round(0 + 1.5) = 2; laneX = 0 + 2 + 1 = 3.
+    expect(points).toEqual([
+      { x: 2, y: 20 },
+      { x: 2, y: 21 },
+      { x: 3, y: 21 },
+      { x: 3, y: -1 },
+      { x: 2, y: -1 },
+      { x: 2, y: 0 },
+    ]);
+  });
+});
+
+describe("routeEdges — quantization: determinism on fractional input (contract 'Determinism')", () => {
+  it("returns byte-identical points for repeated calls and for reordered arrays", () => {
+    const next = fractionStream(555);
+    const { nodes, requests, options } = fractionalScenario(next, 3);
+
+    const first = routeEdges(nodes, requests, options);
+    const second = routeEdges(nodes, requests, options);
+    const reordered = routeEdges(
+      [...nodes].reverse(),
+      [...requests].reverse(),
+      options,
+    );
+
+    for (const request of requests) {
+      expect(second.get(request.id)).toEqual(first.get(request.id));
+      expect(reordered.get(request.id)).toEqual(first.get(request.id));
+    }
+  });
+
+  it("collapses inputs less than half a pixel apart onto the same route", () => {
+    // The sharpest statement of what quantization buys: two measurements that
+    // differ everywhere, but nowhere by enough to change a rounded value, are
+    // the same input as far as the router is concerned. Rect widths stay
+    // integral and only the origins are nudged, so each rect's *boundaries*
+    // land on the same lattice in both variants — the point of the
+    // boundary-quantization rule. Without quantization the two results differ
+    // in every coordinate.
+    const build = (delta: number) => {
+      const nodes: RouteNodeRect[] = [
+        { id: "A", x: 10 + delta, y: 20 + delta, width: 120, height: 50 },
+        { id: "OBS", x: 40 + delta, y: 130 + delta, width: 120, height: 50 },
+        { id: "B", x: -20 + delta, y: 240 + delta, width: 120, height: 50 },
+      ];
+      const request: RouteRequest = {
+        id: "e-A-B",
+        source: "A",
+        target: "B",
+        sourcePoint: { x: 70 + delta, y: 70 + delta },
+        targetPoint: { x: 40 + delta, y: 240 + delta },
+        sourceSide: "bottom",
+        targetSide: "top",
+      };
+      return { nodes, request };
+    };
+
+    const low = build(-0.2);
+    const high = build(0.2);
+
+    const lowPoints = routeEdges(low.nodes, [low.request]).get(low.request.id)!;
+    const highPoints = routeEdges(high.nodes, [high.request]).get(
+      high.request.id,
+    )!;
+
+    expect(highPoints).toEqual(lowPoints);
+  });
+
+  it("keeps inputs that straddle a lattice boundary distinct (10.4 and 10.6 do not merge)", () => {
+    // The contract's own counter-example, and the guard against a quantizer so
+    // coarse that it erases real differences: 10.2 and 10.4 become one point,
+    // 10.4 and 10.6 must not.
+    const nodes: RouteNodeRect[] = [
+      { id: "A", x: 0, y: 0, width: 40, height: 40 },
+      { id: "B", x: 200, y: 0, width: 40, height: 40 },
+    ];
+    const requestAt = (y: number): RouteRequest => ({
+      id: "e-A-B",
+      source: "A",
+      target: "B",
+      sourcePoint: { x: 40, y },
+      targetPoint: { x: 200, y: 20 },
+      sourceSide: "right",
+      targetSide: "left",
+    });
+
+    const at102 = routeEdges(nodes, [requestAt(10.2)]).get("e-A-B")!;
+    const at104 = routeEdges(nodes, [requestAt(10.4)]).get("e-A-B")!;
+    const at106 = routeEdges(nodes, [requestAt(10.6)]).get("e-A-B")!;
+
+    expect(at102[0]).toEqual({ x: 40, y: 10 });
+    expect(at104[0]).toEqual({ x: 40, y: 10 });
+    expect(at106[0]).toEqual({ x: 40, y: 11 });
+    expect(at104).toEqual(at102);
+    expect(at106).not.toEqual(at104);
   });
 });
 

--- a/src/utils/edgeRouter.ts
+++ b/src/utils/edgeRouter.ts
@@ -8,10 +8,12 @@ import type {
 
 /**
  * Self-contained orthogonal edge router (`contracts/edge-routing.md`,
- * `specs/graph-view.md` §4). Node rects are the only obstacles; a sparse
- * Hanan grid over the inflated rects is searched per edge with A*, and the
- * result is a rounded-corner-ready polyline whose first and last points are the
- * live handle positions.
+ * `specs/graph-view.md` §4). Every input coordinate is snapped to an integer
+ * lattice at the entry of `routeEdges`; node rects are the only obstacles; a
+ * sparse Hanan grid over the inflated rects is searched per edge with A*, and
+ * the result is a rounded-corner-ready polyline. A routed edge begins and ends
+ * exactly at its quantized handle positions; a self-loop is synthesized from its
+ * node's rect alone and is exempt from that rule.
  */
 
 /** Clearance kept around every node rect, px. */
@@ -68,6 +70,71 @@ const pushOutward = (
  */
 const clonePoint = (point: Point): Point => ({ x: point.x, y: point.y });
 
+/**
+ * Snaps one coordinate to the integer lattice (`contracts/edge-routing.md`,
+ * "Input quantization"). The router's inputs are DOM measurements, which carry
+ * fractional parts as a matter of course, and a fraction anywhere in the input
+ * puts fractions in the output: routes whose last decimals differ between two
+ * visually identical states, segments a fraction of a pixel long, corners whose
+ * bend radius has collapsed to zero. Quantizing once at the boundary removes
+ * that class of output by construction — integers are closed under the sums,
+ * differences, min/max and ±1-scaled steps every route below is built from — so
+ * nothing has to be rounded on the way out and no geometric comparison here
+ * needs a tolerance.
+ *
+ * `Math.round`, so ties go toward positive infinity, with `-0` normalized to `0`
+ * so that no returned coordinate is ever negative zero.
+ */
+const quantize = (value: number): number => {
+  const rounded = Math.round(value);
+  return rounded === 0 ? 0 : rounded; // `-0 === 0`, so this catches `-0`
+};
+
+/**
+ * Quantizes a rect **by its boundaries, never field by field**: the left edge
+ * lands on `round(x)` and the right edge on `round(x + width)`, each within half
+ * a pixel of what was measured. Rounding `x` and `width` independently is a
+ * different and wrong operation — the two errors add, so the right edge can move
+ * by a whole pixel and the obstacle would no longer cover the node it stands
+ * for.
+ *
+ * A rect thinner than a pixel can collapse to zero extent. That is left to
+ * happen rather than guarded: a collapsed rect still blocks, because obstacles
+ * are these rects inflated by `nodeMargin`, and a band of that width around a
+ * rect of no extent still has an interior. Coincident boundaries are likewise
+ * left alone — `sortedUnique` already folds them when the grid is built.
+ */
+const quantizeRect = (rect: RouteNodeRect): RouteNodeRect => {
+  const x = quantize(rect.x);
+  const y = quantize(rect.y);
+  return {
+    id: rect.id,
+    x,
+    y,
+    width: quantize(rect.x + rect.width) - x,
+    height: quantize(rect.y + rect.height) - y,
+  };
+};
+
+/**
+ * Quantizes the two handle positions of a request per component. A handle
+ * position is a point, not an interval, so there is no companion field whose
+ * consistency has to be preserved and `x` and `y` round independently.
+ * Everything else — the ids and the two sides — is not a coordinate and passes
+ * through untouched.
+ */
+const quantizeRequest = (request: RouteRequest): RouteRequest => ({
+  ...request,
+  sourcePoint: {
+    x: quantize(request.sourcePoint.x),
+    y: quantize(request.sourcePoint.y),
+  },
+  targetPoint: {
+    x: quantize(request.targetPoint.x),
+    y: quantize(request.targetPoint.y),
+  },
+});
+
 const dropDuplicates = (points: Point[]): Point[] =>
   points.filter(
     (point, i) =>
@@ -77,8 +144,9 @@ const dropDuplicates = (points: Point[]): Point[] =>
 /**
  * Collapses runs of collinear points into their end points. The first and last
  * points are always kept: for a routed edge they are the `nodeMargin`-pushed
- * bends, which §3.1 ("Endpoints are exact") requires to survive as `points[1]`
- * and the second-to-last point even when the route runs straight through them.
+ * bends, which `contracts/edge-routing.md` ("Endpoints are exact on the
+ * quantized points") requires to survive as `points[1]` and the second-to-last
+ * point even when the route runs straight through them.
  */
 const dropCollinearInterior = (points: Point[]): Point[] => {
   if (points.length <= 2) return points;
@@ -583,27 +651,38 @@ const fallbackPoints = (
 };
 
 /**
- * Self-loops are synthesized, not routed (§3.1 "Self-loops"): always on the
- * node's right side, out of the bottom edge at 75 % of the width, around a lane
- * `selfLoopGap` clear of the node, and back into the top edge at the same offset.
+ * Self-loops are synthesized, not routed (`contracts/edge-routing.md`,
+ * "Self-loops"): always on the node's right side, out of the bottom edge at 75 %
+ * of the width, around a lane `selfLoopGap` clear of the node, and back into the
+ * top edge at the same offset. The rect and both clearances are already
+ * quantized, so the only fractional value the six points can contain is the
+ * 75 %-of-width stub offset — three quarters of an integer width is fractional
+ * unless that width is a multiple of 4 — and it is rounded here, where it is
+ * formed. This is the one rounding that happens behind the input boundary.
+ *
+ * Consecutive duplicates are collapsed, the same way searched and fallback
+ * routes are: a clearance that quantizes to `0` makes two of the six points
+ * coincide, and a coincident pair shares both coordinates instead of exactly
+ * one, which would break orthogonality. A self-loop therefore returns at most
+ * six points.
  */
 const selfLoopPoints = (
   rect: RouteNodeRect,
   nodeMargin: number,
   selfLoopGap: number,
 ): Point[] => {
-  const x = rect.x + rect.width * 0.75;
+  const x = quantize(rect.x + rect.width * 0.75);
   const lane = rect.x + rect.width + selfLoopGap;
   const below = rect.y + rect.height + nodeMargin;
   const above = rect.y - nodeMargin;
-  return [
+  return dropDuplicates([
     { x, y: rect.y + rect.height },
     { x, y: below },
     { x: lane, y: below },
     { x: lane, y: above },
     { x, y: above },
     { x, y: rect.y },
-  ];
+  ]);
 };
 
 /**
@@ -613,6 +692,12 @@ const selfLoopPoints = (
  *
  * Keyed by `RouteRequest.id`; a request naming a node absent from `nodes` gets
  * no entry at all (§3.1 "Missing nodes").
+ *
+ * Every coordinate in the input is quantized here, before the obstacle set is
+ * built and before any search runs, so every returned coordinate is an integer
+ * (`contracts/edge-routing.md`, "Integer coordinates"). A routed polyline's
+ * endpoints are exact on the quantized request points, not on the fractional
+ * ones a caller passed.
  *
  * Every returned polyline — searched, self-loop and fallback alike — is
  * orthogonal, has at least 2 points, and contains **no immediate reversal**: at
@@ -627,15 +712,25 @@ export const routeEdges = (
   requests: RouteRequest[],
   options: EdgeRouterOptions = {},
 ): Map<string, Point[]> => {
-  const nodeMargin = options.nodeMargin ?? DEFAULT_NODE_MARGIN;
+  // The quantization boundary: nothing below this point sees a coordinate the
+  // caller passed, only its lattice-snapped image. `nodeMargin` and
+  // `selfLoopGap` are distances that end up added to coordinates, so they are
+  // quantized with everything else — that is what makes the integer guarantee
+  // unconditional rather than a promise kept only for callers that happen to
+  // pass integers. `bendPenalty` is a term in the cost function, compared
+  // against path lengths and never added to a position, so it is left alone and
+  // a fractional one stays meaningful (which is why `COST_EPSILON` is still
+  // needed above).
+  const nodeMargin = quantize(options.nodeMargin ?? DEFAULT_NODE_MARGIN);
   const bendPenalty = options.bendPenalty ?? DEFAULT_BEND_PENALTY;
-  const selfLoopGap = options.selfLoopGap ?? DEFAULT_SELF_LOOP_GAP;
+  const selfLoopGap = quantize(options.selfLoopGap ?? DEFAULT_SELF_LOOP_GAP);
+  const quantizedRequests = requests.map(quantizeRequest);
 
   // Duplicate ids are invalid input; the documented rule is that the last one
   // wins. Deduping before the obstacle index is built matters: otherwise a
   // superseded earlier rect keeps blocking segments even though nothing is
   // routed against it.
-  const rectById = new Map(nodes.map((node) => [node.id, node]));
+  const rectById = new Map(nodes.map((node) => [node.id, quantizeRect(node)]));
   const inflated: InflatedRect[] = [...rectById.values()].map((node) => ({
     id: node.id,
     minX: node.x - nodeMargin,
@@ -652,7 +747,7 @@ export const routeEdges = (
   };
 
   const routes = new Map<string, Point[]>();
-  for (const request of requests) {
+  for (const request of quantizedRequests) {
     const sourceRect = rectById.get(request.source);
     const targetRect = rectById.get(request.target);
     if (sourceRect === undefined || targetRect === undefined) {


### PR DESCRIPTION
Closes #89.

`routeEdges` now snaps every input coordinate to an integer lattice at its entry, before the obstacle set is built and before any search runs, so a sub-pixel jog cannot exist in its output by construction.

## What changed

- Rects are quantized **by their boundaries** (`x' = round(x)`, `width' = round(x + width) - round(x)`), never field by field — rounding `x` and `width` independently lets the two errors add and can move the right edge by a whole pixel, so the obstacle would no longer cover the node it stands for.
- Request points are quantized per component, and `nodeMargin` and `selfLoopGap` alongside them. Quantizing the clearances is what makes the integer guarantee hold for **any** caller rather than only for one that happens to pass integers. `bendPenalty` is a term in the cost function, never added to a position, and stays fractional.
- The self-loop's 75 %-of-width stub is rounded where it is formed — the one rounding behind the input boundary — and self-loop output now passes through the same consecutive-duplicate collapse every other returned route already got, so a clearance that quantizes to zero cannot produce a pair of points sharing both coordinates.
- The contract restates "Endpoints are exact" as exactness on the **quantized** points, and bounds three guarantees (orthogonality, `>= 2 points`, no immediate reversals) to clearances that round to at least 1 — a clearance of zero asks a self-loop for a shape with no room to exist, and there orthogonality and `>= 2 points` are jointly unsatisfiable. Integer coordinates, determinism, the tie-break order, missing-node omission and duplicate-id handling stay unconditional, since fractional options are exactly the input this change exists to serve.

Two commits, split so each is reviewable on its own: the contract first (this repo is documentation-first), then the implementation and its tests.

## Evidence

Measured in the running app (default LLVM-IR CFG, `npm run dev`, 2026-08-10), counting the polyline vertices the router returned rather than the rendered path's arc control points — the latter are fractional whenever a corner radius is, which is a property of the renderer and not of the router:

| | before | after |
| --- | --- | --- |
| non-integer vertices | 4 of 58 | **0 of 58** |
| runs shorter than 1 px | — | **0** |
| block 12's self-loop stub | 206.5 | **207** |

Replaying the node rects and handle positions captured from that app through `routeEdges` goes from 62 non-integer coordinates and 9 sub-pixel segments to none of either.

The six turning corners at 0.5 px radius are unchanged, as they must be: they belong to the 1 px handle inset tracked in #93. Their disappearance would have meant this change overreached.

## On the tests

The tests were written from the contract by an agent that did not read the implementation, in parallel with it. They were then validated by mutation rather than by being green: 18 of 20 mutations applied to the router are caught, including rounding `x` and `width` independently, dropping the `-0` normalization, quantizing `bendPenalty`, skipping the self-loop stub rounding, removing the duplicate collapse, quantizing rects but not points, and moving quantization after the obstacle index is built.

Two mutations survive — disabling `dropCollinearInterior` and zeroing `COST_EPSILON`. Both are pre-existing gaps in the suite, equally present on `main`, and are filed as #98 and #99.

## Follow-ups opened while doing this

- #93 — handles sit 1 px inside the node rect, which is what the remaining 0.5 px corners come from
- #94 — the nominal bend radius exceeds half the mandatory endpoint stub, so those bends can never draw at it
- #96 — give the self-loop a defined shape at zero clearance, which would let the domain bound above be deleted
- #95, #97, #98, #99 — a lint-ignore gap, stale section references, and the two test-coverage gaps above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
