### PR TITLE
fix(graph-view): anchor routed edges on the node rect edge, not the handle box

### DIFF
--- a/docs/internal/specs/graph-view.md
+++ b/docs/internal/specs/graph-view.md
@@ -122,6 +122,21 @@ all (#88). Until those land, an overlap in the rendered graph means nothing.
   `measured.width` / `measured.height`) and the live handle positions. Because those track
   the current DOM, an edge follows its node while the node is dragged, and follows a size
   change caused by a content-only edit (§2), with no re-layout involved.
+- **Endpoints are node-boundary anchors, not handle-box anchors.** The coordinate _along_ a
+  side comes from the handle, so per-operand ports (the Use-Def view) keep their own
+  offsets; the coordinate _across_ it comes from the node's measured rect — `rect.y` for a
+  `top` handle, `rect.y + rect.height` for a `bottom` one, and correspondingly for `left` /
+  `right`. The reason is that a handle is positioned from the node's **padding** box, so its
+  measured bounds sit inside the rect the router uses as the obstacle — 1 px in, the width
+  of the node border (`NODE_BORDER_WIDTH`, §5). Anchoring on the handle box makes the drawn
+  attachment point and the router's clearance geometry two independently derived numbers: the
+  `nodeMargin`-pushed point then lands 1 px inside the node's own inflated boundary, and
+  the search has to step that pixel before it can turn, leaving a pair of bends whose
+  corner radius has collapsed to half a pixel at every departure and arrival. Projecting
+  onto the rect edge makes the pushed point coincide with the inflated boundary by
+  construction, whatever the handle's CSS does, and the edge touches the node's visible
+  border exactly. `useEdgeRoutes` therefore deliberately does **not** mirror React Flow's
+  own `getHandlePosition`, which is where the inset was inherited from.
 - **One pass per graph:** `src/hooks/useEdgeRoutes.ts` reads React Flow's store, calls
   `routeEdges` once per pass, and publishes the resulting `Map<edgeId, Point[]>` through a
   React context; `RoutedEdge` looks up its own entry by edge id and never calls the router

--- a/src/hooks/useEdgeRoutes.ts
+++ b/src/hooks/useEdgeRoutes.ts
@@ -61,27 +61,44 @@ interface HandleAnchor {
 }
 
 /**
- * Where a handle actually sits, in flow coordinates. This mirrors React Flow's
- * own `getHandlePosition`, so a route's endpoints land exactly on the pixels
- * React Flow reports as `sourceX`/`sourceY` for the same edge.
+ * Where an edge attaches, in flow coordinates: the handle's center *along* the
+ * side it sits on, projected onto the node's measured rect *across* it
+ * (`specs/graph-view.md` §4).
+ *
+ * This deliberately does **not** mirror React Flow's own `getHandlePosition`.
+ * A handle is positioned from the node's padding box, so its measured bounds
+ * sit one border-width inside the rect the router treats as the obstacle;
+ * anchoring on the handle box would leave the drawn attachment point and the
+ * router's clearance geometry as two independently derived numbers. Taking the
+ * across-side coordinate from the rect makes the `nodeMargin`-pushed point
+ * coincide with the node's inflated boundary by construction. The along-side
+ * coordinate keeps coming from the handle, so per-operand ports (the Use-Def
+ * view) still leave from their own offsets.
+ *
+ * `null` when React Flow has not measured the node yet — such a node is
+ * omitted from the rects too (`collectRects`), so its edges are not drawn this
+ * frame either way.
  */
 const anchorOf = (
   node: InternalNode,
   handle: MeasuredHandle,
 ): HandleAnchor | null => {
-  const x = node.internals.positionAbsolute.x + handle.x;
-  const y = node.internals.positionAbsolute.y + handle.y;
-  const { width, height } = handle;
+  const { width, height } = node.measured;
+  if (width === undefined || height === undefined) return null;
+  const left = node.internals.positionAbsolute.x;
+  const top = node.internals.positionAbsolute.y;
+  const alongX = left + handle.x + handle.width / 2;
+  const alongY = top + handle.y + handle.height / 2;
   const side = SIDE_BY_POSITION[handle.position];
   switch (handle.position) {
     case Position.Top:
-      return { point: { x: x + width / 2, y }, side };
+      return { point: { x: alongX, y: top }, side };
     case Position.Right:
-      return { point: { x: x + width, y: y + height / 2 }, side };
+      return { point: { x: left + width, y: alongY }, side };
     case Position.Bottom:
-      return { point: { x: x + width / 2, y: y + height }, side };
+      return { point: { x: alongX, y: top + height }, side };
     case Position.Left:
-      return { point: { x, y: y + height / 2 }, side };
+      return { point: { x: left, y: alongY }, side };
   }
 };
 
@@ -89,7 +106,8 @@ const anchorOf = (
  * The handle an edge end attaches to. A named handle (the Use-Def view's
  * per-operand ports) resolves to that port's own bounds and `Position`; an
  * unnamed one takes the node's first handle of that type, exactly as React
- * Flow does. `null` when React Flow has not measured the handles yet.
+ * Flow does. `null` when React Flow has not measured the handles — or the node
+ * itself — yet.
  */
 const handleAnchor = (
   node: InternalNode,


### PR DESCRIPTION
Closes #93.

## What changed

`useEdgeRoutes.anchorOf` derived a routed edge's endpoint from the handle element's measured bounds (`node.internals.handleBounds`), while `routeEdges` treats the node's measured rect as the obstacle. A handle is positioned from the **padding** box, so the node's 1 px border pushed every handle inside the rect and the two geometries disagreed by a pixel: the `nodeMargin`-pushed point landed 1 px inside the node's own inflated boundary, and the search had to step that pixel before it could turn, leaving a pair of bends whose corner radius had collapsed to 0.5 px at every departure and arrival.

`anchorOf` now takes the coordinate **across** a side from the node's measured rect (`rect.y` for `top`, `rect.y + rect.height` for `bottom`, and correspondingly for `left` / `right`) and keeps the coordinate **along** the side from the handle, so per-operand ports — the Use-Def view today, #67's CFG successor ports later — still leave from their own offsets. The pushed endpoint then coincides with the node's inflated boundary by construction, whatever the handle's CSS does.

`anchorOf` used to mirror React Flow's `getHandlePosition`, which is how the inset was inherited; it now deliberately does not, and its comment says so. It also returns `null` for a node React Flow has not measured yet — such a node is omitted from the rects too, so its edges were not drawn that frame either way.

`docs/internal/specs/graph-view.md` §4 gains a bullet stating that a routed edge's endpoints are node-boundary anchors rather than handle-box anchors, and why.

## Verification

Measured in a headless Chromium (1600×1000 viewport, `npm run dev`, default LLVM-IR CFG example, 2026-08-10) by reading the rendered `path` `d` attributes back against the live node rects. A corner counts as turning only when its neighbours are not collinear.

| | before | after |
| --- | --- | --- |
| endpoints not on their node's rect boundary | 18 / 20 | 0 |
| turning corners below 3 px | 6 (all 0.5 px) | 0 (smallest 3 px) |

The Use-Def view was checked the same way: no endpoint off the rect boundary, and per-operand ports keep distinct along-side offsets on a shared node (e.g. `func_func_ud_9_i0` receives arrivals at x = 695 and x = 785, both on its rect top y = 380).

`npm run test:run` (571 passed), `npm run format` and `npm run lint` all pass.

## Notes for the reviewer

- This is independent of #89 (integer-lattice quantization, landed in #100), but the two together are what clears the example: quantization removed the sub-pixel class, this removes the 1 px class. The numbers above are with both applied.
- The hook remains untested by the suite, as `specs/graph-view.md` §4 already records — the measurement above was run out of band, as with the frame-budget figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)