### PR TITLE
fix(mermaid): add semantic action for %% comment lines

### DIFF
--- a/docs/internal/specs/mermaid.md
+++ b/docs/internal/specs/mermaid.md
@@ -23,6 +23,10 @@ header), `parse` throws an `Error` with Ohm's match diagnostic.
 - **Statements** after the header, separated by newlines and/or `;`:
   - Node declaration: `Id` with an optional label (see shapes below).
   - Edge: `Node Link Node`.
+  - Comment: `%%` and everything up to the end of the line. A comment is a statement like any
+    other, so it may stand on its own line or follow another statement on the same line; it
+    contributes no node and no edge. Comments before the header are not accepted, since only
+    separators may precede it.
 - **Node ids** are alphanumeric (`alnum+`). **Shapes** by label bracket:
 
   | Syntax     | `shape`  | Rendered as (see `MermaidNode.tsx`) |
@@ -40,7 +44,8 @@ header), `parse` throws an `Error` with Ohm's match diagnostic.
 > Pinned by: `src/parser/__tests__/mermaid/headerAndDirection.test.ts`,
 > `src/parser/__tests__/mermaid/statements.test.ts`,
 > `src/parser/__tests__/mermaid/nodes.test.ts`,
-> `src/parser/__tests__/mermaid/edges.test.ts`
+> `src/parser/__tests__/mermaid/edges.test.ts`,
+> `src/parser/__tests__/mermaid/comments.test.ts`
 
 ## 3. Node deduplication and label back-fill
 
@@ -82,7 +87,3 @@ These are current, test-pinned behavior — changing them is a spec change:
   handlers, other node shapes (`((...))`, `>...]`, `[/.../]`, ...), multi-link chains
   (`A --> B --> C`), and `&`-lists are not in the grammar; input using them throws.
   _(observed, untested)_
-- **`%%` comment lines crash the parser at runtime** ("Missing semantic action for
-  'comment'"): the grammar accepts them as statements but the semantics has no action for
-  the `comment` rule. Tracked by
-  [Issue #75](https://github.com/himadajin/ir-visualizer/issues/75).

--- a/docs/user/supported-formats.md
+++ b/docs/user/supported-formats.md
@@ -120,11 +120,12 @@ graph TD
 
 Supported: `graph`/`flowchart` headers with `TB|TD|BT|RL|LR` directions; nodes with square
 `[..]`, round `(..)`, and curly `{..}` labels; `-->` / `---` links with optional `|label|` or
-`--label-->` labels; newline or `;` separated statements.
+`--label-->` labels; newline or `;` separated statements; `%%` comment lines, which are
+ignored.
 
 **Limitations to know about:**
 
-- Subgraphs, styling, multi-link chains (`A --> B --> C`), other node shapes, and `%%`
-  comment lines are not supported (comments currently cause a parse error).
+- Subgraphs, styling, multi-link chains (`A --> B --> C`), and other node shapes are not
+  supported.
 - Edge labels are displayed with their pipe delimiters (`|yes|`), matching how they are
   written.

--- a/src/parser/__tests__/mermaid/comments.test.ts
+++ b/src/parser/__tests__/mermaid/comments.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { parseMermaidToAST } from "../../mermaid";
+
+describe("mermaid parser", () => {
+  describe("comments", () => {
+    it("when a comment line stands between statements, should ignore it", () => {
+      const ast = parseMermaidToAST(`graph TD\n%% comment\nA --> B`);
+
+      expect(ast.nodes.map((node) => node.id)).toEqual(["A", "B"]);
+      expect(ast.edges).toHaveLength(1);
+    });
+
+    it("when a comment follows a statement on the same line, should ignore it", () => {
+      const ast = parseMermaidToAST(`graph TD\nA --> B %% comment`);
+
+      expect(ast.nodes.map((node) => node.id)).toEqual(["A", "B"]);
+      expect(ast.edges).toHaveLength(1);
+    });
+
+    it("when a comment holds text that looks like a statement, should not parse it", () => {
+      const ast = parseMermaidToAST(`graph TD\nA --> B\n%% C --> D`);
+
+      expect(ast.nodes.map((node) => node.id)).toEqual(["A", "B"]);
+      expect(ast.edges).toHaveLength(1);
+    });
+
+    it("when the graph body is only comments, should parse to an empty graph", () => {
+      const ast = parseMermaidToAST(`graph TD\n%% first\n%% second`);
+
+      expect(ast.direction).toBe("TD");
+      expect(ast.nodes).toEqual([]);
+      expect(ast.edges).toEqual([]);
+    });
+
+    it("when a comment precedes the header, should throw", () => {
+      expect(() =>
+        parseMermaidToAST(`%% comment\ngraph TD\nA --> B`),
+      ).toThrow();
+    });
+  });
+});

--- a/src/parser/mermaid.ts
+++ b/src/parser/mermaid.ts
@@ -134,6 +134,9 @@ function registerSemantics(semantics: ohm.Semantics) {
     NodeLabel_curly(_open: any, text: any, _close: any) {
       return { text: text.sourceString, shape: "curly" };
     },
+    comment(_marker: any, _text: any) {
+      return null;
+    },
     // Default fallbacks
     _iter(...children: any[]) {
       return children.map((c) => c.toAST());


### PR DESCRIPTION
Closes #75.

The Mermaid grammar (`src/parser/mermaid.ohm`) accepts `%%` comment lines as statements, but the semantics in `src/parser/mermaid.ts` defined no action for the `comment` rule. Any input containing a `%%` line therefore crashed the parser with Ohm's "Missing semantic action for 'comment'" error. This adds the missing action so comment lines are accepted and produce no AST statement.

## What changed

- `src/parser/mermaid.ts`: add the `comment` action returning `null`. `Graph` already skips falsy statement results, so a comment contributes no node and no edge.
- `docs/internal/specs/mermaid.md`: move the behavior out of §6 "Known limitations" and into §2 "Accepted syntax", and list the new test under that section's **Pinned by**.
- `docs/user/supported-formats.md`: comments are now listed as supported instead of as a limitation.
- `src/parser/__tests__/mermaid/comments.test.ts`: new pinning tests.

## Notes for reviewers

Because `comment` is reached through the syntactic `Statement` rule, a comment works both on its own line and after another statement on the same line — both forms are pinned. A comment before the header is still rejected (only separators may precede it), which is pinned too so the spec sentence stays honest.

## Verification

- `npm run test:run`: 50 files / 576 tests pass
- `npm run format`, `npm run lint`: clean
- Manually in the dev server, Mermaid mode: pasting a body with a standalone comment, a trailing comment, and a following edge parses to `5 nodes · 6 edges` with no console errors (this crashed before the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)