### PR TITLE
fix(graph-view): derive the bend radius from the router's node margin

### DIFF
--- a/docs/internal/specs/graph-view.md
+++ b/docs/internal/specs/graph-view.md
@@ -156,6 +156,40 @@ all (#88). Until those land, an overlap in the rendered graph means nothing.
   check of this budget.
 - **Rendering:** `RoutedEdge` draws the returned points as an orthogonal polyline with
   **rounded corners**; edge labels (phi) render at the polyline's arc-length midpoint.
+- **The bend radius is derived from the router's node margin, not chosen.** Two
+  inequalities relate it to the spacing constants around it:
+
+  ```
+  2 · bendRadius ≤ nodeMargin
+  2 · nodeMargin + 2 · bendRadius ≤ ELK node spacing
+  ```
+
+  The first is what makes a bend at a route's first and last corner drawable at full size:
+  the contract's exact-endpoints rule (`contracts/edge-routing.md`) means the pushed point
+  survives as `points[1]` and as the second-to-last point, so every route's end segments are
+  exactly `nodeMargin` long and a corner there can consume at most half of that. The second
+  is the same statement for the interior: the corridor between two nodes' clearance bands is
+  `spacing − 2 × nodeMargin` wide, and one bend needs `2 × bendRadius` of it.
+
+  Both are solved by **`bendRadius = nodeMargin / 2`** — 6 px at the default `nodeMargin` of
+  12, requiring 36 px of node spacing, which every configured ELK value already exceeds (40
+  / 50 by default, 40 / 60 in the Use-Def view). Holding the radius at 8 instead would
+  demand `nodeMargin = 16` and 48 px of spacing, above the configured `elk.spacing.nodeNode`,
+  and would widen the clearance band that already closes corridors between unrelated rects
+  ("Known limitations" below); shrinking the radius is the safer of the two directions. The
+  radius is therefore computed from the router's exported margin
+  (`src/components/Graph/roundedPath.ts`), never restated as a literal of its own; it moves
+  into the shared spacing module once #91 introduces one.
+
+  The shrink-to-fit in `roundedPath` (`min(bendRadius, inLen / 2, outLen / 2)`) stays as the
+  safety valve, and after this it engages only where the layout genuinely leaves a corridor
+  narrower than `2 × bendRadius` — today, where ELK lays out on estimated rather than
+  measured sizes and delivers less gap than it was asked for (#91). What is deliberately
+  _not_ done is making the router guarantee a minimum run length so the radius is always
+  nominal: that would put a stroke-appearance constraint into the topology search and could
+  make an edge unroutable for a cosmetic reason. Clearance and topology are the router's
+  concern; stroke appearance is not.
+
 - **Back edges:** after layout, an edge is flagged `data.isBackEdge` when it is a self-loop
   or its target node lies entirely above its source node. The flag is **structural** —
   decided once from ELK's placement geometry and never re-derived from live rects — so
@@ -179,14 +213,15 @@ all (#88). Until those land, an overlap in the rendered graph means nothing.
   source), LLVM/Mermaid at the **end**.
 
 > Pinned by: `src/utils/__tests__/edgeRouter.test.ts` (the contract's guarantees),
-> `src/utils/__tests__/layout.test.ts` (back-edge / self-loop flagging, no geometry stored
-> on edges), `src/hooks/__tests__/useGraphData.test.ts` (back-edge flag inherited on
-> content-only updates), `src/utils/__tests__/converter.test.ts` (dashed chain/glue,
-> markerStart/markerEnd).
+> `src/components/Graph/__tests__/roundedPath.test.ts` (the bend radius and its derivation
+> from the node margin), `src/utils/__tests__/layout.test.ts` (back-edge / self-loop
+> flagging, no geometry stored on edges), `src/hooks/__tests__/useGraphData.test.ts`
+> (back-edge flag inherited on content-only updates),
+> `src/utils/__tests__/converter.test.ts` (dashed chain/glue, markerStart/markerEnd).
 >
 > _(observed, untested)_: live-rect tracking while dragging and after content edits, the
-> one-pass `useEdgeRoutes` hook and its context, the unmeasured-node omission, the rounded
-> corners, the midpoint label placement, the accent color, and the drag-time
+> one-pass `useEdgeRoutes` hook and its context, the unmeasured-node omission, the midpoint
+> label placement, the accent color, and the drag-time
 > throttling/incident-edges pass. The frame-budget figures are measured out of band, not by
 > the test suite. The overlap semantics are _specified, unimplemented_ — a different marker
 > from the two above: there is nothing to observe and nothing to pin until #86–#88 land.

--- a/src/components/Graph/RoutedEdge.tsx
+++ b/src/components/Graph/RoutedEdge.tsx
@@ -1,5 +1,6 @@
 import { BaseEdge, type Edge, type EdgeProps } from "@xyflow/react";
 import { useEdgeRoute } from "../../hooks/useEdgeRoutes";
+import { roundedPath } from "./roundedPath";
 
 /**
  * Data the layout attaches to every routed edge (specs/graph-view.md §4).
@@ -14,38 +15,6 @@ export interface RoutedEdgeData extends Record<string, unknown> {
 }
 
 export type RoutedEdgeType = Edge<RoutedEdgeData, "routed">;
-
-/** Corner radius of routed orthogonal bends, px. */
-const BEND_RADIUS = 8;
-
-/**
- * Rounded-corner path through an orthogonal polyline. Consecutive duplicate
- * points are skipped; the radius shrinks to fit short segments.
- */
-const roundedPath = (points: { x: number; y: number }[]): string => {
-  if (points.length === 0) return "";
-  const parts = [`M ${String(points[0].x)} ${String(points[0].y)}`];
-  for (let i = 1; i < points.length - 1; i++) {
-    const prev = points[i - 1];
-    const corner = points[i];
-    const next = points[i + 1];
-    const inLen = Math.hypot(corner.x - prev.x, corner.y - prev.y);
-    const outLen = Math.hypot(next.x - corner.x, next.y - corner.y);
-    if (inLen === 0 || outLen === 0) continue;
-    const radius = Math.min(BEND_RADIUS, inLen / 2, outLen / 2);
-    const inX = corner.x - ((corner.x - prev.x) / inLen) * radius;
-    const inY = corner.y - ((corner.y - prev.y) / inLen) * radius;
-    const outX = corner.x + ((next.x - corner.x) / outLen) * radius;
-    const outY = corner.y + ((next.y - corner.y) / outLen) * radius;
-    parts.push(
-      `L ${String(inX)} ${String(inY)}`,
-      `Q ${String(corner.x)} ${String(corner.y)} ${String(outX)} ${String(outY)}`,
-    );
-  }
-  const last = points[points.length - 1];
-  parts.push(`L ${String(last.x)} ${String(last.y)}`);
-  return parts.join(" ");
-};
 
 /** Midpoint along the polyline (by arc length), for label placement. */
 const midpoint = (points: { x: number; y: number }[]) => {

--- a/src/components/Graph/__tests__/roundedPath.test.ts
+++ b/src/components/Graph/__tests__/roundedPath.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { BEND_RADIUS, roundedPath } from "../roundedPath";
+import { DEFAULT_NODE_MARGIN } from "../../../utils/edgeRouter";
+
+/**
+ * The bend radius is derived from the router's node margin rather than chosen
+ * (specs/graph-view.md §4). What that buys is checked here on the shape the
+ * router actually emits: a polyline whose first and last segments are exactly
+ * `nodeMargin` long, because the contract keeps the pushed endpoint as
+ * `points[1]` and as the second-to-last point. Every corner on such a route
+ * has to draw at the nominal radius; the shrink-to-fit may only engage where
+ * the layout leaves a corridor narrower than `2 × BEND_RADIUS`.
+ */
+
+/**
+ * The drawn radius of every corner in a path, in order. `roundedPath` emits
+ * one `L … Q …` pair per corner, where the `L` lands `radius` px short of the
+ * corner and the `Q` control point *is* the corner, so the distance between
+ * the two is the radius the corner was drawn at.
+ */
+const drawnRadii = (path: string): number[] => {
+  const radii: number[] = [];
+  const pattern = /L ([-\d.]+) ([-\d.]+) Q ([-\d.]+) ([-\d.]+)/g;
+  for (const match of path.matchAll(pattern)) {
+    const [entryX, entryY, cornerX, cornerY] = match.slice(1).map(Number);
+    radii.push(Math.hypot(cornerX - entryX, cornerY - entryY));
+  }
+  return radii;
+};
+
+describe("BEND_RADIUS", () => {
+  it("is half the router's node margin", () => {
+    expect(BEND_RADIUS).toBe(DEFAULT_NODE_MARGIN / 2);
+  });
+
+  it("leaves a full-radius bend room in a route's mandatory endpoint stub", () => {
+    expect(2 * BEND_RADIUS).toBeLessThanOrEqual(DEFAULT_NODE_MARGIN);
+  });
+
+  it("leaves a full-radius bend room in the corridor the ELK spacing reserves", () => {
+    // The narrowest node spacing any mode configures (layout.ts's default
+    // `elk.spacing.nodeNode`, matched by the Use-Def override). The corridor
+    // between two nodes' clearance bands is that minus both margins.
+    const narrowestNodeSpacing = 40;
+    expect(2 * DEFAULT_NODE_MARGIN + 2 * BEND_RADIUS).toBeLessThanOrEqual(
+      narrowestNodeSpacing,
+    );
+  });
+});
+
+describe("roundedPath", () => {
+  it("draws every corner of a router-shaped route at the nominal radius", () => {
+    // Leaves a node's bottom edge at (0, 100), crosses a 16 px corridor
+    // (`elk.spacing.nodeNode` 40 minus both clearance bands), and arrives on a
+    // node's top edge at (120, 140). Both end segments are exactly
+    // `DEFAULT_NODE_MARGIN` long, as the router guarantees.
+    const points = [
+      { x: 0, y: 100 },
+      { x: 0, y: 112 },
+      { x: 60, y: 112 },
+      { x: 60, y: 128 },
+      { x: 120, y: 128 },
+      { x: 120, y: 140 },
+    ];
+
+    expect(drawnRadii(roundedPath(points))).toEqual([
+      BEND_RADIUS,
+      BEND_RADIUS,
+      BEND_RADIUS,
+      BEND_RADIUS,
+    ]);
+  });
+
+  it("shrinks to fit only where the corridor is narrower than two radii", () => {
+    // A 6 px corridor — what ELK leaves when it lays out on an estimated node
+    // size smaller than the measured one (#91), not something this radius can
+    // avoid.
+    const points = [
+      { x: 0, y: 0 },
+      { x: 40, y: 0 },
+      { x: 40, y: 6 },
+      { x: 80, y: 6 },
+    ];
+
+    expect(drawnRadii(roundedPath(points))).toEqual([3, 3]);
+  });
+
+  it("skips a corner that repeats its neighbour's position", () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 0, y: 0 },
+      { x: 0, y: 40 },
+    ];
+
+    expect(drawnRadii(roundedPath(points))).toEqual([]);
+  });
+});

--- a/src/components/Graph/roundedPath.ts
+++ b/src/components/Graph/roundedPath.ts
@@ -1,0 +1,43 @@
+import { DEFAULT_NODE_MARGIN } from "../../utils/edgeRouter";
+
+/**
+ * Corner radius of routed orthogonal bends, px — derived, not chosen
+ * (`specs/graph-view.md` §4). A route's first and last segments are exactly
+ * `nodeMargin` long, because the contract keeps the pushed endpoint as
+ * `points[1]` and as the second-to-last point, so a bend there can consume at
+ * most half of that: `2 · bendRadius ≤ nodeMargin`. The interior form of the
+ * same statement, `2 · nodeMargin + 2 · bendRadius ≤ ELK node spacing`, holds
+ * for every configured spacing at this radius. Any literal here instead would
+ * be a promise the geometry cannot keep.
+ */
+export const BEND_RADIUS = DEFAULT_NODE_MARGIN / 2;
+
+/**
+ * Rounded-corner path through an orthogonal polyline. Consecutive duplicate
+ * points are skipped; the radius shrinks to fit short segments — the safety
+ * valve for corridors narrower than the relation above demands.
+ */
+export const roundedPath = (points: { x: number; y: number }[]): string => {
+  if (points.length === 0) return "";
+  const parts = [`M ${String(points[0].x)} ${String(points[0].y)}`];
+  for (let i = 1; i < points.length - 1; i++) {
+    const prev = points[i - 1];
+    const corner = points[i];
+    const next = points[i + 1];
+    const inLen = Math.hypot(corner.x - prev.x, corner.y - prev.y);
+    const outLen = Math.hypot(next.x - corner.x, next.y - corner.y);
+    if (inLen === 0 || outLen === 0) continue;
+    const radius = Math.min(BEND_RADIUS, inLen / 2, outLen / 2);
+    const inX = corner.x - ((corner.x - prev.x) / inLen) * radius;
+    const inY = corner.y - ((corner.y - prev.y) / inLen) * radius;
+    const outX = corner.x + ((next.x - corner.x) / outLen) * radius;
+    const outY = corner.y + ((next.y - corner.y) / outLen) * radius;
+    parts.push(
+      `L ${String(inX)} ${String(inY)}`,
+      `Q ${String(corner.x)} ${String(corner.y)} ${String(outX)} ${String(outY)}`,
+    );
+  }
+  const last = points[points.length - 1];
+  parts.push(`L ${String(last.x)} ${String(last.y)}`);
+  return parts.join(" ");
+};


### PR DESCRIPTION
Closes #94.

## What changed

The renderer chose `BEND_RADIUS = 8` while the router guarantees that a route's first and last segments are exactly `nodeMargin = 12` long — the pushed endpoint survives as `points[1]` and as the second-to-last point — so a bend at either end could never draw wider than 6 px. The nominal 8 was an unreachable promise for every edge that turns as it leaves or enters a node, and the graph showed two corner radii side by side with no meaning attached to the difference.

The radius is now derived from the relation rather than chosen:

```
2 · bendRadius ≤ nodeMargin
2 · nodeMargin + 2 · bendRadius ≤ ELK node spacing
```

The first makes the mandatory endpoint stub long enough for a full-radius bend; the second does the same for the corridor between two nodes' clearance bands. With `nodeMargin = 12` that gives `bendRadius = 6` and requires 36 px of spacing, below every configured ELK value (40 / 50 by default, 40 / 60 in the Use-Def view). Holding the radius at 8 would instead demand `nodeMargin = 16` and 48 px of spacing, above the configured `elk.spacing.nodeNode`, and would widen the clearance band that already closes corridors between unrelated rects — shrinking the radius is the safer direction.

- `docs/internal/specs/graph-view.md` §4 records both inequalities and the reasoning, and the "Pinned by" note now covers the rounded corners.
- `BEND_RADIUS` and `roundedPath` move to `src/components/Graph/roundedPath.ts`; `RoutedEdge.tsx` imports them and holds no radius literal. The move is what `react-refresh/only-export-components` requires — a component file may not export constants — and `roundedPath`'s logic is unchanged.
- New `src/components/Graph/__tests__/roundedPath.test.ts` pins the derivation, both inequalities, a nominal-radius route in the shape the router emits (12 px end stubs, 16 px corridor), the shrink-to-fit below `2 · bendRadius`, and the duplicate-point skip.

The shrink-to-fit stays as the safety valve. Deliberately not done: making the router guarantee a minimum run length so the radius is always nominal — that would put a stroke-appearance constraint into the topology search and could make an edge unroutable for a cosmetic reason.

## Verification

`npm run test:run` (583 passed), `npm run format`, `npm run lint` all clean.

Measured in the running app (2026-08-10, default LLVM-IR CFG, `npm run dev`), reading the `d` attribute of every edge path and counting only corners that actually turn:

| | 8 px | 6 px | 3 px |
| --- | --- | --- | --- |
| before | 12 | 6 | 2 |
| after | 0 | 18 | 2 |

The two remaining 3 px corners are on `entry → 4` and `entry → 7`, where ELK lays out on an estimated node size smaller than the measured one and leaves a 6 px corridor. That class is #91's, not this change's, and the issue scopes it out explicitly.

## Note for the reviewer

The radius belongs in the shared spacing module #91 introduces; until then it lives next to `roundedPath` and imports `DEFAULT_NODE_MARGIN` from the router. The second inequality above is the relation #91 has to preserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)