### PR TITLE
docs(edge-routing): replace the stale section references in edgeRouter.ts

### DIFF
--- a/src/hooks/useEdgeRoutes.ts
+++ b/src/hooks/useEdgeRoutes.ts
@@ -109,9 +109,10 @@ const handleAnchor = (
 
 /**
  * Rects for the router. A node React Flow has not measured yet is **omitted**
- * (D6): its edges then get no entry from `routeEdges` and are not drawn this
- * frame. No placeholder shape — one would reintroduce the second geometry
- * generator this design exists to remove.
+ * (`specs/graph-view.md` §4, "Unmeasured endpoints"): its edges then get no
+ * entry from `routeEdges` and are not drawn this frame. No placeholder shape —
+ * one would reintroduce the second geometry generator this design exists to
+ * remove.
  */
 const collectRects = (
   nodeLookup: ReadonlyMap<string, InternalNode>,
@@ -134,7 +135,7 @@ const collectRects = (
 /**
  * One request per `routed` edge. SelectionDAG's edges use React Flow's
  * built-in `default` type and are deliberately left alone — they keep their
- * handle-anchored beziers (plan §2 decision 8).
+ * handle-anchored beziers (`specs/graph-view.md` §4).
  */
 const collectRequests = (
   edges: readonly Edge[],
@@ -194,7 +195,7 @@ const inputSignature = (
  *
  * Throttled to animation frames. **During a drag only the edges incident to a
  * moved node are re-routed** and the results are merged over the previous map;
- * a full pass runs on drag stop (R8 / plan §2 decision 5). That split is
+ * a full pass runs on drag stop (`specs/graph-view.md` §4). That split is
  * required rather than opportunistic: a full pass overruns the 16.7 ms frame
  * budget from roughly 180 nodes, which the Use-Def view can reach. The router
  * is a pure function of the rects it is given, so an incident-only pass is

--- a/src/utils/__tests__/edgeRouter.test.ts
+++ b/src/utils/__tests__/edgeRouter.test.ts
@@ -8,9 +8,10 @@ import type {
 } from "../../types/edgeRouting";
 
 // ---------------------------------------------------------------------------
-// Local geometry helpers. The router's frozen boundary (plan §3.2) only
-// returns points, so intersection/orthogonality checks live here rather than
-// depending on any router internals.
+// Local geometry helpers. The router's frozen boundary
+// (`contracts/edge-routing.md`, "The frozen boundary") only returns points, so
+// intersection/orthogonality checks live here rather than depending on any
+// router internals.
 // ---------------------------------------------------------------------------
 
 /** True when every consecutive pair of points forms an axis-aligned segment. */
@@ -32,9 +33,10 @@ interface Rect {
 
 /**
  * True when the axis-aligned segment a→b passes through the *interior* of
- * `rect` (touching an edge/corner does not count as crossing the interior —
- * plan §3.1 step 3: "a grid segment is traversable when it does not cross
- * the interior of any inflated rect").
+ * `rect` (touching an edge/corner does not count as crossing the interior,
+ * matching the router's own traversability rule: a grid segment is traversable
+ * when it does not cross the interior of any inflated rect — see
+ * `src/utils/edgeRouter.ts`).
  */
 function segmentCrossesRectInterior(a: Point, b: Point, rect: Rect): boolean {
   const left = rect.x;
@@ -75,10 +77,11 @@ function anySegmentCrossesRectInterior(points: Point[], rect: Rect): boolean {
 /**
  * Same as `anySegmentCrossesRectInterior`, but excludes the first segment
  * (`points[0]` -> `points[1]`) and the last segment (the final pair) — the
- * two mandated D2 stubs (`sourcePoint -> S` and `T -> targetPoint`), which
- * "Endpoints are exact" can force through a node's own rect when a pushed
- * point lands inside it. For a polyline with fewer than 4 points there is
- * no segment other than the first/last, so this is trivially false.
+ * two mandated stubs (`sourcePoint -> S` and `T -> targetPoint`), which
+ * "Endpoints are exact on the quantized points" can force through a node's own
+ * rect when a pushed point lands inside it. For a polyline with fewer than 4
+ * points there is no segment other than the first/last, so this is trivially
+ * false.
  */
 function anyMiddleSegmentCrossesRectInterior(
   points: Point[],
@@ -121,9 +124,9 @@ function outwardNormal(side: RouteSide): Point {
 }
 
 /**
- * True when `points` is shaped like the D4 fallback rather than a searched
- * route, without mirroring the whole R15 connector ladder. Only the
- * fallback skeleton (plan §3.1 "No-path fallback") mandates a *second*
+ * True when `points` is shaped like the no-path fallback rather than a searched
+ * route, without mirroring the whole connector ladder. Only the fallback
+ * skeleton (`fallbackPoints` in `src/utils/edgeRouter.ts`) mandates a *second*
  * outward step past `S`, to `P1 = S + n_s·selfLoopGap` — a searched route's
  * third point is whatever the grid search finds next and has no reason to
  * land exactly there. So `points[2] === P1` identifies a fallback: it is
@@ -152,8 +155,8 @@ function isFallbackShape(
 /**
  * True when `points` contains an "immediate reversal": an interior vertex
  * where the segment arriving and the segment leaving run along the same
- * axis but in opposite directions (arbitration-B3 R12 — the checkable form
- * of "never a degenerate hook").
+ * axis but in opposite directions (`contracts/edge-routing.md`, "No immediate
+ * reversals" — the checkable form of "never a degenerate hook").
  */
 function hasImmediateReversal(points: Point[]): boolean {
   for (let i = 1; i < points.length - 1; i++) {
@@ -291,7 +294,7 @@ describe("routeEdges — orthogonality and point count", () => {
   });
 });
 
-describe("routeEdges — exact endpoints (plan §3.1 'Endpoints are exact', D2)", () => {
+describe("routeEdges — exact endpoints (contract: 'Endpoints are exact on the quantized points')", () => {
   it("starts exactly at sourcePoint and ends exactly at targetPoint", () => {
     const { nodes, request } = simpleTwoNodeCase();
     const routes = routeEdges(nodes, [request]);
@@ -324,7 +327,7 @@ describe("routeEdges — exact endpoints (plan §3.1 'Endpoints are exact', D2)"
   });
 });
 
-describe("routeEdges — obstacle avoidance (plan §3.1 step 3)", () => {
+describe("routeEdges — obstacle avoidance (nodes are the only obstacles)", () => {
   it("never draws a segment through the interior of a node squarely between source and target", () => {
     const obstacle: RouteNodeRect = {
       id: "OBS",
@@ -357,7 +360,7 @@ describe("routeEdges — obstacle avoidance (plan §3.1 step 3)", () => {
   });
 });
 
-describe("routeEdges — determinism (plan §3.1 'Determinism is a hard requirement')", () => {
+describe("routeEdges — determinism (contract: 'Determinism')", () => {
   it("returns identical points for identical input on repeated calls", () => {
     const nodes: RouteNodeRect[] = [
       { id: "A", x: 0, y: 0, width: 40, height: 40 },
@@ -417,7 +420,7 @@ describe("routeEdges — determinism (plan §3.1 'Determinism is a hard requirem
   });
 });
 
-describe("routeEdges — tie-breaking (plan §3.1 'Tie-breaking', D3)", () => {
+describe("routeEdges — tie-breaking (contract: 'A fixed tie-break total order')", () => {
   // A perfectly mirror-symmetric obstacle scenario: S, the obstacle, and T
   // all share the same x-span (0..40), so the grid's candidate X lines are
   // exactly {left-inflated, 20 (both endpoints' x), right-inflated} and the
@@ -425,7 +428,7 @@ describe("routeEdges — tie-breaking (plan §3.1 'Tie-breaking', D3)", () => {
   // obstacle therefore has an exact mirror right-detour path of identical
   // length and identical bend count — a genuine, spec-derivable tie.
   //
-  // Per D3, ties are broken by comparing the point sequence lexicographically
+  // Ties are broken by comparing the point sequence lexicographically
   // by (x, y). Both candidate paths coincide through points[0] (sourcePoint,
   // x=20) and points[1] (the nodeMargin-pushed point, still x=20 because the
   // push is purely vertical). At the first point where the two candidates
@@ -460,18 +463,18 @@ describe("routeEdges — tie-breaking (plan §3.1 'Tie-breaking', D3)", () => {
   });
 });
 
-describe("routeEdges — self-loops hug the node's right side (plan §3.1 'Self-loops', D1; arbitration-B R1/R2)", () => {
+describe("routeEdges — self-loops hug the node's right side (contract: 'Self-loops (right side, six points)')", () => {
   it("produces the documented six-point right-side loop shape, derived from the rect and not from sourcePoint/targetPoint", () => {
     const rect: RouteNodeRect = { id: "A", x: 0, y: 0, width: 100, height: 50 };
-    const nodeMargin = 12; // default per plan §3.2 EdgeRouterOptions
-    const selfLoopGap = 24; // default per plan §3.2 EdgeRouterOptions
+    const nodeMargin = 12; // contract default
+    const selfLoopGap = 24; // contract default
     const laneX = rect.x + rect.width + selfLoopGap;
 
-    // R2: self-loops are synthesized from the node rect and are exempt from
-    // D2 — sourcePoint/targetPoint are ignored for them. Use React Flow's
-    // real default (a centred handle), deliberately *not* the 75%-offset
-    // point, so this test actually pins that the loop shape comes from the
-    // rect rather than merely echoing back a pre-shaped request.
+    // Self-loops are synthesized from the node rect and are exempt from the
+    // exact-endpoints rule — sourcePoint/targetPoint are ignored. Use React
+    // Flow's real default (a centred handle), deliberately *not* the
+    // 75%-offset point, so this test actually pins that the loop shape comes
+    // from the rect rather than merely echoing back a pre-shaped request.
     const centredBottom: Point = {
       x: rect.x + rect.width / 2,
       y: rect.y + rect.height,
@@ -490,7 +493,7 @@ describe("routeEdges — self-loops hug the node's right side (plan §3.1 'Self-
 
     const points = routeEdges([rect], [request]).get(request.id)!;
 
-    // arbitration-B R1: the six-point form, exact vertex table.
+    // The contract's six-point form, exact vertex table.
     const expected: Point[] = [
       { x: rect.x + 0.75 * rect.width, y: rect.y + rect.height },
       { x: rect.x + 0.75 * rect.width, y: rect.y + rect.height + nodeMargin },
@@ -501,8 +504,9 @@ describe("routeEdges — self-loops hug the node's right side (plan §3.1 'Self-
     ];
     expect(points).toEqual(expected);
 
-    // R2 in action: the loop does not start/end at the centred handle we
-    // supplied — it starts/ends at the 75%-offset points derived from rect.
+    // The exemption in action: the loop does not start/end at the centred
+    // handle we supplied — it starts/ends at the 75%-offset points derived
+    // from rect.
     expect(points[0]).not.toEqual(request.sourcePoint);
     expect(points[points.length - 1]).not.toEqual(request.targetPoint);
 
@@ -510,10 +514,10 @@ describe("routeEdges — self-loops hug the node's right side (plan §3.1 'Self-
   });
 });
 
-describe("routeEdges — no-path fallback: the R15/R16 skeleton + connector ladder (plan §3.1 'No-path fallback')", () => {
+describe("routeEdges — no-path fallback: the skeleton + connector ladder (`fallbackPoints`)", () => {
   // A single huge obstacle node, distinct from source and target, that
   // encloses the entire region every fixture below uses. Because the
-  // source/target rect exemption (plan §3.1 step 3) only applies to the
+  // source/target rect exemption only applies to the
   // source and target's *own* rects, every grid path must cross this
   // obstacle's interior somewhere — guaranteeing routeEdges finds no path
   // and must emit the fully-specified fallback. A and B's own rects are
@@ -530,10 +534,10 @@ describe("routeEdges — no-path fallback: the R15/R16 skeleton + connector ladd
   const b: RouteNodeRect = { id: "B", x: 900, y: 900, width: 10, height: 10 };
   const nodes = [a, b, wall];
 
-  const nodeMargin = 12; // default per plan §3.2
-  const g = 24; // selfLoopGap default per plan §3.2 — also the ladder's own gap
+  const nodeMargin = 12; // contract default
+  const g = 24; // selfLoopGap contract default — also the ladder's own gap
 
-  // Every expected polyline below is hand-computed directly from plan §3.1's
+  // Every expected polyline below is hand-computed directly from the
   // skeleton (sourcePoint -> S -> P1 -> …connector… -> P2 -> T ->
   // targetPoint, with P1 = S + n_s·g, P2 = T + n_t·g) and its candidate
   // table, not by calling any reimplementation of the ladder.
@@ -647,7 +651,7 @@ describe("routeEdges — no-path fallback: the R15/R16 skeleton + connector ladd
 
   it("rung 4 — dog-leg +x: selected when source and target share the vertical axis pointing opposite ways, running backward", () => {
     // n_s = (0,1) ("bottom"), n_t = (0,-1) ("top") — the "same axis,
-    // opposite ways" case plan §3.1 calls out as needing 3 segments.
+    // opposite ways" case that needs 3 segments.
     const request: RouteRequest = {
       id: "e-A-B",
       source: "A",
@@ -665,7 +669,7 @@ describe("routeEdges — no-path fallback: the R15/R16 skeleton + connector ladd
     // dx = 200, dy = -80: both nonzero. Both along-exit and across-exit
     // fail here — P2 sits "behind" P1 along the shared vertical axis, so
     // whichever L goes vertical-first reverses at P1 and whichever goes
-    // horizontal-first reverses at P2 (plan §3.1 "Coverage"). Dog-leg +x's
+    // horizontal-first reverses at P2. Dog-leg +x's
     // segments are horizontal, orthogonal to the vertical n_s/n_t, so
     // neither of its two guard conditions can ever fire — it's always
     // valid whenever offered, and it's tried before +y.
@@ -689,7 +693,7 @@ describe("routeEdges — no-path fallback: the R15/R16 skeleton + connector ladd
     // Source and target handles coincide and sit on the same side, so
     // P1 = P2 exactly — "the two handles coincide and sit on the same
     // side, where returning to a point without retracing requires going
-    // around it" (plan §3.1). n_s = (0,1) ("bottom").
+    // around it". n_s = (0,1) ("bottom").
     const request: RouteRequest = {
       id: "e-A-B",
       source: "A",
@@ -733,7 +737,7 @@ describe("routeEdges — no-path fallback: the R15/R16 skeleton + connector ladd
   });
 });
 
-describe("routeEdges — requests naming a node absent from `nodes` (plan §3.1 'Missing nodes', D7)", () => {
+describe("routeEdges — requests naming a node absent from `nodes` (contract: 'Missing nodes')", () => {
   const nodes: RouteNodeRect[] = [
     { id: "A", x: 0, y: 0, width: 40, height: 40 },
     { id: "B", x: 200, y: 0, width: 40, height: 40 },
@@ -813,15 +817,14 @@ describe("routeEdges — requests naming a node absent from `nodes` (plan §3.1 
   });
 });
 
-describe("routeEdges — pushed points survive collinear collapse (plan §3.1 'Endpoints are exact'; arbitration-B2 R9/RF4)", () => {
-  // "Collinear interior points are collapsed, but the two pushed points are
-  // never collapsed away" (arbitration-B R3b, restated as a real assertion
-  // by arbitration-B2 R9/RF4). points[1] must be sourcePoint pushed
+describe("routeEdges — pushed points survive collinear collapse (contract: 'Endpoints are exact on the quantized points')", () => {
+  // Collinear interior points are collapsed, but the two pushed points are
+  // never collapsed away: points[1] must be sourcePoint pushed
   // nodeMargin outward along sourceSide, and the second-to-last point must
   // be targetPoint pushed outward along targetSide, even when those pushed
   // points are collinear with everything around them — the case a naive
   // "collapse all collinear points" pass would break.
-  const nodeMargin = 12; // default per plan §3.2
+  const nodeMargin = 12; // contract default
 
   it("keeps points[1] / second-to-last as the pushed points on a dead-straight route", () => {
     // simpleTwoNodeCase: A's right-center to B's left-center, both at y=20 —
@@ -876,18 +879,18 @@ describe("routeEdges — pushed points survive collinear collapse (plan §3.1 'E
   });
 });
 
-describe("routeEdges — own-node clearance is a searched-route property (plan §3.1 'Own-node clearance is a searched-route property', R5/R11)", () => {
-  // R11 (reinstated): the no-clipping rule binds *searched* routes only.
-  // The D4 fallback is exempt by design — its skeleton mandates a second
-  // outward step past S to P1, which can land inside the *other* node's
-  // rect when the two nodes are close or overlapping, and its connector
-  // ladder does no obstacle avoidance at all (plan §3.1 "No-path
-  // fallback"). A fallback-shaped result is identified via
-  // `isFallbackShape` (points[2] === P1) and skipped rather than asserted
-  // clear; every other (searched) result must stay clear on every segment
-  // but the first and the last (the two mandated D2 stubs, which "Endpoints
-  // are exact" can force through a node's own rect even for a searched
-  // route when a pushed point lands inside it).
+describe("routeEdges — own-node clearance is a searched-route property (the per-endpoint obstacle exemption in `edgeRouter.ts`)", () => {
+  // The no-clipping rule binds *searched* routes only. The no-path fallback
+  // is exempt by design — its skeleton mandates a second outward step past S
+  // to P1, which can land inside the *other* node's rect when the two nodes
+  // are close or overlapping, and its connector ladder does no obstacle
+  // avoidance at all (`specs/graph-view.md` §4, "Known limitations"). A
+  // fallback-shaped result is identified via `isFallbackShape`
+  // (points[2] === P1) and skipped rather than asserted clear; every other
+  // (searched) result must stay clear on every segment but the first and the
+  // last (the two mandated stubs, which "Endpoints are exact on the quantized
+  // points" can force through a node's own rect even for a searched route
+  // when a pushed point lands inside it).
 
   it("keeps every non-stub segment of a searched route clear of A's and B's own rect interiors across a sweep of B's position", () => {
     // Regression case origin: two ordinary basic-block-sized nodes,
@@ -932,8 +935,8 @@ describe("routeEdges — own-node clearance is a searched-route property (plan �
 
         const points = routeEdges([aRect, bRect], [request]).get(request.id)!;
 
-        // The fallback is exempt (R5/R11) — skip a fallback-shaped result
-        // rather than asserting clearance on it.
+        // The fallback is exempt — skip a fallback-shaped result rather than
+        // asserting clearance on it.
         if (isFallbackShape(points, request)) continue;
 
         if (anyMiddleSegmentCrossesRectInterior(points, aRect)) {
@@ -953,13 +956,12 @@ describe("routeEdges — own-node clearance is a searched-route property (plan �
   });
 
   it("holds the no-reversal and orthogonality invariants (not clearance) for forced no-path fallback routes, including overlapping source/target rects", () => {
-    // These configs are forced into the D4 fallback via WALL (same
+    // These configs are forced into the no-path fallback via WALL (same
     // technique as the "no-path fallback" describe block above), which is
     // exempt from own-node clearance by design — so this checks the
     // invariants the fallback *is* bound by instead: every returned
     // polyline is still orthogonal and still has no immediate reversal.
-    // Overlapping rects are exactly the case plan §3.1 "Own-node clearance
-    // is a searched-route property" calls out as where a mandated stub can
+    // Overlapping rects are exactly the case where a mandated stub can
     // legitimately land inside the *other* node's rect; a non-overlapping
     // config is included too, to broaden the sample.
     const wall: RouteNodeRect = {
@@ -1024,12 +1026,12 @@ describe("routeEdges — own-node clearance is a searched-route property (plan �
   });
 });
 
-describe("routeEdges — no immediate reversal / never a degenerate hook (arbitration-B3 R12)", () => {
+describe("routeEdges — no immediate reversal / never a degenerate hook (contract: 'No immediate reversals')", () => {
   // "No polyline may contain an immediate reversal: no interior vertex where
   // the segment arriving and the segment leaving run along the same axis in
   // opposite directions." Binding on every returned polyline — searched,
-  // self-loop, and fallback alike. The defect this guards against (the old,
-  // unamended D4 collapsing onto one line and retracing part of itself) only
+  // self-loop, and fallback alike. The defect this guards against (an earlier
+  // fallback shape collapsing onto one line and retracing part of itself) only
   // showed up in 0.83% of fallbacks per the reviewer's sampling, so each
   // case below sweeps a range of configurations rather than asserting one.
 
@@ -1110,7 +1112,7 @@ describe("routeEdges — no immediate reversal / never a degenerate hook (arbitr
   });
 
   it("holds for the no-path fallback across sourceSide/direction combinations and every ladder rung", () => {
-    // A single huge wall forces every one of these requests into the D4
+    // A single huge wall forces every one of these requests into the no-path
     // fallback (same technique as the "no-path fallback" describe block
     // above). A and B are placed far from the geometry the requests
     // describe — the fallback construction depends only on the request's
@@ -1149,12 +1151,11 @@ describe("routeEdges — no immediate reversal / never a degenerate hook (arbitr
 
     // For each vertical/horizontal exit side, one config where source and
     // target push in the same direction along that axis and one where they
-    // push oppositely (the "down 16, up 48, down 16" degenerate hook from
-    // the pre-R15 fallback design lived exactly here — sourceSide "bottom"
-    // below), plus two generic configs and, since R15/R16 replaced D4 with
-    // the skeleton + connector ladder, one config landing on the dog-leg
-    // rung and one on the rectangle rung (plan §3.1 "No-path fallback")
-    // for direct breadth on the newest part of the construction.
+    // push oppositely (the "down 16, up 48, down 16" degenerate hook of the
+    // earlier fallback design lived exactly here — sourceSide "bottom"
+    // below), plus two generic configs and one config landing on each of the
+    // connector ladder's dog-leg and rectangle rungs, for direct breadth on
+    // the newest part of the construction.
     const configs: Config[] = [
       {
         label: "bottom, with normal (elbow omitted, unchanged)",
@@ -2392,13 +2393,14 @@ describe("routeEdges — quantization: determinism on fractional input (contract
   });
 });
 
-describe("routeEdges — performance (plan §2 decision 10; arbitration-B2 R7)", () => {
-  // The real design budget is 50ms for a 60-node / 80-edge pass, but that is
-  // measured out of band (bare Node, warm, median of N) — see the plan and
-  // arbitration-B2 R7. A tight wall-clock bound cannot be held reliably
-  // inside a parallel vitest run, where this number measures scheduler
-  // contention as much as the router itself (observed failing 3/18 full-
-  // suite runs at 52-59ms against a 50ms bound). This assertion is
+describe("routeEdges — performance (`specs/graph-view.md` §4)", () => {
+  // The real budget is the 16.7ms animation frame, and it is measured out of
+  // band (bare Node, warm, median of N) — see `specs/graph-view.md` §4, which
+  // records the figures and says in as many words that this in-suite test is
+  // not a check of that budget. A tight wall-clock bound cannot be held
+  // reliably inside a parallel vitest run, where this number measures
+  // scheduler contention as much as the router itself (observed failing 3/18
+  // full-suite runs at 52-59ms against a 50ms bound). This assertion is
   // deliberately loosened to a generous 300ms ceiling: it is a
   // catastrophic-regression guard (e.g. an accidental O(n^3) blowup), not a
   // budget check, and it must not be "fixed" with warm-up loops or best-of-N

--- a/src/utils/edgeRouter.ts
+++ b/src/utils/edgeRouter.ts
@@ -25,7 +25,8 @@ export const DEFAULT_SELF_LOOP_GAP = 24;
 
 /**
  * Costs closer than this count as equal, so that geometrically symmetric
- * alternatives fall through to the documented tie-break order (§3.1) instead of
+ * alternatives fall through to the documented tie-break order
+ * (`contracts/edge-routing.md`, "A fixed tie-break total order") instead of
  * being decided by float noise.
  */
 const COST_EPSILON = 1e-9;
@@ -53,7 +54,12 @@ const OUTWARD_DIR: Record<RouteSide, number> = {
 
 const reverseDir = (dir: number): number => (dir + 2) % 4;
 
-/** A handle position moved `distance` px out of the node along its side (§3.1 step 5). */
+/**
+ * A handle position moved `distance` px out of the node along its side. At
+ * `nodeMargin` this is the interior bend that `contracts/edge-routing.md`
+ * ("Endpoints are exact on the quantized points") keeps off the ends of the
+ * polyline.
+ */
 const pushOutward = (
   point: Point,
   side: RouteSide,
@@ -164,7 +170,10 @@ const dropCollinearInterior = (points: Point[]): Point[] => {
   return kept;
 };
 
-/** Lexicographic order on point sequences, prefix-first (§3.1 tie-breaking). */
+/**
+ * Lexicographic order on point sequences, prefix-first — the third and last key
+ * of `contracts/edge-routing.md`, "A fixed tie-break total order".
+ */
 const comparePointSequences = (a: Point[], b: Point[]): number => {
   const shared = Math.min(a.length, b.length);
   for (let i = 0; i < shared; i++) {
@@ -196,7 +205,8 @@ interface InflatedRect {
 /**
  * "Is this point strictly inside an obstacle?" over a uniform spatial hash.
  * Built once per `routeEdges` call rather than once per edge, which is what
- * keeps the 60-node / 80-edge pass inside the 50 ms budget (§2 decision 10).
+ * keeps a full pass inside the frame budget measured in `specs/graph-view.md`
+ * §4.
  *
  * A grid segment runs between two consecutive grid lines and every rect edge is
  * a grid line, so a segment lies either wholly inside a rect's interior or
@@ -263,7 +273,10 @@ interface RouterContext {
   ) => boolean;
 }
 
-/** Binary heap over the §3.1 total order. */
+/**
+ * Binary heap over the tie-break total order (`contracts/edge-routing.md`,
+ * "A fixed tie-break total order").
+ */
 const createQueue = (compare: (a: Label, b: Label) => number) => {
   const items: Label[] = [];
   return {
@@ -390,9 +403,9 @@ const routeOnGrid = (
     return label.points;
   };
 
-  // The total order of §3.1: cost, then bend count, then the point sequence.
-  // Every key is non-decreasing along a path, so the first pop of a state is
-  // its optimum under that order.
+  // The contract's tie-break total order: cost, then bend count, then the point
+  // sequence. Every key is non-decreasing along a path, so the first pop of a
+  // state is its optimum under that order.
   const compare = (a: Label, b: Label): number => {
     if (a.priority - b.priority > COST_EPSILON) return 1;
     if (b.priority - a.priority > COST_EPSILON) return -1;
@@ -442,9 +455,9 @@ const routeOnGrid = (
     if (label.goal) return pointsOf(label);
 
     // Arriving at T along +n_t would make the mandated `T → targetPoint` stub
-    // double back on the approach, which the no-immediate-reversal rule forbids
-    // (§3.1). Such an approach simply cannot finish; if nothing else reaches T,
-    // the edge falls back to D4.
+    // double back on the approach, which `contracts/edge-routing.md` ("No
+    // immediate reversals") forbids. Such an approach simply cannot finish; if
+    // nothing else reaches T, the edge falls back to `fallbackPoints` below.
     if (
       label.xi === endXi &&
       label.yi === endYi &&
@@ -475,7 +488,7 @@ const routeOnGrid = (
       }
       const nextX = xs[nextXi];
       const nextY = ys[nextYi];
-      // §3.1 step 3: the exemption is per endpoint. The source node's rect is
+      // The obstacle exemption is per endpoint. The source node's rect is
       // exempt only for the segments incident to S, the target's only for those
       // incident to T; every other segment treats both as obstacles, so a
       // searched route can never clip its own endpoint node. Where that makes
@@ -516,9 +529,9 @@ const routeOnGrid = (
 /**
  * An interior vertex where the arriving and leaving segments run along the same
  * axis in opposite directions — the one and only form of the no-reversal rule
- * (§3.1 "No immediate reversals"). Note that `points[i - 1] !== points[i + 1]`
- * is _not_ an equivalent test: "out 16, back 48" passes it and is exactly the
- * shape being banned.
+ * (`contracts/edge-routing.md`, "No immediate reversals"). Note that
+ * `points[i - 1] !== points[i + 1]` is _not_ an equivalent test: "out 16, back
+ * 48" passes it and is exactly the shape being banned.
  */
 const hasImmediateReversal = (points: Point[]): boolean => {
   for (let i = 1; i < points.length - 1; i++) {
@@ -544,8 +557,9 @@ const hasImmediateReversal = (points: Point[]): boolean => {
 };
 
 /**
- * Deterministic shape used when the grid offers no path (§3.1 "No-path
- * fallback"): `sourcePoint → S → P1 → connector → P2 → T → targetPoint`.
+ * Deterministic shape used when the grid offers no path — the no-path fallback
+ * of `specs/graph-view.md` §4, which does no obstacle avoidance at all:
+ * `sourcePoint → S → P1 → connector → P2 → T → targetPoint`.
  *
  * `P1` steps a further `selfLoopGap` out along the source normal and `P2` sits a
  * `selfLoopGap` outside `T`, so the polyline always leaves straight and always
@@ -558,7 +572,7 @@ const hasImmediateReversal = (points: Point[]): boolean => {
  * the rule wins, which keeps the choice deterministic. Two segments suffice for
  * most geometry; 36 of the 144 side/direction combinations need the three-segment
  * lateral dog-leg, and coincident handles on the same side need the four-segment
- * rectangle (§3.1 documents the full ladder).
+ * rectangle. The full ladder is the `connectors` array below, in order.
  */
 const fallbackPoints = (
   request: RouteRequest,
@@ -597,7 +611,8 @@ const fallbackPoints = (
       verticalExit ? [acrossExit] : [alongExit],
     );
   }
-  // Three-segment lateral dog-legs, positive side first (R1's convention).
+  // Three-segment lateral dog-legs, positive side first — a fixed order, so the
+  // choice stays deterministic.
   const xPositive = Math.max(p1.x, p2.x) + selfLoopGap;
   const xNegative = Math.min(p1.x, p2.x) - selfLoopGap;
   const yPositive = Math.max(p1.y, p2.y) + selfLoopGap;
@@ -688,10 +703,10 @@ const selfLoopPoints = (
 /**
  * Routes every request against the live node rects. Pure: the same rects and
  * requests always produce byte-identical polylines, and no route depends on the
- * order of either input array (§3.1 "Determinism is a hard requirement").
+ * order of either input array (`contracts/edge-routing.md`, "Determinism").
  *
  * Keyed by `RouteRequest.id`; a request naming a node absent from `nodes` gets
- * no entry at all (§3.1 "Missing nodes").
+ * no entry at all (`contracts/edge-routing.md`, "Missing nodes").
  *
  * Every coordinate in the input is quantized here, before the obstacle set is
  * built and before any search runs, so every returned coordinate is an integer
@@ -702,10 +717,10 @@ const selfLoopPoints = (
  * Every returned polyline — searched, self-loop and fallback alike — is
  * orthogonal, has at least 2 points, and contains **no immediate reversal**: at
  * no interior vertex do the arriving and leaving segments run along the same
- * axis in opposite directions (§3.1 "No immediate reversals"). That is the
- * checkable form of "never a degenerate hook". The search gets it by refusing to
- * double back, the self-loop by construction, the fallback via its lateral
- * detour case.
+ * axis in opposite directions (`contracts/edge-routing.md`, "No immediate
+ * reversals"). That is the checkable form of "never a degenerate hook". The
+ * search gets it by refusing to double back, the self-loop by construction, the
+ * fallback via its lateral detour case.
  */
 export const routeEdges = (
   nodes: RouteNodeRect[],


### PR DESCRIPTION
Closes #97.

`src/utils/edgeRouter.ts` cited its own specification throughout its inline documentation as `§3.1 "Endpoints are exact"`, `§3.1 step 3`, `§2 decision 10` and so on. Those section numbers belonged to a plan document under `docs/` that was removed in #70, and the specification now lives in `docs/internal/contracts/edge-routing.md`, which has named sections and has never carried that numbering. Some references also quoted heading text that no longer exists — #89 renamed the guarantee `§3.1 "Endpoints are exact"` names to "Endpoints are exact on the quantized points". Because that contract explicitly delegates the algorithm back to this file, the inline documentation is part of the project's documentation rather than commentary around it, and a reader following one of these references had nothing to reach.

Every such citation now names a section or guarantee that exists.

## What each reference became

- Tie-break sites (`COST_EPSILON`, `comparePointSequences`, the queue, the `compare` in `routeOnGrid`) → `contracts/edge-routing.md`, "A fixed tie-break total order".
- `§3.1 "Determinism is a hard requirement"` → "Determinism"; `§3.1 "Missing nodes"` → "Missing nodes"; `§3.1 "No immediate reversals"` → the same-named guarantee. These four kept their meaning and only changed address.
- `§3.1 "Endpoints are exact"` → "Endpoints are exact on the quantized points", the current heading.
- `§2 decision 10` (obstacle index) → `specs/graph-view.md` §4.
- References that pointed at *algorithm steps* rather than at a guarantee — `§3.1 step 3` (the per-endpoint obstacle exemption), `§3.1 step 5` (the `nodeMargin` push), `§3.1 "No-path fallback"`, "§3.1 documents the full ladder" — became plain prose or a pointer to the code implementing them (`fallbackPoints`, the `connectors` array). The contract delegates the algorithm to this file, so there is no document for them to resolve into; inventing contract sections for them would have contradicted that delegation.

## Scope beyond the router

The issue's first acceptance criterion is repo-wide, so two more files are covered:

- `src/utils/__tests__/edgeRouter.test.ts` carried the same numbering across its `describe` titles and comments, together with the plan's `D2`/`D4`/`R15`/`arbitration-B…` decision labels. Those labels sat inside the citations being rewritten and are equally unresolvable, so they went with them.
- `src/hooks/useEdgeRoutes.ts` cited `plan §2 decision 8`, `R8 / plan §2 decision 5` and `D6`; all three are `specs/graph-view.md` §4 material.

## Two figures dropped rather than rehomed

The router claimed the obstacle index "keeps the 60-node / 80-edge pass inside the 50 ms budget", and the timing test restated it as "the real design budget". `specs/graph-view.md` §4 supersedes both: the budget is the 16.7 ms animation frame, measured out of band (60 nodes / 117 edges ≈ 3 ms, 180 / ~370 ≈ 16 ms), and the spec says in as many words that the in-suite 300 ms test is a catastrophic-regression guard rather than a check of that budget. Rehoming a number the spec contradicts would have replaced a dangling reference with a wrong one.

## Verification

- Comments only. The non-comment lines in the diff are `describe` title strings and end-of-line comments on constants; no executed expression changed.
- `npm run test:run` → 49 files / 568 tests passed.
- `npm run lint` clean, `prettier --check` clean.
- `grep -rn "plan §\|arbitration" src/ e2e/ docs/` → no matches.
- Rebased onto `820779f` (#102), which rewrote both cited documents. Every heading and guarantee name cited here was re-checked against the post-#102 text and still resolves; #102's additions to `edge-routing.md` are a new "Bundles and separation" section that touches none of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)