### PR TITLE
feat: make IR mode parse contract async

### DIFF
--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -8,7 +8,7 @@ One-page orientation for the codebase. Read this first; follow the links for the
 flowchart TD
   Editor["CodeEditor (Monaco + Shiki)"] -->|"onChange(text)"| Workspace["useIRWorkspace<br/>(mode state + 750ms debounce)"]
   Registry["IR mode registry (src/irModes)<br/>parser / defaultCode / editorLanguage /<br/>nodeTypes / edgeBuilder / layoutOptions"] -.->|"active mode"| Workspace
-  Workspace -->|"mode.parse(code)"| Parser["Mode-specific parser (src/parser)"]
+  Workspace -->|"await mode.parse(code)"| Parser["Mode-specific parser (src/parser)"]
   Parser -->|AST| Builder["graphBuilder (src/graphBuilder)"]
   Builder -->|GraphData| GraphHook["useGraphData<br/>(topology signature,<br/>position preservation)"]
   GraphHook -->|"getLayoutedElements"| Layout["layout.ts (ELK placement) +<br/>converter.ts (sizing)"]
@@ -20,9 +20,12 @@ flowchart TD
 ```
 
 - Typing in the editor updates `code` state; after a 750 ms debounce, the active mode's
-  `parse()` runs. Parse errors are caught and shown in the editor panel's status footer; the
+  `parse()` runs. Parse failures are caught and shown in the editor panel's status footer; the
   previous graph stays.
 - `parse()` is parser + graphBuilder composed: text → AST → `GraphData` (plain, React-free).
+  It is **async** (`contracts/ir-mode-registry.md`, "Parsing is asynchronous"): a parse whose
+  code/mode/view changed while it was in flight is discarded, so a slow parse can never
+  overwrite a newer one.
 - `useGraphData` decides between a full (async) ELK re-layout (topology changed) and a
   position-preserving content update (same topology). See `specs/graph-view.md`.
 - Layout converts `GraphData` to React Flow nodes/edges, estimating node dimensions from

--- a/docs/internal/contracts/ir-mode-registry.md
+++ b/docs/internal/contracts/ir-mode-registry.md
@@ -15,7 +15,7 @@ interface IRModeDefinition {
   label: string; // editor-panel display label, e.g. "LLVM-IR"
   editorLanguage: string; // Monaco language id registered in CodeEditor
   defaultCode: string; // code shown when the mode is selected
-  parse: (code: string) => GraphData; // text -> graph, throws Error on invalid input
+  parse: (code: string) => Promise<GraphData>; // text -> graph, rejects with Error on invalid input
   nodeTypes: Record<string, ComponentType<NodeProps>>; // this mode's React Flow node renderers
   edgeBuilder: IREdgeBuilder; // see below
   layoutOptions?: Record<string, string>; // ELK layout options, e.g. layer spacing
@@ -23,6 +23,32 @@ interface IRModeDefinition {
   views?: IRViewDefinition[]; // optional alternative projections — see "Views" below
 }
 ```
+
+## Parsing is asynchronous
+
+`parse` returns a promise because a mode's parser may need to do async work before it can
+produce a graph — Mermaid's upstream parser lazy-loads its diagram definitions
+(`specs/mermaid.md`), and nothing in this contract should force a parser to be synchronous
+just because two of the three current ones happen to be.
+
+The rules:
+
+- **Invalid input rejects with an `Error`.** A parser that detects the problem synchronously
+  may simply `throw` inside its async function — that is the same thing. Callers see one
+  failure shape.
+- **The parser layer stays synchronous where the IR allows it.** `src/parser/**` exports the
+  natural shape for its grammar; a mode whose parser is synchronous adapts it in its registry
+  entry (`const parseCfg = async (code: string) => parseLLVM(code)`) rather than making the
+  parser lie about being async.
+- **Stale results are discarded, not applied.** `useIRWorkspace` parses in a debounced effect;
+  when the code, mode, or view changes while a parse is in flight, the effect's cleanup marks
+  that parse cancelled and neither its graph nor its error reaches state. A slow parse can
+  therefore never overwrite the result of a newer one. This is the parse-stage counterpart of
+  the layout generation counter in `useGraphData` (`specs/graph-view.md` §2); the two stages
+  guard independently.
+- **`parse` is not cancellable.** It takes no `AbortSignal` — the caller drops the result. No
+  current parser can be interrupted mid-run, and adding a signal nothing honors would be
+  indirection without a payer.
 
 ## Views
 
@@ -35,7 +61,7 @@ same editor language, same default code, same parser front-end, different
 interface IRViewDefinition {
   key: string; // stable, e.g. "cfg", "use-def"
   label: string; // toggle label, e.g. "CFG"
-  parse: (code: string) => GraphData; // same throw-on-invalid rule as the mode's parse
+  parse: (code: string) => Promise<GraphData>; // same reject-on-invalid rule as the mode's parse
   edgeBuilder?: IREdgeBuilder; // defaults to the mode's edgeBuilder
   layoutOptions?: Record<string, string>; // defaults to the mode's layoutOptions
   bundleOf?: (edge: GraphEdge) => string | undefined; // defaults to the mode's bundleOf
@@ -48,7 +74,9 @@ Rules:
   its top-level `parse`/`edgeBuilder`/`layoutOptions`/`bundleOf`.
 - When present, `views` has ≥ 2 entries and `views[0]` is the **default view**;
   it must behave identically to the mode's top-level fields (share the same
-  function references — don't duplicate logic).
+  function references — don't duplicate logic). When `parse` is an async adapter
+  around a synchronous parser, that adapter is a single module-level `const` used
+  by both sites, not two `async` arrows that happen to have the same body.
 - `useIRWorkspace` owns the active view key. Switching **views keeps the editor
   code** (that is the point of views); switching **modes resets** the view to the
   default and replaces the code with `defaultCode`.
@@ -130,8 +158,10 @@ implementation land with #88; the router-side guarantee it feeds lands with #86.
 
 ## What consumes the registry
 
-- `App.tsx` / `useIRWorkspace` — looks up the active mode by key, calls `mode.parse(code)`,
-  uses `mode.defaultCode` on mode switch and `mode.editorLanguage` for the editor.
+- `App.tsx` / `useIRWorkspace` — looks up the active mode by key, awaits `mode.parse(code)`
+  in the debounced parse effect (discarding the result if it is stale, see "Parsing is
+  asynchronous"), uses `mode.defaultCode` on mode switch and `mode.editorLanguage` for the
+  editor.
 - `useGraphData` — takes an `IRLayoutBehavior` into `updateGraph(graph, behavior)` /
   `resetLayout()`, so layout, edge-building and bundling are mode- (or view-) driven rather
   than branching by string.
@@ -154,9 +184,9 @@ No other file should need to change. If it does, that's a signal the registry co
 ## Known behavior difference not covered by this contract
 
 SelectionDAG's `parse` (`parseSelectionDAGToGraphData`) tolerates unparseable lines by treating
-them as comments rather than throwing, because real SelectionDAG dumps mix a free-text header line
+them as comments rather than failing, because real SelectionDAG dumps mix a free-text header line
 with the actual `tN: ... = ...` node lines. This is intentional per-line tolerance, not a violation
-of the "`parse` throws `Error` on invalid input" rule above — the SelectionDAG grammar's unit of
-parsing is a line, and a "failure" for one line does not fail the whole `parse` call. LLVM and
-Mermaid parse the entire input as one document and do throw on failure. See
+of the "`parse` rejects with `Error` on invalid input" rule above — the SelectionDAG grammar's unit
+of parsing is a line, and a "failure" for one line does not fail the whole `parse` call. LLVM and
+Mermaid parse the entire input as one document and do fail on invalid input. See
 `src/parser/selectionDAG.ts` for the code-level comment.

--- a/src/hooks/__tests__/useIRWorkspace.test.ts
+++ b/src/hooks/__tests__/useIRWorkspace.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { GraphData } from "../../types/graph";
+
+// The registry contract makes `parse` async and leaves discarding stale results
+// to the caller (contracts/ir-mode-registry.md, "Parsing is asynchronous").
+// These tests stand in a registry whose parses never settle on their own, so a
+// slow parse can be made to land *after* a newer one — the case a real parser
+// only hits under a race.
+const { modeA, modeB, updateGraph, graphState } = vi.hoisted(() => {
+  interface Pending {
+    code: string;
+    resolve: (graph: unknown) => void;
+    reject: (error: unknown) => void;
+  }
+
+  const makeMode = (key: string, defaultCode: string) => {
+    const pending: Pending[] = [];
+    const parse = vi.fn(
+      (code: string) =>
+        new Promise((resolve, reject) => {
+          pending.push({ code, resolve, reject });
+        }),
+    );
+    return {
+      pending,
+      parse,
+      definition: {
+        key,
+        label: key,
+        editorLanguage: "plaintext",
+        defaultCode,
+        parse,
+        nodeTypes: {},
+        edgeBuilder: { buildReactFlowEdge: (edge: unknown) => edge },
+      },
+    };
+  };
+
+  const modeA = makeMode("a", "code-a");
+  const modeB = makeMode("b", "code-b");
+  const updateGraph = vi.fn();
+
+  return {
+    modeA,
+    modeB,
+    updateGraph,
+    graphState: {
+      nodes: [],
+      edges: [],
+      onNodesChange: vi.fn(),
+      onEdgesChange: vi.fn(),
+      setNodes: vi.fn(),
+      setEdges: vi.fn(),
+      updateGraph,
+      resetLayout: vi.fn(),
+    },
+  };
+});
+
+vi.mock("../../irModes", () => ({
+  IR_MODES: { a: modeA.definition, b: modeB.definition },
+  IR_MODE_LIST: [modeA.definition, modeB.definition],
+  DEFAULT_IR_MODE_KEY: "a",
+}));
+
+vi.mock("../useGraphData", () => ({ useGraphData: () => graphState }));
+
+const { useIRWorkspace } = await import("../useIRWorkspace");
+
+const PARSE_DEBOUNCE_MS = 750;
+
+function graph(id: string): GraphData {
+  return { direction: "TD", nodes: [{ id, label: id }], edges: [] };
+}
+
+/** Run the debounce timer out, so the pending parse for the current code starts. */
+async function runDebounce() {
+  await act(async () => {
+    vi.advanceTimersByTime(PARSE_DEBOUNCE_MS);
+  });
+}
+
+/** Settle hand-held parse promises and let their continuations run. */
+async function settle(fn: () => void) {
+  await act(async () => {
+    fn();
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  modeA.pending.length = 0;
+  modeB.pending.length = 0;
+  modeA.parse.mockClear();
+  modeB.parse.mockClear();
+  updateGraph.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useIRWorkspace parse effect", () => {
+  it("applies a parse that resolves while it is still current", async () => {
+    const { result } = renderHook(() => useIRWorkspace());
+    await runDebounce();
+
+    expect(modeA.parse).toHaveBeenCalledWith("code-a");
+    await settle(() => modeA.pending[0].resolve(graph("n1")));
+
+    expect(updateGraph).toHaveBeenCalledTimes(1);
+    expect(updateGraph.mock.calls[0][0]).toEqual(graph("n1"));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("reports a rejected parse as the error message", async () => {
+    const { result } = renderHook(() => useIRWorkspace());
+    await runDebounce();
+
+    await settle(() => modeA.pending[0].reject(new Error("bad syntax")));
+
+    expect(result.current.error).toBe("bad syntax");
+    expect(updateGraph).not.toHaveBeenCalled();
+  });
+
+  it("discards a parse whose code changed while it was in flight", async () => {
+    const { result } = renderHook(() => useIRWorkspace());
+    await runDebounce();
+
+    act(() => result.current.setCode("code-a2"));
+    await runDebounce();
+
+    expect(modeA.pending).toHaveLength(2);
+    // The newer parse lands first, then the stale one — the order a slow
+    // parser produces and the reason a plain "last write wins" is not enough.
+    await settle(() => modeA.pending[1].resolve(graph("new")));
+    await settle(() => modeA.pending[0].resolve(graph("stale")));
+
+    expect(updateGraph).toHaveBeenCalledTimes(1);
+    expect(updateGraph.mock.calls[0][0]).toEqual(graph("new"));
+  });
+
+  it("discards a parse whose mode changed while it was in flight", async () => {
+    const { result } = renderHook(() => useIRWorkspace());
+    await runDebounce();
+
+    act(() => result.current.changeMode("b" as never));
+    await runDebounce();
+
+    expect(modeB.parse).toHaveBeenCalledWith("code-b");
+    await settle(() => modeB.pending[0].resolve(graph("from-b")));
+    await settle(() => modeA.pending[0].resolve(graph("from-a")));
+
+    expect(updateGraph).toHaveBeenCalledTimes(1);
+    expect(updateGraph.mock.calls[0][0]).toEqual(graph("from-b"));
+  });
+
+  it("does not let a stale rejection overwrite a newer success", async () => {
+    const { result } = renderHook(() => useIRWorkspace());
+    await runDebounce();
+
+    act(() => result.current.setCode("code-a2"));
+    await runDebounce();
+
+    await settle(() => modeA.pending[1].resolve(graph("new")));
+    await settle(() => modeA.pending[0].reject(new Error("stale failure")));
+
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/hooks/useIRWorkspace.ts
+++ b/src/hooks/useIRWorkspace.ts
@@ -33,22 +33,36 @@ export function useIRWorkspace() {
     resetLayout,
   } = useGraphData();
 
+  // Parsing is async (contracts/ir-mode-registry.md, "Parsing is
+  // asynchronous"). The effect's deps cover every input a parse depends on, so
+  // a `cancelled` flag set by the cleanup is enough to keep a parse that is
+  // still in flight when the code/mode/view changes from landing: neither its
+  // graph nor its error reaches state. Layout staleness is guarded separately,
+  // by useGraphData's generation counter.
   useEffect(() => {
+    let cancelled = false;
     const timer = setTimeout(() => {
-      try {
-        const parse = activeView?.parse ?? mode.parse;
-        const graph = parse(code);
-        updateGraph(graph, {
-          edgeBuilder: activeView?.edgeBuilder ?? mode.edgeBuilder,
-          layoutOptions: activeView?.layoutOptions ?? mode.layoutOptions,
-        });
-        setError(null);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Unknown error");
-      }
+      void (async () => {
+        try {
+          const parse = activeView?.parse ?? mode.parse;
+          const graph = await parse(code);
+          if (cancelled) return;
+          updateGraph(graph, {
+            edgeBuilder: activeView?.edgeBuilder ?? mode.edgeBuilder,
+            layoutOptions: activeView?.layoutOptions ?? mode.layoutOptions,
+          });
+          setError(null);
+        } catch (err) {
+          if (cancelled) return;
+          setError(err instanceof Error ? err.message : "Unknown error");
+        }
+      })();
     }, PARSE_DEBOUNCE_MS);
 
-    return () => clearTimeout(timer);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   }, [code, mode, activeView, updateGraph]);
 
   const changeMode = useCallback((newModeKey: IRModeKey) => {

--- a/src/irModes/llvmMode.ts
+++ b/src/irModes/llvmMode.ts
@@ -43,12 +43,18 @@ define i32 @func(i32 %0, i32 %1, i1  %2) {
 }
 `;
 
+// The LLVM parsers are synchronous; the registry contract is async. Adapt them
+// here rather than making the parser layer lie about being async. Each adapter
+// is a single const because views[0] must share the top-level parse's identity.
+const parseCfg = async (code: string) => parseLLVM(code);
+const parseUseDef = async (code: string) => parseLLVMUseDef(code);
+
 export const llvmMode = {
   key: "llvm-ir" as const,
   label: "LLVM-IR",
   editorLanguage: "llvm",
   defaultCode: DEFAULT_CODE,
-  parse: parseLLVM,
+  parse: parseCfg,
   nodeTypes: {
     llvmBasicBlock: LLVMBasicBlockNode,
     llvmFunctionHeader: LLVMFunctionHeaderNode,
@@ -64,11 +70,11 @@ export const llvmMode = {
   // views[0] shares parse/edgeBuilder with the top-level fields per the
   // registry contract ("Views"): it IS the default view.
   views: [
-    { key: "cfg", label: "CFG", parse: parseLLVM },
+    { key: "cfg", label: "CFG", parse: parseCfg },
     {
       key: "use-def",
       label: "Use-Def",
-      parse: parseLLVMUseDef,
+      parse: parseUseDef,
       layoutOptions: {
         "elk.layered.spacing.nodeNodeBetweenLayers": "60",
         "elk.spacing.nodeNode": "40",

--- a/src/irModes/mermaidMode.ts
+++ b/src/irModes/mermaidMode.ts
@@ -11,12 +11,16 @@ const DEFAULT_CODE = `graph TD
   D -->|No| C
 `;
 
+// parseMermaid is synchronous today; the registry contract is async. See
+// llvmMode.ts for why the adapter lives here and not in the parser layer.
+const parse = async (code: string) => parseMermaid(code);
+
 export const mermaidMode = {
   key: "mermaid" as const,
   label: "Mermaid",
   editorLanguage: "mermaid",
   defaultCode: DEFAULT_CODE,
-  parse: parseMermaid,
+  parse,
   nodeTypes: {
     mermaidNode: MermaidNode,
   },

--- a/src/irModes/selectionDAGMode.ts
+++ b/src/irModes/selectionDAGMode.ts
@@ -22,12 +22,16 @@ SelectionDAG has 22 nodes:
   t22: ch = RISCVISD::RET_GLUE t21, Register:i64 $x10, t21:1
 `;
 
+// parseSelectionDAGToGraphData is synchronous; the registry contract is async.
+// See llvmMode.ts for why the adapter lives here and not in the parser layer.
+const parse = async (code: string) => parseSelectionDAGToGraphData(code);
+
 export const selectionDAGMode = {
   key: "selectionDAG" as const,
   label: "SelectionDAG",
   editorLanguage: "llvm",
   defaultCode: DEFAULT_CODE,
-  parse: parseSelectionDAGToGraphData,
+  parse,
   nodeTypes: {
     selectionDAGNode: SelectionDAGNode,
   },

--- a/src/irModes/types.ts
+++ b/src/irModes/types.ts
@@ -18,9 +18,12 @@ export interface IRModeDefinition {
   editorLanguage: string;
   /** Code shown in the editor when this mode is selected. */
   defaultCode: string;
-  /** Text -> graph. Throws Error on invalid input (see the registry contract
-   * for SelectionDAG's per-line tolerance, which is not an exception to this). */
-  parse: (code: string) => GraphData;
+  /** Text -> graph. Rejects with an Error on invalid input (see the registry
+   * contract for SelectionDAG's per-line tolerance, which is not an exception
+   * to this). Async because a parser may need to load before it can parse; a
+   * synchronous parser is adapted here, not rewritten. Stale results are
+   * discarded by the caller — see the contract, "Parsing is asynchronous". */
+  parse: (code: string) => Promise<GraphData>;
   /** This mode's React Flow node renderers, keyed by the camelCase nodeType.
    * Covers every view's renderers (GraphViewer merges per mode, not per view). */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -44,8 +47,8 @@ export interface IRViewDefinition {
   key: string;
   /** Toggle label, e.g. "CFG". */
   label: string;
-  /** Text -> graph; same throw-on-invalid rule as the mode's parse. */
-  parse: (code: string) => GraphData;
+  /** Text -> graph; same reject-on-invalid rule as the mode's parse. */
+  parse: (code: string) => Promise<GraphData>;
   /** Defaults to the mode's edgeBuilder. */
   edgeBuilder?: IREdgeBuilder;
   /** Defaults to the mode's layoutOptions. */


### PR DESCRIPTION
Closes #79. Part of #78 (full mermaid flowchart support via the upstream parser).

The IR mode registry contract defined `parse` as `(code) => GraphData`, called synchronously from the debounced parse effect in `useIRWorkspace`. The upstream mermaid parser is async — `Diagram.fromText` lazy-loads diagram definitions — so a mermaid mode built on it could not implement the contract at all. `parse` is now `(code) => Promise<GraphData>` for modes and views alike. This is also a prerequisite for moving ELK layout off the main thread (#69).

No user-visible behavior change.

## What changed

**Contract** (`docs/internal/contracts/ir-mode-registry.md`, `src/irModes/types.ts`)

`IRModeDefinition.parse` and `IRViewDefinition.parse` return a promise, and invalid input now *rejects* with an `Error` rather than throwing. A new "Parsing is asynchronous" section records the four rules the change establishes: the reject-on-invalid shape, that the parser layer stays synchronous where the IR allows it, that stale results are discarded rather than applied, and that `parse` deliberately takes no `AbortSignal` (no current parser can be interrupted, and a signal nothing honors is indirection without a payer).

**Modes** (`src/irModes/*.ts`)

`src/parser/**` is unchanged. Each mode adapts its own synchronous parser in its registry entry (`const parseCfg = async (code) => parseLLVM(code)`) rather than making the parser lie about being async — parser and integration tests are untouched, and mermaid's adapter collapses to `parse: parseMermaid` once #80 makes that parser genuinely async. LLVM's adapters are module-level consts because `views[0]` must share the top-level `parse`'s identity, per the registry contract's "Views" rules.

**Parse effect** (`src/hooks/useIRWorkspace.ts`)

Awaiting inside the effect opens a race the synchronous version could not have: a parse still in flight when the code, mode, or view changes would otherwise overwrite the newer result. The effect's dependency array already covers every input a parse reads, so a `cancelled` flag set by the cleanup is sufficient — it drops both the stale graph and the stale error. A generation counter would buy nothing here, since no code path starts a parse from outside the effect. This is the parse-stage counterpart of the layout generation counter in `useGraphData`; the two stages guard independently.

## Review notes

`src/hooks/__tests__/useIRWorkspace.test.ts` is new. It stands in a registry whose parses never settle on their own, so the test resolves them by hand and can make a slow parse land *after* a newer one — the ordering a real parser only produces under a race. Five cases: the happy path, a rejection surfacing as the error message, a stale-by-code parse discarded, a stale-by-mode parse discarded, and a stale rejection not overwriting a newer success. Reverting the `cancelled` guard fails three of the five, so the tests are not passing vacuously.

Verified: `npm run test:run` (582 passed), `npm run lint`, `npm run format`, `tsc --noEmit`, `npm run build`, and `npm run test:e2e` (9 passed — initial graph render, all three mode switches, edit-updates-graph, and the parse-error path, which together are what "no user-visible behavior change" rests on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)