### PR TITLE
fix(edge-routing): keep every guarantee at zero clearance

### DIFF
--- a/docs/internal/contracts/edge-routing.md
+++ b/docs/internal/contracts/edge-routing.md
@@ -121,13 +121,12 @@ ever negative zero.
 
 For a caller that already passes integers, quantization is the identity **on the input**:
 every rect, point and option reaches the router unchanged, so the obstacle set and the
-search see exactly what they saw before. Two behavioral changes still reach such a caller,
-both of them in self-loops (see Self-loops). The stub offset is now rounded, so a node whose
+search see exactly what they saw before. One behavioral change still reaches such a caller,
+and it is in self-loops (see Self-loops): the stub offset is now rounded, so a node whose
 integer width is not a multiple of 4 has its loop leave and re-enter at `round(x + 0.75w)`,
 up to half a pixel from where it did before — a quarter of a pixel for a width that is odd,
-half a pixel for one that is even but not a multiple of 4. And a self-loop's consecutive
-duplicate vertices are now collapsed, which a caller passing `nodeMargin: 0` or
-`selfLoopGap: 0` can observe.
+half a pixel for one that is even but not a multiple of 4. A caller passing a clearance of
+`0` sees two more: the duplicate collapse, and the one-pixel floor below.
 
 ### Degenerate input
 
@@ -146,41 +145,42 @@ guard of its own.
   become one point — `10.2` and `10.4` do, `10.4` and `10.6` do not. For the options it
   means a `nodeMargin` or `selfLoopGap` anywhere in `[-0.5, 0.5)` becomes exactly `0`, which
   can make two vertices of a polyline coincide. Consecutive duplicates are collapsed
-  wherever they arise (see Self-loops); what is promised once a clearance has reached `0` is
-  bounded by the note below.
+  wherever they arise (see Self-loops), and a clearance of `0` is given a shape by the floor
+  described below.
 - Rounding is monotonic, so no ordering between boundaries can invert: what was to the left
   of something else is afterwards to the left of it or coincident with it, never to the right
   of it. Nothing that depends on an ordering can change sign because of quantization.
 
-**Clearance that rounds to zero is outside the domain.** A `nodeMargin` or `selfLoopGap` of
-`0` asks for geometry with no room in it, and such a shape has degenerated rather than
-merely lost precision. A self-loop is asked to leave its node, go around it and come back
-across no distance at all: on a narrow enough rect the lane coincides with the stub, the
-loop has nowhere to run, and what is left of it doubles back on itself. A routed edge is
-asked for something equally impossible when its two request points quantize to the same
-point and `nodeMargin` is `0` — what comes back can then be nothing but that one point,
-twice. Three of the guarantees below are therefore stated for a `nodeMargin` and a
-`selfLoopGap` that round to at least `1`: **Orthogonality**, **≥ 2 points** and **no
-immediate reversals**. What the router returns outside that domain is left unspecified here
-on purpose — a follow-up issue covers making these shapes well defined at zero clearance,
-and pinning values now would pin values that issue is going to change.
+**A clearance of zero is floored at one pixel where a shape is synthesized.** A `nodeMargin`
+or a `selfLoopGap` of `0` asks for geometry with no room in it. Taken literally there is no
+valid answer left: a self-loop asked to leave its node, go around it and come back across no
+distance at all doubles back on itself, and a routed edge whose two request points quantize
+to the same point with a `nodeMargin` of `0` has nothing but that one point to return twice.
+Every shape the router **synthesizes** therefore keeps at least one pixel of room where the
+clearance it is given leaves none — the self-loop's lane against its stub and its vertical
+extent (see Self-loops), and the outward steps of the no-path fallback, which is also what
+an otherwise empty route falls back to. The floor is a maximum against the requested
+distance, so it binds only below a pixel: a shape that had room in the first place is not
+moved, and no output changes anywhere for a `nodeMargin` and a `selfLoopGap` of `1` or more.
+Every guarantee below is therefore unconditional — it holds for any options, zero and
+fractional alike.
 
-The remaining guarantees are unconditional. **Integer coordinates**, **determinism**, the
-**tie-break order**, **missing-node omission** and **duplicate-id handling** hold whatever
-the options are, fractional or zero — fractional options are exactly the input this
-quantization exists to serve, so the bound must not touch them. The bound itself is a
-property of asking for geometry with no room to exist, not of quantization: an exactly-zero
-option reaches the same corner with no rounding involved, and quantization only widens the
-set of inputs that land there from `{0}` to the half-open interval `[-0.5, 0.5)` that rounds
-to it. `bendPenalty` carries no such bound either: it is a cost, not a clearance, and zero
-or fractional values of it are ordinary input.
+The floor applies to synthesis only, not to the obstacle set: a `nodeMargin` of `0` still
+inflates nothing and still blocks nothing (see the collapsed-rect case above), because there
+the zero is a meaningful answer rather than an impossible one. The corner it addresses is
+not a product of quantization either — an exactly-zero option reaches it with no rounding
+involved, and quantization only widens the set of inputs that land there from `{0}` to the
+half-open interval `[-0.5, 0.5)` that rounds to it. `bendPenalty` is floored nowhere and
+needs no floor: it is a cost, not a clearance, and zero or fractional values of it are
+ordinary input.
 
 ## Guarantees callers may rely on
 
 - **Orthogonality.** Every returned polyline is axis-aligned: consecutive points always
-  share exactly one coordinate. Stated within the clearance domain above (`nodeMargin` and
-  `selfLoopGap` rounding to at least `1`): at a `nodeMargin` of `0`, two request points that
-  quantize to the same point can leave nothing to return but that point twice.
+  share exactly one coordinate — never both, so no two consecutive points are identical.
+  This holds at any clearance: two request points that quantize to the same point with a
+  `nodeMargin` of `0` come back as the fallback's loop around that point, not as the point
+  twice.
 - **Integer coordinates.** Every `x` and every `y` of every point in every returned
   polyline is an integer — searched routes, self-loops and fallback routes alike, for any
   finite input. This is a consequence of the quantization above rather than of a rounding
@@ -192,7 +192,7 @@ or fractional values of it are ordinary input.
   formed (see Self-loops below). Callers therefore never have to round router output, and no
   returned coordinate is `-0`.
 - **≥ 2 points.** Every entry in the returned map has at least two points, however
-  degenerate the rects and the requests are. Stated within the clearance domain above.
+  degenerate the rects, the requests and the clearances are.
 - **Endpoints are exact on the quantized points.** A routed (non-self-loop) polyline starts
   exactly at the quantized `RouteRequest.sourcePoint` and ends exactly at the quantized
   `RouteRequest.targetPoint` — that is, at `(round(x), round(y))` of each, with `-0`
@@ -214,10 +214,12 @@ or fractional values of it are ordinary input.
   neighbours, and keeping them is what "Endpoints are exact" above requires. This is what
   makes the returned polyline a bend list rather than a trace: a consumer that rounds
   corners has one vertex per corner to round, and adding an unrelated node near a straight
-  edge does not change the edge's geometry. Stated within the clearance domain above, and
-  binding on routed and self-loop polylines; the fallback shape the router emits for an
-  edge it can find no path for places its vertices by construction (see the ladder named in
-  the opening paragraph) and may leave collinear ones among them.
+  edge does not change the edge's geometry. Binding on searched and self-loop polylines at
+  any clearance; the fallback shape places its vertices by construction (see the ladder named
+  in the opening paragraph) and may leave collinear ones among them. The router emits that
+  shape for an edge it can find no path for, and for one whose search collapses to a single
+  point — which is what two request points quantizing together with a `nodeMargin` of `0`
+  does.
 - **Determinism.** Identical input rects and requests always produce byte-identical
   points, with no dependence on the iteration order of either the `nodes` array or the
   `requests` array — reordering either changes no individual route.
@@ -238,10 +240,11 @@ or fractional values of it are ordinary input.
   fallback alike: no interior vertex has its arriving and leaving segments running along
   the same axis in opposite directions. This is the precise, checkable form of "never a
   degenerate hook"; `points[i - 1] !== points[i + 1]` is _not_ an equivalent test (an
-  out-16-then-back-48 detour satisfies it while being exactly the shape banned). Stated
-  within the clearance domain above, for the reason given there: a shape with no room to
-  exist has nothing but a doubling-back left in it. A `selfLoopGap` of `0` reaches this for
-  fallback routes as well as for self-loops, since the fallback's detours are sized by it.
+  out-16-then-back-48 detour satisfies it while being exactly the shape banned). This holds
+  at any clearance: a doubling-back is precisely what a shape with no room to exist has left
+  in it, and the one-pixel floor above is what keeps that room. The floor is needed by the
+  fallback as much as by the self-loop, since the fallback's detours are sized by
+  `selfLoopGap` too.
 - **Missing nodes.** A `RouteRequest` whose `source` or `target` id is **not present** in
   the `nodes` array produces **no entry** in the returned map. `routeEdges` does not throw
   and does not substitute a default rect — it simply omits that request. Self-loops are
@@ -300,20 +303,33 @@ polyline runs through these six points in this order, subject to the collapse de
 below, with
 
 - `stubX = round(x + 0.75w)`, the offset along the bottom and top edges where the loop
-  leaves and re-enters, and
-- `laneX = x + w + selfLoopGap`, the vertical lane to the right of the node:
+  leaves and re-enters,
+- `laneX = max(x + w + selfLoopGap, stubX + 1)`, the vertical lane to the right of the node,
+- `aboveY = y - nodeMargin` and `belowY = max(y + h + nodeMargin, aboveY + 1)`, the two
+  horizontal runs that pass the node:
 
-| #   | point                         |                            |
-| --- | ----------------------------- | -------------------------- |
-| 0   | `(stubX, y + h)`              | leaves the **bottom** edge |
-| 1   | `(stubX, y + h + nodeMargin)` | steps clear of the node    |
-| 2   | `(laneX, y + h + nodeMargin)` | runs **right** to the lane |
-| 3   | `(laneX, y - nodeMargin)`     | runs **up** past the node  |
-| 4   | `(stubX, y - nodeMargin)`     | comes back **left**        |
-| 5   | `(stubX, y)`                  | re-enters the **top** edge |
+| #   | point             |                            |
+| --- | ----------------- | -------------------------- |
+| 0   | `(stubX, y + h)`  | leaves the **bottom** edge |
+| 1   | `(stubX, belowY)` | steps clear of the node    |
+| 2   | `(laneX, belowY)` | runs **right** to the lane |
+| 3   | `(laneX, aboveY)` | runs **up** past the node  |
+| 4   | `(stubX, aboveY)` | comes back **left**        |
+| 5   | `(stubX, y)`      | re-enters the **top** edge |
 
-`laneX` needs no rounding of its own — `x`, `w` and `selfLoopGap` are all integers by the
-time it is formed — and neither do the four `y` values. `stubX` is the only non-integer
+The two maxima are the one-pixel floor of "A clearance of zero is floored at one pixel"
+above, and they are what keeps this shape a loop at any clearance. Without the first, a
+`selfLoopGap` of `0` on a rect that quantizes to `w ≤ 2` puts the lane exactly on the stub
+(`round(0.75w) === w` for `w ∈ {0, 1, 2}`) and the loop runs down, back up and down again —
+an immediate reversal. Without the second, a `nodeMargin` of `0` on a rect that quantizes to
+`h = 0` collapses all six points onto one. Both bind only where the requested clearance is
+worth less than a pixel: with `selfLoopGap ≥ 1` the lane already clears the stub, since
+`stubX ≤ x + w`, and with `nodeMargin ≥ 1` or `h ≥ 1` the extent is already at least a pixel
+tall. The default `12`/`24` loop of a real node rect is exactly the unfloored shape.
+
+Neither maximum needs rounding of its own — `x`, `y`, `w`, `h`, `nodeMargin` and
+`selfLoopGap` are all integers by the time they are formed, `stubX` is rounded, and a
+maximum of integers is an integer. `stubX` is the only non-integer
 value that can reach the output: three quarters of a width is fractional whenever the width
 is not a multiple of 4, so the sum is rounded there and the integer guarantee holds for
 self-loops too. For example `w = 100` gives `stubX = x + 75`, `w = 101` gives
@@ -326,22 +342,20 @@ differ only in the sign of zero, e.g. `x = -1, w = 1`).
 returned is that shape with every pair of identical consecutive points folded into one. This
 is required behavior, not an incidental detail, and it is the same duplicate collapse that
 searched and fallback routes already pass through — self-loops are no longer the exception.
-It is load-bearing because an option can round to zero: a `nodeMargin` in `[-0.5, 0.5)`
-makes points 0 and 1 coincide (and 4 and 5), and a `selfLoopGap` in `[-0.5, 0.5)` makes
-`stubX === laneX` on a rect that quantizes to `w ≤ 2`, which makes 1 coincide with 2 and 3
-with 4. Two identical consecutive points share both coordinates rather than exactly one, so
-leaving them in the output would break Orthogonality.
+It is load-bearing because `nodeMargin` can round to zero and, unlike the room `laneX` and
+`belowY` are given, is not floored where it appears on its own: a `nodeMargin` in
+`[-0.5, 0.5)` puts point 1 on point 0 whenever `h ≥ 1`, and puts point 4 on point 5 always. The other fold the table used
+to admit is gone — `laneX > stubX` by construction now, so 1 and 2, and 3 and 4, are never
+identical. Two identical consecutive points share both coordinates rather than exactly one,
+so leaving them in the output would break Orthogonality.
 
-A self-loop therefore returns **at most** six points, and can return fewer when a clearance
-rounds to zero — whether it does depends on the rect, and a `selfLoopGap` of `0` folds
-nothing unless the rect is narrow enough for the lane to reach the stub. What is returned in
-that case is left unspecified here, since those inputs are outside the domain the guarantees
-are given for (see "Clearance that rounds to zero" above). What the collapse does buy is
-that **a self-loop is orthogonal at any clearance**: no two consecutive returned points are
-ever identical, so every consecutive pair shares exactly one coordinate, in domain or out of
-it. Within the domain there is nothing to fold — with `nodeMargin` and `selfLoopGap` of `1`
-or more, no two _consecutive_ vertices of the six coincide — so the collapse is only ever
-observable outside it.
+A self-loop therefore returns six points whenever `nodeMargin` is `1` or more, and, when it
+rounds to `0`, four for a rect that quantizes to `h ≥ 1` or five for one that quantizes to
+`h = 0`, where the floored `belowY` keeps points 0 and 1 apart. Every one of those
+shapes is a loop: orthogonal, at least two points, no immediate reversal, every interior
+vertex a corner. That is the whole point of flooring the room rather than bounding the
+domain, and it is why the collapse is a fold of _identical_ points and not of collinear
+ones.
 
 The side is the **right** side, always — not chosen per node and not derived from free
 space. Points 1 and 4 are load-bearing, not decoration: without them the first/last

--- a/src/utils/__tests__/edgeRouter.test.ts
+++ b/src/utils/__tests__/edgeRouter.test.ts
@@ -1599,9 +1599,9 @@ function fractionalScenario(next: () => number, i: number) {
     targetSide: "top",
   };
   // Fractional options too: the contract makes the integer guarantee
-  // unconditional by rounding `nodeMargin` and `selfLoopGap`. Both stay in the
-  // stated clearance domain (they round to 12/13 and 24/25, never to 0), so
-  // orthogonality and no-immediate-reversal are in force here.
+  // unconditional by rounding `nodeMargin` and `selfLoopGap`. Both round well
+  // clear of 0 here (to 12/13 and 24/25), so this scenario exercises the
+  // shapes as they are built, with the one-pixel floor never binding.
   const options = {
     nodeMargin: 12 + next(),
     selfLoopGap: 24 + next(),
@@ -1886,8 +1886,9 @@ describe("routeEdges — quantization: no sub-pixel runs (issue #89 acceptance c
   });
 
   it("keeps orthogonality and the no-reversal invariant on fractional input", () => {
-    // Both guarantees are stated for a `nodeMargin` and `selfLoopGap` that
-    // round to at least 1, which every option this sweep generates does.
+    // Both guarantees are unconditional. This sweep covers the fractional
+    // clearances quantization exists to serve; the zero-clearance half of the
+    // domain is swept separately, under "the one-pixel floor" below.
     const next = fractionStream(4211);
     const failures: string[] = [];
 
@@ -2091,8 +2092,9 @@ describe("routeEdges — quantization: a rect that collapses to zero extent stil
   // "A collapsed rect is still an obstacle: every rect is inflated by
   // `nodeMargin` before the obstacle set is built, so a rect of no extent keeps
   // a band of that width clear around where it sits, exactly as a full-size one
-  // does." Unconditional — not one of the three guarantees bounded to a
-  // clearance of at least 1, and not left unspecified.
+  // does." This is the one place a `nodeMargin` of 0 is taken literally: the
+  // one-pixel floor applies where a shape is synthesized, never to the
+  // obstacle set, so a zero margin still inflates nothing and blocks nothing.
   //
   // The wrong implementation is the tempting one: drop rects whose quantized
   // extent is zero from the obstacle set, on the reasoning that a rect of no
@@ -2486,15 +2488,11 @@ describe("routeEdges — quantization: the self-loop stub offset is rounded (con
 });
 
 describe("routeEdges — quantization: the self-loop duplicate collapse (contract 'Consecutive duplicate vertices are collapsed')", () => {
-  // The collapse "is only ever observable outside" the clearance domain, so
-  // this block is the one place a clearance rounding to 0 is exercised. What
-  // the contract promises there is exactly three things and no more: integer
-  // coordinates, no consecutive duplicate vertices, and — as a consequence —
-  // that every consecutive pair shares exactly one coordinate. The point
-  // count and the point values are documented as unspecified at zero
-  // clearance and are deliberately not asserted. Without the collapse, two
-  // identical consecutive points would share *both* coordinates and break
-  // orthogonality, which is the failure this catches.
+  // The collapse is only ever observable at a `nodeMargin` of 0, where points
+  // 0/1 and 4/5 of the table coincide. Without it those pairs would share
+  // *both* coordinates rather than exactly one and break orthogonality, which
+  // is the failure this catches. The shapes those inputs produce are pinned
+  // under "the one-pixel floor" below; here the concern is only the fold.
 
   it("never returns two identical consecutive vertices, at any clearance", () => {
     const rects: RouteNodeRect[] = [
@@ -2547,11 +2545,12 @@ describe("routeEdges — quantization: the self-loop duplicate collapse (contrac
     expect(failures).toEqual([]);
   });
 
-  it("has nothing to fold inside the clearance domain: the six-point shape survives intact", () => {
-    // "Within the domain there is nothing to fold — with `nodeMargin` and
-    // `selfLoopGap` of 1 or more, no two *consecutive* vertices of the six
-    // coincide". A collapse implemented too eagerly (folding collinear points
-    // rather than identical ones) would shorten this to four.
+  it("has nothing to fold at a clearance of 1: the six-point shape survives intact", () => {
+    // "A self-loop returns six points whenever `nodeMargin` is 1 or more". A
+    // collapse implemented too eagerly (folding collinear points rather than
+    // identical ones) would shorten this to four. A width of 2 also puts the
+    // lane one pixel from the stub without the floor having to do anything —
+    // the smallest gap the floor would otherwise have had to create.
     const rect: RouteNodeRect = { id: "A", x: 0, y: 0, width: 2, height: 20 };
     const request: RouteRequest = {
       id: "loop-A",
@@ -2577,6 +2576,242 @@ describe("routeEdges — quantization: the self-loop duplicate collapse (contrac
       { x: 2, y: -1 },
       { x: 2, y: 0 },
     ]);
+  });
+});
+
+describe("routeEdges — the one-pixel floor (contract 'A clearance of zero is floored at one pixel')", () => {
+  // A `nodeMargin` or `selfLoopGap` of 0 asks a synthesized shape to exist
+  // across no distance at all. The floor gives it a pixel to exist in, which is
+  // what makes Orthogonality, `>= 2 points` and No immediate reversals hold for
+  // every input rather than only above a clearance of 1. These are the cases
+  // that motivated the floor and the sweep that says nothing else is left.
+
+  /** The three guarantees the floor exists to keep, plus the integer rule. */
+  function guaranteeFailures(points: Point[], label: string): string[] {
+    const failures: string[] = [];
+    if (points.length < 2) failures.push(`${label}: fewer than 2 points`);
+    if (!isOrthogonalPolyline(points))
+      failures.push(`${label}: not orthogonal`);
+    if (hasConsecutiveDuplicatePoint(points)) {
+      failures.push(`${label}: consecutive duplicate point`);
+    }
+    if (hasImmediateReversal(points)) {
+      failures.push(`${label}: immediate reversal`);
+    }
+    if (!allCoordinatesAreIntegers(points)) {
+      failures.push(`${label}: non-integer coordinate`);
+    }
+    if (hasNegativeZeroCoordinate(points))
+      failures.push(`${label}: contains -0`);
+    return failures;
+  }
+
+  function loopRequest(rect: RouteNodeRect): RouteRequest {
+    return {
+      id: "loop-A",
+      source: "A",
+      target: "A",
+      // Ignored — a self-loop is synthesized from the rect alone — but a real
+      // caller passes the live handle positions, so this one does too.
+      sourcePoint: { x: rect.x + rect.width / 2, y: rect.y + rect.height },
+      targetPoint: { x: rect.x + rect.width / 2, y: rect.y },
+      sourceSide: "bottom",
+      targetSide: "top",
+    };
+  }
+
+  it("keeps every self-loop a loop across the clearance sweep, zero included", () => {
+    // The sweep of issue #96: widths across the `w <= 2` boundary where
+    // `round(0.75w) === w`, heights that quantize to zero and to a real
+    // extent, both clearances at 0 and above, over origins that put the rect
+    // on and off the lattice. Every case that failed before the floor had a
+    // clearance of 0; none with both at 1 or more did.
+    const failures: string[] = [];
+
+    for (const originX of [0, -7, 3.4]) {
+      for (const originY of [0, -5, 2.6]) {
+        for (let width = 0; width <= 8; width++) {
+          for (const height of [0, 1, 2, 3, 40]) {
+            for (const nodeMargin of [0, 1, 2, 12]) {
+              for (const selfLoopGap of [0, 1, 2, 24]) {
+                const rect: RouteNodeRect = {
+                  id: "A",
+                  x: originX,
+                  y: originY,
+                  width,
+                  height,
+                };
+                const request = loopRequest(rect);
+                const points = routeEdges([rect], [request], {
+                  nodeMargin,
+                  selfLoopGap,
+                }).get(request.id)!;
+                const label = `(${originX},${originY}) w=${width} h=${height} nodeMargin=${nodeMargin} selfLoopGap=${selfLoopGap}`;
+
+                failures.push(...guaranteeFailures(points, label));
+                if (!interiorVerticesAreCorners(points)) {
+                  failures.push(`${label}: interior vertex is not a corner`);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("floors the lane against the stub: a selfLoopGap of 0 on a narrow rect still leaves room to run", () => {
+    // w = 2 is the boundary case — `round(0.75 * 2) = 2 = w`, so the unfloored
+    // lane would land exactly on the stub and the loop would run down, back up
+    // and down again. `laneX = max(0 + 2 + 0, 2 + 1) = 3`.
+    const rect: RouteNodeRect = { id: "A", x: 0, y: 0, width: 2, height: 20 };
+    const points = routeEdges([rect], [loopRequest(rect)], {
+      nodeMargin: 12,
+      selfLoopGap: 0,
+    }).get("loop-A")!;
+
+    expect(points).toEqual([
+      { x: 2, y: 20 },
+      { x: 2, y: 32 },
+      { x: 3, y: 32 },
+      { x: 3, y: -12 },
+      { x: 2, y: -12 },
+      { x: 2, y: 0 },
+    ]);
+  });
+
+  it("floors the vertical extent: a rect of no height at zero clearance still yields a loop, not a point", () => {
+    // Every one of the six vertices used to collapse onto `(0, 0)` here.
+    // `aboveY = 0`, `belowY = max(0 + 0 + 0, 0 + 1) = 1`, `laneX = max(0, 1)`,
+    // and the fold at the top edge takes the six to five.
+    const rect: RouteNodeRect = { id: "A", x: 0, y: 0, width: 0, height: 0 };
+    const points = routeEdges([rect], [loopRequest(rect)], {
+      nodeMargin: 0,
+      selfLoopGap: 0,
+    }).get("loop-A")!;
+
+    expect(points).toEqual([
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 1, y: 0 },
+      { x: 0, y: 0 },
+    ]);
+  });
+
+  it("does not move a loop that had room in the first place", () => {
+    // The acceptance criterion the floor must not cost anything: at the
+    // defaults, on a node-sized rect, the shape is the unfloored vertex table
+    // exactly. `max` is a floor, not an offset.
+    const rect: RouteNodeRect = {
+      id: "A",
+      x: 40,
+      y: 80,
+      width: 180,
+      height: 60,
+    };
+    const points = routeEdges([rect], [loopRequest(rect)]).get("loop-A")!;
+
+    expect(points).toEqual([
+      { x: 175, y: 140 }, // stubX = 40 + 135
+      { x: 175, y: 152 }, // + nodeMargin 12
+      { x: 244, y: 152 }, // laneX = 40 + 180 + 24
+      { x: 244, y: 68 },
+      { x: 175, y: 68 },
+      { x: 175, y: 80 },
+    ]);
+  });
+
+  it("returns a loop around the point, not the point twice, when both request points quantize together at a nodeMargin of 0", () => {
+    // The other shape with nowhere to go: the search collapses to a single
+    // point, and returning it twice would share both coordinates instead of
+    // exactly one. The fallback's floored steps out draw a loop around it.
+    const nodes: RouteNodeRect[] = [
+      { id: "A", x: 0, y: 0, width: 10, height: 10 },
+      { id: "B", x: 0, y: 0, width: 10, height: 10 },
+    ];
+    const request: RouteRequest = {
+      id: "e-A-B",
+      source: "A",
+      target: "B",
+      sourcePoint: { x: 5, y: 10 },
+      targetPoint: { x: 5, y: 10 },
+      sourceSide: "bottom",
+      targetSide: "top",
+    };
+
+    const points = routeEdges(nodes, [request], {
+      nodeMargin: 0,
+      selfLoopGap: 0,
+    }).get(request.id)!;
+
+    expect(guaranteeFailures(points, "coincident")).toEqual([]);
+    expect(points.length).toBeGreaterThan(2);
+    // Endpoints are still exact on the quantized request points.
+    expect(points[0]).toEqual({ x: 5, y: 10 });
+    expect(points[points.length - 1]).toEqual({ x: 5, y: 10 });
+  });
+
+  it("keeps the no-path fallback reversal-free at a selfLoopGap of 0, on every pair of sides", () => {
+    // The fallback's whole ladder is sized by `selfLoopGap`: at 0 its step out
+    // has no length, P2 lands on T, and the approach doubles back over the
+    // segment that reached it. The wall forces every request here onto the
+    // fallback (see the ladder block above for the same fixture).
+    const wall: RouteNodeRect = {
+      id: "WALL",
+      x: -1000,
+      y: -1000,
+      width: 3000,
+      height: 3000,
+    };
+    const a: RouteNodeRect = {
+      id: "A",
+      x: -900,
+      y: -900,
+      width: 10,
+      height: 10,
+    };
+    const b: RouteNodeRect = { id: "B", x: 900, y: 900, width: 10, height: 10 };
+    const sides: RouteSide[] = ["top", "right", "bottom", "left"];
+    const failures: string[] = [];
+
+    for (const sourceSide of sides) {
+      for (const targetSide of sides) {
+        // Coincident request points as well as distinct ones: the four-segment
+        // rectangle rung of the ladder is the one a zero gap flattens hardest.
+        for (const targetPoint of [
+          { x: 300, y: 170 },
+          { x: 20, y: 40 },
+        ]) {
+          for (const nodeMargin of [0, 1, 12]) {
+            const request: RouteRequest = {
+              id: "e-A-B",
+              source: "A",
+              target: "B",
+              sourcePoint: { x: 20, y: 40 },
+              targetPoint,
+              sourceSide,
+              targetSide,
+            };
+            const points = routeEdges([a, b, wall], [request], {
+              nodeMargin,
+              selfLoopGap: 0,
+            }).get(request.id)!;
+
+            failures.push(
+              ...guaranteeFailures(
+                points,
+                `${sourceSide}->${targetSide} target=(${targetPoint.x},${targetPoint.y}) nodeMargin=${nodeMargin}`,
+              ),
+            );
+          }
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
   });
 });
 

--- a/src/utils/edgeRouter.ts
+++ b/src/utils/edgeRouter.ts
@@ -24,6 +24,21 @@ export const DEFAULT_BEND_PENALTY = 30;
 export const DEFAULT_SELF_LOOP_GAP = 24;
 
 /**
+ * Room a synthesized shape keeps where the clearance it is given leaves none
+ * (`contracts/edge-routing.md`, "A clearance of zero is floored at one pixel").
+ * A `nodeMargin` or `selfLoopGap` of `0` asks a self-loop to go around its node
+ * across no distance at all, and asks the fallback to approach a target it is
+ * already standing on; both answers are a doubling-back, which the no-reversal
+ * guarantee forbids. Flooring the room these shapes are built from is what
+ * makes that guarantee — and orthogonality, and `>= 2` points — hold for every
+ * input rather than only for callers that pass a clearance of at least a pixel.
+ *
+ * Applied at synthesis only, never to the obstacle set: a `nodeMargin` of `0`
+ * genuinely means "inflate nothing", and the search is entitled to that answer.
+ */
+const MIN_CLEARANCE = 1;
+
+/**
  * Costs closer than this count as equal, so that geometrically symmetric
  * alternatives fall through to the documented tie-break order
  * (`contracts/edge-routing.md`, "A fixed tie-break total order") instead of
@@ -561,12 +576,18 @@ const hasImmediateReversal = (points: Point[]): boolean => {
  * of `specs/graph-view.md` §4, which does no obstacle avoidance at all:
  * `sourcePoint → S → P1 → connector → P2 → T → targetPoint`.
  *
- * `P1` steps a further `selfLoopGap` out along the source normal and `P2` sits a
- * `selfLoopGap` outside `T`, so the polyline always leaves straight and always
- * approaches the target from outside. That makes the no-reversal rule hold at
- * `S` and `T` unconditionally, and reduces the whole problem to two conditions on
- * the connector: its first segment must not run along `-n_s`, its last must not
- * run along `+n_t`.
+ * `P1` steps a further `gap` out along the source normal and `P2` sits a `gap`
+ * outside `T`, so the polyline always leaves straight and always approaches the
+ * target from outside. That makes the no-reversal rule hold at `S` and `T`
+ * unconditionally, and reduces the whole problem to two conditions on the
+ * connector: its first segment must not run along `-n_s`, its last must not run
+ * along `+n_t`.
+ *
+ * The whole ladder is sized by that one distance, which is why it is the
+ * `selfLoopGap` floored at `MIN_CLEARANCE` rather than the raw option: at a
+ * `selfLoopGap` of `0` every step out has zero length, `P2` lands on `T`, and
+ * the approach doubles back over the segment that reached it — the shape the
+ * no-reversal guarantee exists to forbid.
  *
  * Connector candidates are tried in a fixed order and the first one satisfying
  * the rule wins, which keeps the choice deterministic. Two segments suffice for
@@ -579,6 +600,7 @@ const fallbackPoints = (
   nodeMargin: number,
   selfLoopGap: number,
 ): Point[] => {
+  const gap = Math.max(selfLoopGap, MIN_CLEARANCE);
   const sourceNormal = OUTWARD_DIR[request.sourceSide];
   const start = pushOutward(
     request.sourcePoint,
@@ -589,12 +611,12 @@ const fallbackPoints = (
   const p1 = pushOutward(
     request.sourcePoint,
     request.sourceSide,
-    nodeMargin + selfLoopGap,
+    nodeMargin + gap,
   );
   const p2 = pushOutward(
     request.targetPoint,
     request.targetSide,
-    nodeMargin + selfLoopGap,
+    nodeMargin + gap,
   );
   const verticalExit = sourceNormal === DIR_UP || sourceNormal === DIR_DOWN;
 
@@ -613,10 +635,10 @@ const fallbackPoints = (
   }
   // Three-segment lateral dog-legs, positive side first — a fixed order, so the
   // choice stays deterministic.
-  const xPositive = Math.max(p1.x, p2.x) + selfLoopGap;
-  const xNegative = Math.min(p1.x, p2.x) - selfLoopGap;
-  const yPositive = Math.max(p1.y, p2.y) + selfLoopGap;
-  const yNegative = Math.min(p1.y, p2.y) - selfLoopGap;
+  const xPositive = Math.max(p1.x, p2.x) + gap;
+  const xNegative = Math.min(p1.x, p2.x) - gap;
+  const yPositive = Math.max(p1.y, p2.y) + gap;
+  const yNegative = Math.min(p1.y, p2.y) - gap;
   connectors.push(
     [
       { x: xPositive, y: p1.y },
@@ -638,10 +660,10 @@ const fallbackPoints = (
   if (p1.x === p2.x && p1.y === p2.y) {
     // Coincident handles on the same side: the only way back to a point without
     // retracing is to go around it.
-    const lateralX = verticalExit ? selfLoopGap : 0;
-    const lateralY = verticalExit ? 0 : selfLoopGap;
-    const outX = DIR_DX[sourceNormal] * selfLoopGap;
-    const outY = DIR_DY[sourceNormal] * selfLoopGap;
+    const lateralX = verticalExit ? gap : 0;
+    const lateralY = verticalExit ? 0 : gap;
+    const outX = DIR_DX[sourceNormal] * gap;
+    const outY = DIR_DY[sourceNormal] * gap;
     connectors.push([
       { x: p1.x + lateralX, y: p1.y + lateralY },
       { x: p1.x + lateralX + outX, y: p1.y + lateralY + outY },
@@ -675,11 +697,20 @@ const fallbackPoints = (
  * unless that width is a multiple of 4 — and it is rounded here, where it is
  * formed. This is the one rounding that happens behind the input boundary.
  *
+ * The lane and the vertical extent are floored at `MIN_CLEARANCE` against the
+ * points they have to clear, which is what gives the loop a shape at a clearance
+ * of `0`: without the first floor a `selfLoopGap` of `0` puts the lane on the
+ * stub for any rect that quantizes to `w <= 2` (`round(0.75w) === w` there) and
+ * the loop doubles back; without the second a `nodeMargin` of `0` on a rect of
+ * no height collapses all six points onto one. Both are maxima, so a loop with
+ * room to begin with is not moved.
+ *
  * Consecutive duplicates are collapsed, the same way searched and fallback
- * routes are: a clearance that quantizes to `0` makes two of the six points
- * coincide, and a coincident pair shares both coordinates instead of exactly
- * one, which would break orthogonality. A self-loop therefore returns at most
- * six points.
+ * routes are: `nodeMargin` is not floored — it is the caller's clearance around
+ * the node, not room this shape needs — so a `nodeMargin` of `0` still makes the
+ * stub ends coincide with the horizontal runs, and a coincident pair shares both
+ * coordinates instead of exactly one, which would break orthogonality. A
+ * self-loop therefore returns at most six points.
  */
 const selfLoopPoints = (
   rect: RouteNodeRect,
@@ -687,9 +718,12 @@ const selfLoopPoints = (
   selfLoopGap: number,
 ): Point[] => {
   const x = quantize(rect.x + rect.width * 0.75);
-  const lane = rect.x + rect.width + selfLoopGap;
-  const below = rect.y + rect.height + nodeMargin;
+  const lane = Math.max(rect.x + rect.width + selfLoopGap, x + MIN_CLEARANCE);
   const above = rect.y - nodeMargin;
+  const below = Math.max(
+    rect.y + rect.height + nodeMargin,
+    above + MIN_CLEARANCE,
+  );
   return dropDuplicates([
     { x, y: rect.y + rect.height },
     { x, y: below },
@@ -720,7 +754,9 @@ const selfLoopPoints = (
  * axis in opposite directions (`contracts/edge-routing.md`, "No immediate
  * reversals"). That is the checkable form of "never a degenerate hook". The
  * search gets it by refusing to double back, the self-loop by construction, the
- * fallback via its lateral detour case.
+ * fallback via its lateral detour case. All three hold at any clearance,
+ * including one that quantizes to `0`, because the room a synthesized shape is
+ * built from is floored at `MIN_CLEARANCE`.
  */
 export const routeEdges = (
   nodes: RouteNodeRect[],
@@ -800,11 +836,16 @@ export const routeEdges = (
           ]
         : fallbackPoints(request, nodeMargin, selfLoopGap),
     );
+    // A route can still collapse to a single point: with a `nodeMargin` of `0`,
+    // two request points that quantize to the same point leave the search
+    // nothing to return but that point. Returning it twice would share both
+    // coordinates instead of exactly one, so the fallback — whose steps out are
+    // floored at `MIN_CLEARANCE` — draws the loop around it instead.
     routes.set(
       request.id,
       points.length >= 2
         ? points
-        : [clonePoint(request.sourcePoint), clonePoint(request.targetPoint)],
+        : fallbackPoints(request, nodeMargin, selfLoopGap),
     );
   }
   return routes;


### PR DESCRIPTION
Closes #96.

## What this changes

A `nodeMargin` or `selfLoopGap` of `0` asks a synthesized shape to exist across no distance at all. #89 handled that by bounding the contract's domain: **Orthogonality**, **≥ 2 points** and **no immediate reversals** were stated only for clearances rounding to at least `1`, with what a self-loop returns below that left explicitly unspecified. This gives those shapes somewhere to go instead, so the bound can be deleted and the three guarantees hold for every input.

Every shape the router *synthesizes* now keeps at least one pixel of room where the clearance it is given leaves none. The floor is a `max` against the requested distance, so it binds only below a pixel — nothing moves that had room already.

- **Self-loop** (`selfLoopPoints`): `laneX = max(x + w + selfLoopGap, stubX + 1)` and `belowY = max(y + h + nodeMargin, aboveY + 1)`. Without the first, a `selfLoopGap` of `0` on a rect that quantizes to `w ≤ 2` put the lane exactly on the stub (`round(0.75w) === w` there) and the loop doubled back; without the second, a `nodeMargin` of `0` on a rect of no height collapsed all six vertices onto one point.
- **No-path fallback** (`fallbackPoints`): the whole ladder is sized by `selfLoopGap`, so it now uses the floored gap. At `0`, every step out had no length, `P2` landed on `T`, and the approach doubled back over the segment that reached it — a reversal reachable even with `nodeMargin ≥ 1`.
- **Collapsed routes** (`routeEdges`): a route that collapses to a single point — which is what two request points quantizing together with a `nodeMargin` of `0` does — falls back to the fallback shape instead of returning `[sourcePoint, targetPoint]`, i.e. the same point twice, sharing both coordinates rather than exactly one.

The floor applies to synthesis only, never to the obstacle set: a `nodeMargin` of `0` still inflates nothing and still blocks nothing, because there the zero is a meaningful answer rather than an impossible one.

## Scope note

Issue #96 as filed is scoped to the self-loop, but its third acceptance criterion — delete the clearance bound from the contract and restore the three guarantees unconditionally — is not reachable that way: the same corner exists in the fallback and in the collapsed-route path, and the contract's own bound paragraph names the routed case explicitly. Measured on a sweep of 11,664 routed configurations before this change, 60 violated orthogonality (`nodeMargin` of `0`, coincident request points) and 200 violated no-reversal (`selfLoopGap` of `0`). All three are fixed here so the bound can go; this was agreed before implementation. The issue title should be updated to this PR's title to keep the squash-merge commit message right.

## Verification

- `docs/internal/contracts/edge-routing.md` updated first: the domain paragraph is replaced by the one-pixel floor rule, the four affected guarantees are unconditional again, and the Self-loops vertex table carries the floored `laneX` / `belowY` and the now-specified point counts (six at `nodeMargin ≥ 1`; four or five at `0`).
- New test block "the one-pixel floor": the issue's sweep (`w ∈ [0,8] × h ∈ {0,1,2,3,40} × nodeMargin ∈ {0,1,2,12} × selfLoopGap ∈ {0,1,2,24}` over three origins) asserting orthogonality, ≥ 2 points, no reversal, no consecutive duplicates, integer coordinates, no `-0`, and interior vertices that are corners; exact-shape pins for both floors; the coincident-request-point case; and the fallback at `selfLoopGap: 0` over every pair of sides. All five fail without the floor.
- Sweeps before/after: self-loop 6,480 configurations, 729 violations → 0; routed 11,664 configurations, 260 → 0; **0 output differences anywhere at a `nodeMargin` and `selfLoopGap` of 1 or more**.
- The default `12`/`24` loop of a node-sized rect is the unfloored vertex table exactly, pinned by its own test. Both production call sites (`src/hooks/useEdgeRoutes.ts`) pass the defaults, so rendering is unchanged.
- `npm run test:run` (583 passed), `npm run format`, `npm run lint`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)