### PR TITLE
docs: specify edge-overlap semantics as same-value bundles

### DIFF
--- a/docs/internal/contracts/edge-routing.md
+++ b/docs/internal/contracts/edge-routing.md
@@ -13,6 +13,11 @@ documentation for how the guarantees below are achieved.
 The router implementation and its test suite are written against this boundary. It is
 frozen — names and signature are reproduced here verbatim and must not be "improved".
 
+One exception to "verbatim", and it is deliberate: `RouteRequest.bundleId` is not in
+`src/types/edgeRouting.ts` yet. It is fixed here ahead of its use so the boundary is
+decided once rather than reopened twice, and it lands in code with #86. Everything else in
+the block is what the source declares today.
+
 ```ts
 // src/types/edgeRouting.ts
 export interface Point {
@@ -37,6 +42,7 @@ export interface RouteRequest {
   targetPoint: Point;
   sourceSide: RouteSide;
   targetSide: RouteSide;
+  bundleId?: string; // requests sharing one carry the same value — see Bundles
 }
 
 export interface EdgeRouterOptions {
@@ -55,7 +61,10 @@ export const routeEdges: (
 
 `routeEdges` is a **pure function**: nothing here depends on React Flow or ELK, and no
 side effect crosses the boundary in either direction. `nodes` are the only obstacles;
-there is no notion of edges, labels, or anything else blocking a route.
+there is no notion of edges, labels, or anything else blocking a route. Routes are not
+independent of one another for all that — separation (see Bundles) is a relation between
+the returned polylines — but that is a property of the pass, which sees every request at
+once, not an obstacle in the search.
 
 ### Defaults
 
@@ -221,6 +230,46 @@ or fractional values of it are ordinary input.
   repeated id in `nodes`, or in `requests`, does not throw. The documented behavior is
   "the last one wins": the last rect with a given id is the one routed against, and the
   last request with a given id is the one left in the returned map.
+
+Every guarantee above is a property of one polyline in isolation. How two of them may
+relate is the separate question below, and it is not yet answered by the implementation.
+
+## Bundles and separation
+
+Nothing above says whether two returned polylines may run along the same pixels. Today they
+may and do: every route is searched on the same grid, so unrelated edges coincide by
+accident. `specs/graph-view.md` §4 fixes what such an overlap is allowed to mean — shared
+geometry means one value carried by several edges — and this section is that rule in the
+router's own terms. `bundleId` is how the caller states it; the router never asks what an
+IR is.
+
+- **Bundle.** The set of requests carrying one `bundleId`. A request whose `bundleId` is
+  `undefined` is a bundle of one — `undefined` is not a wildcard, so a caller that supplies
+  no bundle ids is asking for pairwise separation of everything. Self-loops take part like
+  any other request.
+- **Sharing.** Two polylines _share geometry_ when their point sets intersect in a subset
+  of positive length — a common sub-segment. Crossing at a point does not count, and
+  neither does meeting at a single common endpoint; those are exactly the shapes the spec's
+  junction mark is there to tell apart.
+- **The guarantee.** For any two requests with distinct ids, the returned polylines share
+  geometry **only if** both carry the same defined `bundleId`.
+
+The converse is deliberately not promised. Drawing a bundle as one distribution tree (#88)
+is a rendering intent, and stating the biconditional would outlaw a legal shape: a bundle
+whose branches leave the source in opposite directions has a zero-length trunk and shares
+nothing but its departure point, yet is correctly rendered. "Overlap iff same value" is the
+reading given to the picture; "share only if same bundle" is what the router can be held
+to.
+
+**Status: not held.** The router ignores `bundleId`; the guarantee and the unit tests that
+pin it land with #86. Search behavior is not the only thing in the way — two facts about
+the handles produce shared geometry whatever the search does, and neither is fixable here:
+every in-edge of a node ends at one top-center handle (#87) and CFG successors leave
+through one bottom-center handle (#67), so those routes share a tail or a stub before the
+router has any say. (#88, the distribution tree, is the other half of the picture — the
+sharing this contract permits but does not yet produce.) Until #86, an edge overlap in the
+output is not a contract violation but unspecified behavior, so `docs/README.md`'s "code
+that violates a contract is a bug" does not apply to it.
 
 ## Self-loops (right side, six points)
 

--- a/docs/internal/contracts/ir-mode-registry.md
+++ b/docs/internal/contracts/ir-mode-registry.md
@@ -19,6 +19,7 @@ interface IRModeDefinition {
   nodeTypes: Record<string, ComponentType<NodeProps>>; // this mode's React Flow node renderers
   edgeBuilder: IREdgeBuilder; // see below
   layoutOptions?: Record<string, string>; // ELK layout options, e.g. layer spacing
+  bundleOf?: (edge: GraphEdge) => string | undefined; // see "Bundles" below
   views?: IRViewDefinition[]; // optional alternative projections — see "Views" below
 }
 ```
@@ -37,13 +38,14 @@ interface IRViewDefinition {
   parse: (code: string) => GraphData; // same throw-on-invalid rule as the mode's parse
   edgeBuilder?: IREdgeBuilder; // defaults to the mode's edgeBuilder
   layoutOptions?: Record<string, string>; // defaults to the mode's layoutOptions
+  bundleOf?: (edge: GraphEdge) => string | undefined; // defaults to the mode's bundleOf
 }
 ```
 
 Rules:
 
 - `views` is optional. A mode without it has a single implicit view built from
-  its top-level `parse`/`edgeBuilder`/`layoutOptions`.
+  its top-level `parse`/`edgeBuilder`/`layoutOptions`/`bundleOf`.
 - When present, `views` has ≥ 2 entries and `views[0]` is the **default view**;
   it must behave identically to the mode's top-level fields (share the same
   function references — don't duplicate logic).
@@ -62,12 +64,15 @@ The layout-relevant half of a mode is named separately so a view-resolved value
 can be passed wherever layout behavior is needed:
 
 ```ts
-type IRLayoutBehavior = Pick<IRModeDefinition, "edgeBuilder" | "layoutOptions">;
+type IRLayoutBehavior = Pick<
+  IRModeDefinition,
+  "edgeBuilder" | "layoutOptions" | "bundleOf"
+>;
 ```
 
 `useGraphData.updateGraph(graph, behavior)` takes `IRLayoutBehavior` rather than
 the full `IRModeDefinition`; a mode object satisfies it structurally, and the
-workspace passes the active view's resolved `edgeBuilder`/`layoutOptions`.
+workspace passes the active view's resolved `edgeBuilder`/`layoutOptions`/`bundleOf`.
 
 `IREdgeBuilder` (`src/utils/layout.ts`) captures how a mode turns a `GraphEdge`
 into a React Flow edge:
@@ -90,13 +95,46 @@ All three current modes live in `src/irModes/`: `llvmMode.ts`, `mermaidMode.ts`,
 `selectionDAGMode.ts`, aggregated by `src/irModes/index.ts` into `IR_MODES` (keyed map) and
 `IR_MODE_LIST` (array, for iterating in the editor panel).
 
+## Bundles
+
+Whether two edges may be drawn on top of one another is decided by whether they carry the
+same value (`specs/graph-view.md` §4). "The same value" is an IR-level question that the
+router cannot answer and must not try to — so it belongs here, answered once per mode.
+
+`bundleOf` maps an edge to the id of the bundle it belongs to, or `undefined` for none.
+Two edges may share geometry exactly when it returns the same defined id for both.
+`undefined` is a bundle of one rather than a wildcard: an edge outside every bundle must
+stay separate from everything.
+
+| mode / view       | `bundleOf`              | why                                                                                           |
+| ----------------- | ----------------------- | --------------------------------------------------------------------------------------------- |
+| LLVM-IR · Use-Def | `(edge) => edge.source` | the out-edges of one instruction node are the uses of that node's single def — one SSA value  |
+| LLVM-IR · CFG     | omitted                 | conditional successors are mutually exclusive alternatives with distinct labels, not one flow |
+| Mermaid           | omitted                 | an edge is a user-authored relation; the language has no notion of a value being carried      |
+| SelectionDAG      | omitted                 | not routed at all — bezier edges on operand handles                                           |
+
+Use-Def keys on the source **node** because an instruction node has exactly one def. An IR
+whose nodes expose several def ports would key on the port instead
+(`` `${edge.source}:${edge.sourceHandle}` ``); that is a change to one mode's `bundleOf`,
+not to this contract.
+
+`bundleOf` is view-resolved like `edgeBuilder`/`layoutOptions` and travels with them in
+`IRLayoutBehavior` — LLVM-IR is the case that needs this, since its two views disagree.
+`getLayoutedElements` applies it once when it builds the React Flow edges, stamping the
+result on `data.bundleId`; `useEdgeRoutes` copies that onto `RouteRequest.bundleId`
+(`contracts/edge-routing.md`). The registry is therefore consulted at build time only —
+nothing on the render path asks a mode a question.
+
+**Status: declared here, not yet in `src/irModes/types.ts`.** The field and the Use-Def
+implementation land with #88; the router-side guarantee it feeds lands with #86.
+
 ## What consumes the registry
 
 - `App.tsx` / `useIRWorkspace` — looks up the active mode by key, calls `mode.parse(code)`,
   uses `mode.defaultCode` on mode switch and `mode.editorLanguage` for the editor.
 - `useGraphData` — takes an `IRLayoutBehavior` into `updateGraph(graph, behavior)` /
-  `resetLayout()`, so layout and edge-building are mode- (or view-) driven rather than
-  branching by string.
+  `resetLayout()`, so layout, edge-building and bundling are mode- (or view-) driven rather
+  than branching by string.
 - `GraphViewer` — merges `nodeTypes` from every entry in `IR_MODE_LIST` (plus the
   mode-agnostic fallback `codeNode`) instead of importing each mode's node components directly.
 
@@ -106,7 +144,9 @@ All three current modes live in `src/irModes/`: `llvmMode.ts`, `mermaidMode.ts`,
    `src/graphBuilder`.
 2. Add the mode's node component(s) under `src/components/Graph/<NewMode>/`.
 3. Write `src/irModes/newMode.ts` implementing `IRModeDefinition`. Reuse `codeGraphEdgeBuilder`
-   unless the new IR needs custom edge semantics like SelectionDAG.
+   unless the new IR needs custom edge semantics like SelectionDAG. Declare `bundleOf` only
+   if the IR has same-value fan-out (see Bundles); omitting it means no two of its edges may
+   overlap, which is the right answer for a control-flow graph.
 4. Add the new entry to `IR_MODES`/`IR_MODE_LIST` in `src/irModes/index.ts`.
 
 No other file should need to change. If it does, that's a signal the registry contract has a gap.

--- a/docs/internal/specs/graph-view.md
+++ b/docs/internal/specs/graph-view.md
@@ -84,6 +84,40 @@ no immediate reversals, missing-node omission), and its option defaults are froz
 `contracts/edge-routing.md`; the algorithm behind those guarantees is documented in
 `src/utils/edgeRouter.ts` itself.
 
+**Overlap is a meaning, not an accident.** Two edges drawn along the same pixels read as
+one flow, so the router may only produce that shape where it is true. Three rules fix what
+shared geometry means:
+
+1. **Two edges share geometry iff they carry the same value.** A _bundle_ is the fan-out
+   of one entity — in the Use-Def view, the out-edges of a single def. Within a bundle,
+   edges share a trunk and split at explicit junction points; between bundles nothing may
+   be shared. Bundle membership is IR-specific and is declared by the mode registry's
+   `bundleOf` (`contracts/ir-mode-registry.md`). An edge in no bundle is a bundle of one,
+   so "this mode has no bundles" means "nothing here may overlap".
+2. **Junctions are marked.** A split inside a bundle carries a visible junction mark — the
+   circuit-schematic idiom: a dot means connected, an unmarked crossing means two unrelated
+   edges pass over each other.
+3. **Convergence is never drawn.** Fan-in edges stay geometrically independent all the way
+   to the target, each keeping its own arrival point and its own arrowhead. This is
+   semantically load-bearing at a phi node, where every incoming edge carries a _different_
+   value: one shared tail into the node would assert the opposite.
+
+CFG conditional successors (`br i1`, `switch`) are mutually exclusive alternatives rather
+than one flow that splits, and they carry distinct labels besides, so they are never
+bundled. That the CFG view therefore holds no bundles at all is a consequence of these
+semantics, not a gap in them.
+
+The bundle id reaches the router through the existing pipeline rather than a second
+channel: `getLayoutedElements` stamps `bundleOf(edge)` onto the React Flow edge's
+`data.bundleId`, and `useEdgeRoutes` copies it into `RouteRequest.bundleId`
+(`contracts/edge-routing.md`). The router is never told what an IR is.
+
+**These rules are not yet held.** They are the target the router is being moved toward, and
+four things stand in the way: every in-edge of a node lands on one top-center handle (#87),
+CFG successors leave through one bottom-center handle (#67), unrelated routes coincide by
+accident on the shared search grid (#86), and same-value fan-out is not drawn as a trunk at
+all (#88). Until those land, an overlap in the rendered graph means nothing.
+
 - **Inputs** are React Flow's measured rects (`internals.positionAbsolute`,
   `measured.width` / `measured.height`) and the live handle positions. Because those track
   the current DOM, an edge follows its node while the node is dragged, and follows a size
@@ -139,7 +173,8 @@ no immediate reversals, missing-node omission), and its option defaults are froz
 > one-pass `useEdgeRoutes` hook and its context, the unmeasured-node omission, the rounded
 > corners, the midpoint label placement, the accent color, and the drag-time
 > throttling/incident-edges pass. The frame-budget figures are measured out of band, not by
-> the test suite.
+> the test suite. The overlap semantics are _specified, unimplemented_ — a different marker
+> from the two above: there is nothing to observe and nothing to pin until #86–#88 land.
 
 ## 5. Node dimension estimation
 


### PR DESCRIPTION
Closes #85.

## What and why

Two edges drawn along the same pixels currently mean nothing: every route is searched on the same Hanan grid, so unrelated edges coincide by accident while strongly suggesting a merge. A reader cannot tell an accidental overlap from an intentional one. This lands the semantics that make overlap a meaningful bit — shared geometry iff the edges carry the same value — and fixes the boundary that carries it, ahead of the implementation in #86/#87/#88.

Documentation only, per #85's scope, plus the two boundary fields the semantics need (see "Beyond the issue's scope" below).

## Changes

- **`docs/internal/specs/graph-view.md` §4** — the three rules (same-value bundles; junctions marked; convergence never drawn), why CFG conditional successors are never bundled, and the path the bundle id travels: `bundleOf(edge)` → `data.bundleId` → `RouteRequest.bundleId`. A closing paragraph names the four things that currently violate the rules (#87, #67, #86, #88).
- **`docs/internal/contracts/edge-routing.md`** — `RouteRequest.bundleId?: string` in the frozen boundary, and a new "Bundles and separation" section defining *bundle*, *sharing*, and the guarantee.
- **`docs/internal/contracts/ir-mode-registry.md`** — `bundleOf` on `IRModeDefinition` / `IRViewDefinition`, `IRLayoutBehavior` widened to carry it, a per-mode table with the reasoning, and a note in the "adding a mode" checklist.

## Two judgment calls a reviewer should check

**The contract states `only if`, not `iff`.** #85 asks for "share a segment iff same bundle", but the strict biconditional has a counterexample: a bundle whose branches leave the def in opposite directions has a zero-length trunk and shares nothing but its departure point, which is a correct rendering. So the contract promises only the testable half — different bundles never share — and records the converse as #88's rendering intent. "Overlap iff same value" stays as the reading given to the picture in the spec; "share only if same bundle" is what the router can be held to.

**Bundle membership is a dedicated `bundleOf`, not something `edgeBuilder` stamps.** Routing it through `edgeBuilder` would mean wrapping the whole edge-construction for Use-Def just to add one field (with `data` merging to get wrong) and would leave the concept unnamed. `bundleOf` is one line per mode — Use-Def `(edge) => edge.source`, everyone else omits it — and needs no new field on `GraphEdge`, so `contracts/graph-data.md` is untouched and the change stays within #85's three files.

## Beyond the issue's scope

#85 says documentation only. Both new fields (`RouteRequest.bundleId`, `bundleOf`) are declared by the contracts but are **not** in `src/` — each contract says so explicitly and names the issue it lands with (#86 and #88). This keeps `docs/README.md`'s docs-first rule intact without leaving dead declarations in the source. Both files also state that until then an edge overlap is unspecified behavior rather than a contract violation, so "code that violates a contract is a bug" is not misapplied to the current router.

## Verification

`npm run test:run` (568 passed), `npm run format`, `npm run lint` — all clean. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)