### PR TITLE
fix(lint): add storybook-static to the ESLint ignore list

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist", "coverage"]),
+  globalIgnores(["dist", "coverage", "storybook-static"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [


### PR DESCRIPTION
Closes #95

## What changed

`eslint.config.js` ignored only `dist` and `coverage`. `storybook-static` is now ignored alongside them:

```js
globalIgnores(["dist", "coverage", "storybook-static"]),
```

## Why

`storybook-static` is git-ignored build output, but ESLint still walked into it. On any machine where `npm run build-storybook` has run, `npm run lint` failed with 31 problems in bundled vendor code nobody wrote — all inside `storybook-static/sb-manager/*.js`, of the shape ESLint reports when a bundle carries inline directives for rules this config does not define (`Definition for rule '@typescript-eslint/no-unused-vars' was not found`, `Unused eslint-disable directive`).

Since `npm run lint` runs with `--max-warnings=0`, this failed the gate rather than emitting an ignorable warning. CI checks out clean and never builds Storybook before linting, so the failure was invisible there and blocked only contributors who had used Storybook locally — precisely the people following the post-change checks `AGENTS.md` prescribes.

## Verification

`node_modules` was empty in this worktree, so I ran `npm ci`, then `npm run build-storybook` to put a real Storybook build in the tree. That reproduced the issue exactly:

- **Before:** `✖ 31 problems (13 errors, 18 warnings)`, every one under `storybook-static/`
- **After:** `npm run lint` exits 0

With `storybook-static/` still present, all three post-change commands from `AGENTS.md` run clean as written, which is the second acceptance criterion:

| Command | Result |
| --- | --- |
| `npm run test:run` | 49 files, 568 tests passed |
| `npm run format` | no changes — Prettier 3 already reads `.gitignore`, so it never descended into the build |
| `npm run lint` | exit 0 |

## Reviewer notes

Issue #95 also asked whether the ignore list should be **derived** from `.gitignore` rather than restated, since the two have drifted once already. We decided against it for now: deriving would mean adding `@eslint/compat` for `includeIgnoreFile`, and the literal addition fully satisfies both acceptance criteria without a new dependency.

Worth knowing that the drift is latent rather than resolved — `.gitignore` also lists `dist-ssr`, `test-results`, `playwright-report`, and `blob-report`, none of which ESLint ignores. None break lint today because no `.js` files land in them in practice, but a future build output that does emit JS would reproduce this same failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)