### PR TITLE
test(edge-routing): pin the tie-break tolerance for fractional costs

### DIFF
--- a/docs/internal/contracts/edge-routing.md
+++ b/docs/internal/contracts/edge-routing.md
@@ -226,7 +226,14 @@ or fractional values of it are ordinary input.
   (2) number of bends, (3) the point sequence compared lexicographically by `(x, y)` — a
   shorter sequence that is a prefix of a longer one sorts first. The chosen shape is
   therefore a documented property of the router, not an implementation accident, and this
-  is what the determinism guarantee above rests on.
+  is what the determinism guarantee above rests on. **"Equally cheap" means equal to within
+  a small tolerance, not bit-equal.** `bendPenalty` is deliberately left unquantized (see
+  the options table), so a total cost is a float sum of integer run lengths and fractional
+  bend prices, and two candidates that cost the same in exact arithmetic can still land on
+  totals differing in their last bits — the search reaches them through different sequences
+  of additions. Ranking those by key (1) would decide the shape by accumulated rounding
+  error, which is the implementation accident this order exists to rule out; the tolerance
+  is what lets keys (2) and (3) decide instead.
 - **No immediate reversals.** Binding on every returned polyline — searched, self-loop and
   fallback alike: no interior vertex has its arriving and leaving segments running along
   the same axis in opposite directions. This is the precise, checkable form of "never a

--- a/src/utils/__tests__/edgeRouter.test.ts
+++ b/src/utils/__tests__/edgeRouter.test.ts
@@ -272,6 +272,35 @@ function polylineLength(points: Point[]): number {
 }
 
 /**
+ * Number of vertices where the polyline changes axis — the `turns` of the
+ * contract's cost function `length + bendPenalty * turns`, and its second
+ * tie-break key.
+ */
+function bendCount(points: Point[]): number {
+  let bends = 0;
+  for (let i = 1; i < points.length - 1; i++) {
+    const arrivesHorizontally = points[i - 1].y === points[i].y;
+    const leavesHorizontally = points[i].y === points[i + 1].y;
+    if (arrivesHorizontally !== leavesHorizontally) bends++;
+  }
+  return bends;
+}
+
+/**
+ * The contract's third tie-break key restated as a predicate over returned
+ * points: point sequences compared lexicographically by `(x, y)`, with a
+ * shorter sequence that is a prefix of a longer one sorting first.
+ */
+function comparePointSequences(a: Point[], b: Point[]): number {
+  const shared = Math.min(a.length, b.length);
+  for (let i = 0; i < shared; i++) {
+    if (a[i].x !== b[i].x) return a[i].x < b[i].x ? -1 : 1;
+    if (a[i].y !== b[i].y) return a[i].y < b[i].y ? -1 : 1;
+  }
+  return a.length - b.length;
+}
+
+/**
  * A deterministic stream of fractions in [0, 1) with three decimals, used by
  * the fractional sweeps below. A plain LCG rather than `Math.random` so that a
  * failure is reproducible and the suite cannot pass or fail by luck.
@@ -463,22 +492,22 @@ describe("routeEdges — tie-breaking (contract: 'A fixed tie-break total order'
   // the other's above 20 (reflection x -> 40 - x around the axis of
   // symmetry) — so the smaller-x (left) candidate must sort first and win,
   // regardless of exactly which grid line the router picks for the detour.
-  it("breaks a symmetric tie toward the lexicographically smaller (left) detour", () => {
-    const nodes: RouteNodeRect[] = [
-      { id: "S", x: 0, y: 0, width: 40, height: 40 },
-      { id: "OBS", x: 0, y: 120, width: 40, height: 40 },
-      { id: "T", x: 0, y: 240, width: 40, height: 40 },
-    ];
-    const request: RouteRequest = {
-      id: "e-S-T",
-      source: "S",
-      target: "T",
-      sourcePoint: { x: 20, y: 40 },
-      targetPoint: { x: 20, y: 240 },
-      sourceSide: "bottom",
-      targetSide: "top",
-    };
+  const nodes: RouteNodeRect[] = [
+    { id: "S", x: 0, y: 0, width: 40, height: 40 },
+    { id: "OBS", x: 0, y: 120, width: 40, height: 40 },
+    { id: "T", x: 0, y: 240, width: 40, height: 40 },
+  ];
+  const request: RouteRequest = {
+    id: "e-S-T",
+    source: "S",
+    target: "T",
+    sourcePoint: { x: 20, y: 40 },
+    targetPoint: { x: 20, y: 240 },
+    sourceSide: "bottom",
+    targetSide: "top",
+  };
 
+  it("breaks a symmetric tie toward the lexicographically smaller (left) detour", () => {
     const points = routeEdges(nodes, [request]).get(request.id)!;
 
     // A real route must exist (there's room to detour on both sides).
@@ -487,6 +516,57 @@ describe("routeEdges — tie-breaking (contract: 'A fixed tie-break total order'
     const diverging = points.find((p) => p.x !== 20);
     expect(diverging).toBeDefined();
     expect(diverging!.x).toBeLessThan(20);
+  });
+
+  // The same corridor, routed with a *fractional* `bendPenalty` — and that is
+  // the whole point of this fixture rather than a decoration on the one above.
+  // `bendPenalty` is a cost and never a coordinate, so it is the one input the
+  // router deliberately leaves unquantized, which makes a total cost a float
+  // sum of integer run lengths and fractional bend prices. One third has no
+  // exact binary representation, so two candidates that are equal in exact
+  // arithmetic accumulate to totals that differ in their last bits — the search
+  // reaches them through different sequences of additions. The test above uses
+  // the default integer penalty, where the two totals come out bit-identical
+  // and the comparator's tolerance is never exercised; here it is the only
+  // thing standing between the documented order and a shape picked by rounding
+  // error. Drop the tolerance and the right-hand candidate below wins instead.
+  it("breaks a tie between costs that are equal only in exact arithmetic", () => {
+    const points = routeEdges(nodes, [request], { bendPenalty: 1 / 3 }).get(
+      request.id,
+    )!;
+
+    // The competing candidate: it crosses to the far side of the obstacle
+    // 56 px lower down and detours right, so the run alongside the obstacle is
+    // 56 px shorter and the total comes out the same.
+    const rightDetour: Point[] = [
+      { x: 20, y: 40 },
+      { x: 20, y: 52 },
+      { x: 20, y: 108 },
+      { x: 52, y: 108 },
+      { x: 52, y: 172 },
+      { x: 20, y: 172 },
+      { x: 20, y: 228 },
+      { x: 20, y: 240 },
+    ];
+
+    // Keys (1) and (2) cannot separate the two: equal length and equal bend
+    // count make `length + bendPenalty * turns` equal for *any* penalty, so
+    // this is a tie in exact arithmetic whatever the router is configured with.
+    expect(polylineLength(points)).toBe(polylineLength(rightDetour));
+    expect(bendCount(points)).toBe(bendCount(rightDetour));
+
+    // Key (3) therefore decides, and it picks the lexicographically smaller
+    // sequence — the left detour, which turns off the shared x = 20 run first.
+    expect(comparePointSequences(points, rightDetour)).toBeLessThan(0);
+    expect(points).toEqual([
+      { x: 20, y: 40 },
+      { x: 20, y: 52 },
+      { x: -12, y: 52 },
+      { x: -12, y: 172 },
+      { x: 20, y: 172 },
+      { x: 20, y: 228 },
+      { x: 20, y: 240 },
+    ]);
   });
 });
 


### PR DESCRIPTION
`COST_EPSILON` in `edgeRouter.ts` makes the A* label comparator treat costs closer than `1e-9` as equal, so that geometrically symmetric alternatives fall through to the documented tie-break order — cost, then bend count, then the point sequence compared lexicographically — instead of being decided by float noise. Nothing in the suite detected its removal: setting it to `0` left all 568 tests green. The existing tie-break test uses a symmetric obstacle layout with integer geometry, where the two candidate costs come out bit-identical and no tolerance is required to see the tie.

The contract left the question open as well, so there was no stated property for a test to be written against. "Equally cheap" said nothing about what equal means for a float sum. `contracts/edge-routing.md` now says it means **equal to within a small tolerance, not bit-equal**, and why: `bendPenalty` is deliberately left unquantized, being a cost and never a coordinate, so a total cost is a float sum of integer run lengths and fractional bend prices, and two candidates equal in exact arithmetic can still land on totals differing in their last bits.

No new fixture was needed. The existing symmetric corridor — `S`, `OBS`, `T` stacked and all spanning x 0–40 — already exercises the tolerance once `bendPenalty` is fractional. Routed with `1/3`, which has no exact binary representation, its two candidates are:

- the left detour, `12 + 32 + 120 + 32 + 56 + 12` = 264 px, 4 bends;
- the right detour, which crosses to the far side 56 px lower down so the run alongside the obstacle is 56 px shorter, `12 + 56 + 32 + 64 + 32 + 56 + 12` = 264 px, 4 bends.

Equal length and equal bend count make keys (1) and (2) tie for *any* penalty, so key (3) must decide. The search reaches the two through different sequences of additions, so their float totals differ in the last bits and only the tolerance keeps key (1) from ranking them.

One test in the existing tie-breaking `describe`, whose fixture is hoisted to describe scope so both tests share it. It asserts the tie on the first two keys, that the returned route sorts strictly before the competitor under key (3), and pins the resulting polyline; a comment states why the layout needs a fractional `bendPenalty` to be meaningful. Two helpers are added alongside `polylineLength`: `bendCount` and `comparePointSequences`, the latter a restatement of the contract's third key over returned points, in the same spirit as the existing `q`.

Verification: with `COST_EPSILON = 0` the new test fails, and it fails on the tie-break key itself rather than incidentally — `expected 0 to be less than 0` at the key (3) assertion, the router having returned the competing candidate. Restored to `1e-9`, `npm run test:run` is green (572 tests), as are `format` and `lint`.

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)