### PR TITLE
feat: surface LLVM parser diagnostics in the editor

### DIFF
--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -10,7 +10,7 @@ flowchart TD
   Registry["IR mode registry (src/irModes)<br/>parser / defaultCode / editorLanguage /<br/>nodeTypes / edgeBuilder / layoutOptions"] -.->|"active mode"| Workspace
   Workspace -->|"await mode.parse(code)"| Parser["Mode-specific parser (src/parser)"]
   Parser -->|AST| Builder["graphBuilder (src/graphBuilder)"]
-  Builder -->|GraphData| GraphHook["useGraphData<br/>(topology signature,<br/>position preservation)"]
+  Builder -->|"GraphData (+ diagnostics)"| GraphHook["useGraphData<br/>(topology signature,<br/>position preservation)"]
   GraphHook -->|"getLayoutedElements"| Layout["layout.ts (ELK placement) +<br/>converter.ts (sizing)"]
   Layout -->|"React Flow nodes/edges"| Viewer["GraphViewer (React Flow)<br/>node components from registry"]
   Viewer -->|"live measured rects"| Routes["useEdgeRoutes<br/>(one pass per graph)"]
@@ -22,10 +22,12 @@ flowchart TD
 - Typing in the editor updates `code` state; after a 750 ms debounce, the active mode's
   `parse()` runs. Parse failures are caught and shown in the editor panel's status footer; the
   previous graph stays.
-- `parse()` is parser + graphBuilder composed: text → AST → `GraphData` (plain, React-free).
-  It is **async** (`contracts/ir-mode-registry.md`, "Parsing is asynchronous"): a parse whose
-  code/mode/view changed while it was in flight is discarded, so a slow parse can never
-  overwrite a newer one.
+- `parse()` is parser + graphBuilder composed: text → AST → `IRParseResult` (a `GraphData`
+  plus the parse's recoverable diagnostics — plain, React-free). It is **async**
+  (`contracts/ir-mode-registry.md`, "Parsing is asynchronous"): a parse whose code/mode/view
+  changed while it was in flight is discarded, so a slow parse can never overwrite a newer one.
+  Diagnostics take the same path as the error string — parse result to status footer — and
+  never enter the layout stage.
 - `useGraphData` decides between a full (async) ELK re-layout (topology changed) and a
   position-preserving content update (same topology). See `specs/graph-view.md`.
 - Layout converts `GraphData` to React Flow nodes/edges, estimating node dimensions from
@@ -48,7 +50,7 @@ flowchart TD
 | IR mode registry    | `src/irModes`              | One `IRModeDefinition` per IR — see `contracts/ir-mode-registry.md`                                                                                                                 | import only |
 | Edge-routing types  | `src/types/edgeRouting.ts` | `Point`/`RouteSide`/`RouteNodeRect`/`RouteRequest`/`EdgeRouterOptions` — the frozen router boundary, see `contracts/edge-routing.md`                                                | no          |
 | Layout / conversion | `src/utils`                | ELK node placement (`layout.ts`), live orthogonal edge routing (`edgeRouter.ts`, types in `src/types/edgeRouting.ts`), React Flow node/edge construction, node sizing, font metrics | types only  |
-| Hooks               | `src/hooks`                | `useIRWorkspace` (mode/code/parse/error), `useGraphData` (graph state), `useEdgeRoutes` (one routing pass per graph, published via context), `usePaneResize`                        | yes         |
+| Hooks               | `src/hooks`                | `useIRWorkspace` (mode/code/parse/error/diagnostics), `useGraphData` (graph state), `useEdgeRoutes` (one routing pass per graph, published via context), `usePaneResize`            | yes         |
 | App shell           | `src/components/AppShell`  | `CanvasShell` (full-bleed `GraphViewer` root) + `EditorPanel` (header, Monaco, status footer)                                                                                       | yes         |
 | Graph rendering     | `src/components/Graph`     | React Flow node/edge components (+ colocated `*.stories.tsx`)                                                                                                                       | yes         |
 | Editor              | `src/components/Editor`    | Monaco editor with Shiki highlighting for `llvm`/`mermaid`                                                                                                                          | yes         |

--- a/docs/internal/contracts/ir-mode-registry.md
+++ b/docs/internal/contracts/ir-mode-registry.md
@@ -15,7 +15,7 @@ interface IRModeDefinition {
   label: string; // editor-panel display label, e.g. "LLVM-IR"
   editorLanguage: string; // Monaco language id registered in CodeEditor
   defaultCode: string; // code shown when the mode is selected
-  parse: (code: string) => Promise<GraphData>; // text -> graph, rejects with Error on invalid input
+  parse: (code: string) => Promise<IRParseResult>; // text -> graph + diagnostics, rejects with Error on invalid input
   nodeTypes: Record<string, ComponentType<NodeProps>>; // this mode's React Flow node renderers
   edgeBuilder: IREdgeBuilder; // see below
   layoutOptions?: Record<string, string>; // ELK layout options, e.g. layer spacing
@@ -42,13 +42,53 @@ The rules:
   parser lie about being async.
 - **Stale results are discarded, not applied.** `useIRWorkspace` parses in a debounced effect;
   when the code, mode, or view changes while a parse is in flight, the effect's cleanup marks
-  that parse cancelled and neither its graph nor its error reaches state. A slow parse can
-  therefore never overwrite the result of a newer one. This is the parse-stage counterpart of
-  the layout generation counter in `useGraphData` (`specs/graph-view.md` §2); the two stages
-  guard independently.
+  that parse cancelled and neither its graph, its diagnostics nor its error reaches state. A
+  slow parse can therefore never overwrite the result of a newer one. This is the parse-stage
+  counterpart of the layout generation counter in `useGraphData` (`specs/graph-view.md` §2);
+  the two stages guard independently.
 - **`parse` is not cancellable.** It takes no `AbortSignal` — the caller drops the result. No
   current parser can be interrupted mid-run, and adding a signal nothing honors would be
   indirection without a payer.
+
+## Recoverable diagnostics
+
+Rejecting with an `Error` is how a parser reports that it produced **no graph**. A parser may
+also produce a graph and still have something to say about the input: a line it recovered from
+rather than understood. That is a second, non-fatal outcome, and `parse` carries it in the same
+result rather than in a per-mode side channel:
+
+```ts
+interface IRParseResult {
+  graph: GraphData; // what the layout stage consumes
+  diagnostics?: IRParseDiagnostic[]; // recoverable problems; omitted when there are none
+}
+
+interface IRParseDiagnostic {
+  line: number; // 1-based line in the editor text
+  message: string; // one self-contained sentence, no severity prefix
+}
+```
+
+The rules:
+
+- **A diagnostic never implies failure.** A parse that returns diagnostics succeeded: the graph
+  is applied and the error state clears exactly as for a clean parse. The two outcomes are
+  disjoint — a rejected parse has no diagnostics, because it has no result at all.
+- **The message carries no severity word.** The presentation layer owns that; the footer renders
+  the `warning:` prefix (`specs/graph-view.md` §6.3).
+- **`line` is 1-based and refers to the text that was parsed**, so it stays meaningful next to
+  the editor. A recovery with no source line has no diagnostic to report.
+- **Diagnostics belong to the parse, not to the graph.** They are not part of `GraphData`
+  (`contracts/graph-data.md`): the layout stage never sees them, and a topology signature is
+  unaffected by them.
+- **Views of one mode may disagree.** Diagnostics are whatever the active view's `parse`
+  returned. LLVM-IR's two views share a front-end and therefore report the same set, but nothing
+  in this contract requires that.
+
+Today only the LLVM-IR mode populates the field (`specs/llvm-ir.md` §3.4, from
+`LLVMModule.diagnostics`); Mermaid and SelectionDAG return a bare `{ graph }`. The channel is
+mode-agnostic so that the SelectionDAG case below can start reporting its skipped lines without
+another contract change.
 
 ## Views
 
@@ -61,7 +101,7 @@ same editor language, same default code, same parser front-end, different
 interface IRViewDefinition {
   key: string; // stable, e.g. "cfg", "use-def"
   label: string; // toggle label, e.g. "CFG"
-  parse: (code: string) => Promise<GraphData>; // same reject-on-invalid rule as the mode's parse
+  parse: (code: string) => Promise<IRParseResult>; // same reject-on-invalid rule as the mode's parse
   edgeBuilder?: IREdgeBuilder; // defaults to the mode's edgeBuilder
   layoutOptions?: Record<string, string>; // defaults to the mode's layoutOptions
   bundleOf?: (edge: GraphEdge) => string | undefined; // defaults to the mode's bundleOf
@@ -160,8 +200,8 @@ implementation land with #88; the router-side guarantee it feeds lands with #86.
 
 - `App.tsx` / `useIRWorkspace` — looks up the active mode by key, awaits `mode.parse(code)`
   in the debounced parse effect (discarding the result if it is stale, see "Parsing is
-  asynchronous"), uses `mode.defaultCode` on mode switch and `mode.editorLanguage` for the
-  editor.
+  asynchronous"), hands `result.graph` to `useGraphData` and `result.diagnostics` to the status
+  footer, uses `mode.defaultCode` on mode switch and `mode.editorLanguage` for the editor.
 - `useGraphData` — takes an `IRLayoutBehavior` into `updateGraph(graph, behavior)` /
   `resetLayout()`, so layout, edge-building and bundling are mode- (or view-) driven rather
   than branching by string.
@@ -190,3 +230,7 @@ of the "`parse` rejects with `Error` on invalid input" rule above — the Select
 of parsing is a line, and a "failure" for one line does not fail the whole `parse` call. LLVM and
 Mermaid parse the entire input as one document and do fail on invalid input. See
 `src/parser/selectionDAG.ts` for the code-level comment.
+
+A skipped line is exactly the "recovered from rather than understood" case that
+`IRParseResult.diagnostics` exists for, so this difference is now reportable rather than
+structurally invisible. The mode does not report it yet.

--- a/docs/internal/specs/graph-view.md
+++ b/docs/internal/specs/graph-view.md
@@ -13,8 +13,13 @@ behavior with no covering test.
 - Editing the code (or switching modes or views) schedules a parse of the active mode's
   active view after a **750 ms debounce** (`PARSE_DEBOUNCE_MS` in `useIRWorkspace`);
   intermediate keystrokes cancel the pending parse.
-- On success the graph updates and any error clears. On failure the **previous graph stays**
-  and the error message is shown, untruncated, in the editor panel's status footer (§6).
+- On success the graph updates, any error clears, and the parse's recoverable diagnostics
+  (`contracts/ir-mode-registry.md`, "Recoverable diagnostics") replace the previous ones — an
+  empty set when the parse was clean. On failure the **previous graph stays** and the error
+  message is shown, untruncated, in the editor panel's status footer (§6).
+- A failed parse also **clears the diagnostics**. They are line-anchored statements about the
+  text that produced them; keeping them alongside an error about newer text would point their
+  line numbers at lines that no longer say what they described.
 - Switching modes replaces the editor content with the new mode's `defaultCode` and resets
   the active view to the mode's default view.
 - Switching views (modes with `views`, see `contracts/ir-mode-registry.md`) **keeps the
@@ -302,16 +307,29 @@ that is not the canvas.
 
 ### 6.3 Status footer
 
-One line of monospace text at the bottom of the panel, styled as a compiler diagnostic. It
-is the only place parse status is reported; there is no snackbar over the graph.
+Monospace text at the bottom of the panel, styled as compiler output. It is the only place
+parse status is reported; there is no snackbar over the graph.
 
 - Success: `✓ parsed · N nodes · M edges` — the check glyph in `ok`, the text in `ink-muted`.
 - Failure: `error: <full message>` with a 2 px left rule in `error`. The message is **not
   truncated**; long messages wrap and scroll inside the footer, which caps at roughly 8
   lines. The error clears on the next successful parse (§1).
+- Success with diagnostics: the success line, then **one line per diagnostic**, each
+  `warning: line <N>: <message>` with the `warning:` prefix in `warn` and a 2 px left rule in
+  `warn`. The prefix is the only place severity is written — the parser's message carries no
+  severity word (`contracts/ir-mode-registry.md`). Diagnostics are listed in the order the
+  parse returned them, none is dropped, and the footer's line cap makes a long list scroll
+  rather than truncate.
+- `error` outranks `warn` on the left rule, and the two never appear together: a failed parse
+  has no diagnostics (§1).
 
-> Pinned by: `e2e/smoke.spec.ts` (a parse error reaches the footer). The exact success
-> wording, the line cap, and the absence of truncation are _observed, untested_.
+The `warning:` prefix is deliberately not `error:`, so that "did this input parse?" stays
+answerable by looking for a single word.
+
+> Pinned by: `e2e/smoke.spec.ts` (a parse error reaches the footer),
+> `src/components/AppShell/__tests__/EditorPanel.test.tsx` (the three footer states and the
+> severity precedence). The exact success wording, the line cap, and the absence of
+> truncation are _observed, untested_.
 
 ### 6.4 Canvas control cluster
 
@@ -355,14 +373,15 @@ the canvas, not a node.
 | `ink-muted`    | `#57606A`                                                              | Secondary text (status footer)                                                                                                                               |
 | `ok`           | `#1A7F37`                                                              | Parse success only — never decorative                                                                                                                        |
 | `error`        | `#CF222E`                                                              | Parse failure only — never decorative                                                                                                                        |
+| `warn`         | `#9A6700`                                                              | Recoverable parse diagnostics only — never decorative                                                                                                        |
 | `selectedFill` | `#e8e8e8` (text `#222`, weight 600)                                    | Selected toggle-button state                                                                                                                                 |
 | `hoverFill`    | `#f0f0f0`                                                              | Hover fill for shell chrome buttons                                                                                                                          |
 | `focusRing`    | 2 px `#57606A`                                                         | Focus-visible ring on all interactive shell chrome (neutral, not accent)                                                                                     |
 | elevation      | `0 1px 2px rgba(31,35,40,.05), 0 4px 12px rgba(31,35,40,.06)`          | Floating chrome only; graph nodes stay flat (no shadow)                                                                                                      |
 
-- There is no `accent` token: `ok` (green) and `error` (red) are the only semantic,
-  non-gray colors in the shell chrome. The muted purple on back edges (§4) is graph
-  grammar, not a shell token.
+- There is no `accent` token: `ok` (green), `warn` (amber) and `error` (red) are the only
+  semantic, non-gray colors in the shell chrome, and all three report parse status. The muted
+  purple on back edges (§4) is graph grammar, not a shell token.
 - **No translucency and no backdrop blur**: every surface is fully opaque.
 - **Typography**: no webfonts. All shell chrome uses the app's system sans-serif stack
   (`system-ui`). Monospace is reserved for the status footer (compiler-output feel) and

--- a/docs/internal/specs/llvm-ir.md
+++ b/docs/internal/specs/llvm-ir.md
@@ -202,9 +202,11 @@ previous block is closed with a synthetic empty terminator (`opcode: ""`, no suc
 so it contributes no CFG edge), a diagnostic is recorded, and the label starts its block
 normally.
 
-`LLVMModule.diagnostics` entries carry a 1-based `line` and a `message`. The editor does not
-surface them yet; that work is tracked by
-[Issue #64](https://github.com/himadajin/ir-visualizer/issues/64).
+`LLVMModule.diagnostics` entries carry a 1-based `line` and a `message`. A message is one
+self-contained sentence with no severity word in it: the mode passes the list straight through
+as `IRParseResult.diagnostics` (`contracts/ir-mode-registry.md`), and the status footer owns
+the `warning:` prefix (`specs/graph-view.md` §6.3). Both views of the mode report the same
+list — they share this front-end and differ only in the graphBuilder.
 
 > Pinned by: `src/parser/__tests__/llvm/errors.test.ts`,
 > `src/parser/llvm/__tests__/module.test.ts`
@@ -278,7 +280,9 @@ The dispatch narrows on the **shape** of the terminator (presence of `condition`
 `switch` still has opcode `"switch"` but no `cases` field and must fall through to the
 uniform-successor rule instead of crashing.
 
-`parseLLVM(input)` is exactly `convertASTToGraph(parseLLVMToAST(input))`.
+`parseLLVM(input).graph` is exactly `convertASTToGraph(parseLLVMToAST(input))`; the entry point
+returns the module's `diagnostics` (§3.4) alongside it, because a caller that wants the graph
+wants to know what the parser recovered from on the way to it.
 
 ID namespacing: node ids embed the function name (`func_<name>_block_<label>` etc.) so
 multiple functions can reuse block labels (`entry`, numeric labels) without collision; ids
@@ -314,7 +318,5 @@ The produced graph always has `direction: "TD"`.
   name with a declared type alias would be excluded too (_observed, untested_ — printer
   output does not produce such collisions).
 - Comments (`;`) are stripped and not preserved anywhere (label hints excepted, §1).
-- `LLVMModule.diagnostics` is recorded but not surfaced in the UI
-  ([Issue #64](https://github.com/himadajin/ir-visualizer/issues/64)).
 - Extracting declaration names is still not done (`LLVMDeclaration.name` is always the
   literal `"declaration"`).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ function App() {
     code,
     setCode,
     error,
+    diagnostics,
     nodes,
     edges,
     onNodesChange,
@@ -153,6 +154,7 @@ function App() {
         onCodeChange={handleEditorChange}
         onClear={clearCode}
         error={error}
+        diagnostics={diagnostics}
         nodeCount={nodes.length}
         edgeCount={edges.length}
       />

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -55,7 +55,7 @@ entry:
   ret i32 %x
 }`;
 
-    const graph = parseLLVM(input);
+    const { graph } = parseLLVM(input);
 
     // Should have header + basic block + exit
     expect(graph.nodes.length).toBeGreaterThanOrEqual(3);
@@ -87,7 +87,7 @@ else:
   ret void
 }`;
 
-    const graph = parseLLVM(input);
+    const { graph } = parseLLVM(input);
 
     // Should have: header, entry block, then block, else block, exit node
     const basicBlocks = graph.nodes.filter(
@@ -112,7 +112,7 @@ define void @foo() {
   ret void
 }`;
 
-    const graph = parseLLVM(input);
+    const { graph } = parseLLVM(input);
 
     const globalNode = graph.nodes.find(
       (n) => n.nodeType === "llvm-globalVariable",
@@ -126,7 +126,7 @@ define void @foo() {
 
 describe("Integration: parseLLVMUseDef (parser + use-def graph builder)", () => {
   it("should produce a flat dataflow graph from the default LLVM example", () => {
-    const graph = parseLLVMUseDef(llvmMode.defaultCode);
+    const { graph } = parseLLVMUseDef(llvmMode.defaultCode);
 
     expect(graph.nodes.length).toBeGreaterThan(0);
     expect(graph.edges.length).toBeGreaterThan(0);
@@ -165,7 +165,7 @@ entry:
   ret i32 %x
 }`;
 
-    const graph = parseLLVMUseDef(input);
+    const { graph } = parseLLVMUseDef(input);
 
     const instructionNodes = graph.nodes.filter(
       (n) => n.nodeType === "llvm-useDefInstruction",

--- a/src/components/AppShell/EditorPanel.tsx
+++ b/src/components/AppShell/EditorPanel.tsx
@@ -11,7 +11,7 @@ import {
 } from "@mui/material";
 import { CodeEditor } from "../Editor/CodeEditor";
 import { IR_MODE_LIST, type IRModeKey } from "../../irModes";
-import type { IRViewDefinition } from "../../irModes/types";
+import type { IRParseDiagnostic, IRViewDefinition } from "../../irModes/types";
 import { NODE_FONT_FAMILY } from "../Graph/common/nodeTextStyle";
 import {
   PANEL_MARGIN,
@@ -29,6 +29,17 @@ import {
 /** The status footer never grows past roughly eight lines of diagnostics. */
 const FOOTER_LINE_HEIGHT = 18;
 const FOOTER_MAX_LINES = 8;
+
+/**
+ * The footer's left rule carries the worst thing the last parse produced
+ * (`specs/graph-view.md` §6.3): an error outranks warnings, and a clean parse
+ * gets no rule at all.
+ */
+const statusRule = (error: string | null, diagnostics: IRParseDiagnostic[]) => {
+  if (error) return `2px solid ${SHELL_COLORS.error}`;
+  if (diagnostics.length > 0) return `2px solid ${SHELL_COLORS.warn}`;
+  return undefined;
+};
 
 /**
  * The one orchestrated motion of the shell: the panel ⇄ pill morph. Declared
@@ -157,6 +168,8 @@ interface EditorPanelProps {
   onClear: () => void;
   /** Latest parse error, or null after a successful parse. */
   error: string | null;
+  /** Recoverable diagnostics of the latest successful parse; empty otherwise. */
+  diagnostics: IRParseDiagnostic[];
   nodeCount: number;
   edgeCount: number;
 }
@@ -189,6 +202,7 @@ export function EditorPanel({
   onCodeChange,
   onClear,
   error,
+  diagnostics,
   nodeCount,
   edgeCount,
 }: EditorPanelProps) {
@@ -382,7 +396,9 @@ export function EditorPanel({
         aria-live="polite"
         sx={{
           borderTop: `1px solid ${SHELL_HAIRLINE}`,
-          borderLeft: error ? `2px solid ${SHELL_COLORS.error}` : undefined,
+          // Severity precedence, not a blend: a failed parse never carries
+          // diagnostics (spec §1), so the two conditions are exclusive anyway.
+          borderLeft: statusRule(error, diagnostics),
           px: 1,
           py: 0.75,
           fontFamily: NODE_FONT_FAMILY,
@@ -408,6 +424,16 @@ export function EditorPanel({
               ✓
             </Box>{" "}
             {`parsed · ${nodeCount} nodes · ${edgeCount} edges`}
+            {/* One line per diagnostic, in the order the parse returned them;
+                none is dropped — a long list scrolls (spec §6.3). */}
+            {diagnostics.map((diagnostic, index) => (
+              <Box key={index} component="div">
+                <Box component="span" sx={{ color: SHELL_COLORS.warn }}>
+                  warning:
+                </Box>{" "}
+                {`line ${String(diagnostic.line)}: ${diagnostic.message}`}
+              </Box>
+            ))}
           </>
         )}
       </Box>

--- a/src/components/AppShell/__tests__/EditorPanel.test.tsx
+++ b/src/components/AppShell/__tests__/EditorPanel.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { EditorPanel } from "../EditorPanel";
+import { SHELL_COLORS } from "../shellTokens";
+import type { IRParseDiagnostic } from "../../../irModes/types";
+
+// Monaco needs a real editor host; the footer is what this file is about.
+vi.mock("../../Editor/CodeEditor", () => ({
+  CodeEditor: () => <div data-testid="code-editor" />,
+}));
+
+/**
+ * The status footer's three states (`specs/graph-view.md` §6.3). It is the only
+ * place parse status is reported, so "did this input parse?" has to stay
+ * answerable from the words in this one element: `error:` for a failure,
+ * `warning:` for a parse that succeeded with recoverable diagnostics.
+ */
+function renderPanel(
+  overrides: Partial<Parameters<typeof EditorPanel>[0]> = {},
+) {
+  return render(
+    <EditorPanel
+      open
+      onOpenChange={vi.fn()}
+      narrow={false}
+      width={420}
+      sheetHeight={0}
+      onResizeHandleMouseDown={vi.fn()}
+      mode={"llvm-ir" as never}
+      onModeChange={vi.fn()}
+      code=""
+      language="llvm"
+      onCodeChange={vi.fn()}
+      onClear={vi.fn()}
+      error={null}
+      diagnostics={[]}
+      nodeCount={3}
+      edgeCount={2}
+      {...overrides}
+    />,
+  );
+}
+
+// Vitest runs without `globals`, so testing-library's auto-cleanup is off and
+// each render would otherwise stack another panel in the document.
+afterEach(cleanup);
+
+const warning: IRParseDiagnostic = {
+  line: 5,
+  message: "terminator targets label '%missing', but no block has that id.",
+};
+
+describe("EditorPanel status footer", () => {
+  it("reports a clean parse with the node and edge counts alone", () => {
+    renderPanel();
+
+    const status = screen.getByTestId("parse-status");
+    expect(status).toHaveTextContent("✓ parsed · 3 nodes · 2 edges");
+    expect(status).not.toHaveTextContent("warning:");
+    expect(status).not.toHaveTextContent("error:");
+    expect(status).toHaveStyle({ borderLeft: "" });
+  });
+
+  it("keeps the success line and adds one warning line per diagnostic", () => {
+    renderPanel({ diagnostics: [warning, { line: 9, message: "second" }] });
+
+    const status = screen.getByTestId("parse-status");
+    expect(status).toHaveTextContent("✓ parsed · 3 nodes · 2 edges");
+    expect(status).toHaveTextContent(`warning: line 5: ${warning.message}`);
+    expect(status).toHaveTextContent("warning: line 9: second");
+    // A diagnostic is not a failure: the word that answers "did it parse?"
+    // must not appear (spec §6.3).
+    expect(status).not.toHaveTextContent("error:");
+    expect(status).toHaveStyle({
+      borderLeft: `2px solid ${SHELL_COLORS.warn}`,
+    });
+  });
+
+  it("shows a failure as an error and nothing else", () => {
+    renderPanel({ error: "Line 4: block 'entry' has no terminator" });
+
+    const status = screen.getByTestId("parse-status");
+    expect(status).toHaveTextContent(
+      "error: Line 4: block 'entry' has no terminator",
+    );
+    expect(status).not.toHaveTextContent("✓ parsed");
+    expect(status).toHaveStyle({
+      borderLeft: `2px solid ${SHELL_COLORS.error}`,
+    });
+  });
+
+  it("lets an error outrank diagnostics that arrived with it", () => {
+    // The workspace clears diagnostics on failure (spec §1), so this pins the
+    // footer's own precedence rather than a state the app can produce.
+    renderPanel({ error: "boom", diagnostics: [warning] });
+
+    const status = screen.getByTestId("parse-status");
+    expect(status).toHaveTextContent("error: boom");
+    expect(status).not.toHaveTextContent("warning:");
+    expect(status).toHaveStyle({
+      borderLeft: `2px solid ${SHELL_COLORS.error}`,
+    });
+  });
+});

--- a/src/components/AppShell/shellTokens.ts
+++ b/src/components/AppShell/shellTokens.ts
@@ -32,6 +32,8 @@ export const SHELL_COLORS = {
   ok: "#1A7F37",
   /** Parse failure only — never decorative. */
   error: "#CF222E",
+  /** Recoverable parse diagnostics only — never decorative. */
+  warn: "#9A6700",
 } as const;
 
 /** Floating chrome only; graph nodes stay flat. Kept light on purpose. */

--- a/src/hooks/__tests__/useIRWorkspace.test.ts
+++ b/src/hooks/__tests__/useIRWorkspace.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import type { GraphData } from "../../types/graph";
+import type { IRParseDiagnostic, IRParseResult } from "../../irModes/types";
 
 // The registry contract makes `parse` async and leaves discarding stale results
 // to the caller (contracts/ir-mode-registry.md, "Parsing is asynchronous").
@@ -75,6 +76,11 @@ function graph(id: string): GraphData {
   return { direction: "TD", nodes: [{ id, label: id }], edges: [] };
 }
 
+/** What a mode's `parse` resolves to (contracts/ir-mode-registry.md). */
+function parsed(id: string, diagnostics?: IRParseDiagnostic[]): IRParseResult {
+  return { graph: graph(id), diagnostics };
+}
+
 /** Run the debounce timer out, so the pending parse for the current code starts. */
 async function runDebounce() {
   await act(async () => {
@@ -108,7 +114,7 @@ describe("useIRWorkspace parse effect", () => {
     await runDebounce();
 
     expect(modeA.parse).toHaveBeenCalledWith("code-a");
-    await settle(() => modeA.pending[0].resolve(graph("n1")));
+    await settle(() => modeA.pending[0].resolve(parsed("n1")));
 
     expect(updateGraph).toHaveBeenCalledTimes(1);
     expect(updateGraph.mock.calls[0][0]).toEqual(graph("n1"));
@@ -135,8 +141,8 @@ describe("useIRWorkspace parse effect", () => {
     expect(modeA.pending).toHaveLength(2);
     // The newer parse lands first, then the stale one — the order a slow
     // parser produces and the reason a plain "last write wins" is not enough.
-    await settle(() => modeA.pending[1].resolve(graph("new")));
-    await settle(() => modeA.pending[0].resolve(graph("stale")));
+    await settle(() => modeA.pending[1].resolve(parsed("new")));
+    await settle(() => modeA.pending[0].resolve(parsed("stale")));
 
     expect(updateGraph).toHaveBeenCalledTimes(1);
     expect(updateGraph.mock.calls[0][0]).toEqual(graph("new"));
@@ -150,8 +156,8 @@ describe("useIRWorkspace parse effect", () => {
     await runDebounce();
 
     expect(modeB.parse).toHaveBeenCalledWith("code-b");
-    await settle(() => modeB.pending[0].resolve(graph("from-b")));
-    await settle(() => modeA.pending[0].resolve(graph("from-a")));
+    await settle(() => modeB.pending[0].resolve(parsed("from-b")));
+    await settle(() => modeA.pending[0].resolve(parsed("from-a")));
 
     expect(updateGraph).toHaveBeenCalledTimes(1);
     expect(updateGraph.mock.calls[0][0]).toEqual(graph("from-b"));
@@ -164,9 +170,74 @@ describe("useIRWorkspace parse effect", () => {
     act(() => result.current.setCode("code-a2"));
     await runDebounce();
 
-    await settle(() => modeA.pending[1].resolve(graph("new")));
+    await settle(() => modeA.pending[1].resolve(parsed("new")));
     await settle(() => modeA.pending[0].reject(new Error("stale failure")));
 
     expect(result.current.error).toBeNull();
+  });
+});
+
+// contracts/ir-mode-registry.md, "Recoverable diagnostics" + specs/graph-view.md §1.
+describe("useIRWorkspace diagnostics", () => {
+  const warning: IRParseDiagnostic = { line: 4, message: "recovered" };
+
+  it("publishes the diagnostics of a successful parse, which stays a success", async () => {
+    const { result } = renderHook(() => useIRWorkspace());
+    await runDebounce();
+
+    await settle(() => modeA.pending[0].resolve(parsed("n1", [warning])));
+
+    expect(result.current.diagnostics).toEqual([warning]);
+    expect(result.current.error).toBeNull();
+    expect(updateGraph).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports no diagnostics for a clean parse", async () => {
+    const { result } = renderHook(() => useIRWorkspace());
+    await runDebounce();
+
+    await settle(() => modeA.pending[0].resolve(parsed("n1")));
+
+    expect(result.current.diagnostics).toEqual([]);
+  });
+
+  it("clears the previous diagnostics when the next parse is clean", async () => {
+    const { result } = renderHook(() => useIRWorkspace());
+    await runDebounce();
+    await settle(() => modeA.pending[0].resolve(parsed("n1", [warning])));
+
+    act(() => result.current.setCode("code-a2"));
+    await runDebounce();
+    await settle(() => modeA.pending[1].resolve(parsed("n2")));
+
+    expect(result.current.diagnostics).toEqual([]);
+  });
+
+  it("clears the previous diagnostics when the next parse fails", async () => {
+    // The graph on screen survives a failure, but the diagnostics do not: their
+    // line numbers describe text the editor no longer holds (spec §1).
+    const { result } = renderHook(() => useIRWorkspace());
+    await runDebounce();
+    await settle(() => modeA.pending[0].resolve(parsed("n1", [warning])));
+
+    act(() => result.current.setCode("code-a2"));
+    await runDebounce();
+    await settle(() => modeA.pending[1].reject(new Error("bad syntax")));
+
+    expect(result.current.error).toBe("bad syntax");
+    expect(result.current.diagnostics).toEqual([]);
+  });
+
+  it("does not let a stale parse's diagnostics reach state", async () => {
+    const { result } = renderHook(() => useIRWorkspace());
+    await runDebounce();
+
+    act(() => result.current.setCode("code-a2"));
+    await runDebounce();
+
+    await settle(() => modeA.pending[1].resolve(parsed("new")));
+    await settle(() => modeA.pending[0].resolve(parsed("stale", [warning])));
+
+    expect(result.current.diagnostics).toEqual([]);
   });
 });

--- a/src/hooks/useIRWorkspace.ts
+++ b/src/hooks/useIRWorkspace.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { useGraphData } from "./useGraphData";
 import { IR_MODES, DEFAULT_IR_MODE_KEY, type IRModeKey } from "../irModes";
-import type { IRModeDefinition } from "../irModes/types";
+import type { IRModeDefinition, IRParseDiagnostic } from "../irModes/types";
+
+/** Shared empty list, so a clean parse does not re-render on identity alone. */
+const NO_DIAGNOSTICS: IRParseDiagnostic[] = [];
 
 const PARSE_DEBOUNCE_MS = 750;
 
@@ -9,8 +12,9 @@ const PARSE_DEBOUNCE_MS = 750;
  * Owns the IR-mode/code/parse/error side of the app: which mode is active,
  * which of the mode's views is active (contracts/ir-mode-registry.md
  * "Views"), the editor's current text, the debounced parse-on-change
- * effect, and the resulting graph (via useGraphData). Mode switching and
- * parsing are driven entirely by the IR mode registry (src/irModes).
+ * effect, the resulting graph (via useGraphData), and the parse's recoverable
+ * diagnostics. Mode switching and parsing are driven entirely by the IR mode
+ * registry (src/irModes).
  */
 export function useIRWorkspace() {
   const [modeKey, setModeKey] = useState<IRModeKey>(DEFAULT_IR_MODE_KEY);
@@ -23,6 +27,8 @@ export function useIRWorkspace() {
     mode.views?.find((view) => view.key === viewKey) ?? mode.views?.[0];
   const [code, setCode] = useState(mode.defaultCode);
   const [error, setError] = useState<string | null>(null);
+  const [diagnostics, setDiagnostics] =
+    useState<IRParseDiagnostic[]>(NO_DIAGNOSTICS);
 
   const {
     nodes,
@@ -45,16 +51,22 @@ export function useIRWorkspace() {
       void (async () => {
         try {
           const parse = activeView?.parse ?? mode.parse;
-          const graph = await parse(code);
+          const result = await parse(code);
           if (cancelled) return;
-          updateGraph(graph, {
+          updateGraph(result.graph, {
             edgeBuilder: activeView?.edgeBuilder ?? mode.edgeBuilder,
             layoutOptions: activeView?.layoutOptions ?? mode.layoutOptions,
           });
           setError(null);
+          setDiagnostics(result.diagnostics ?? NO_DIAGNOSTICS);
         } catch (err) {
           if (cancelled) return;
           setError(err instanceof Error ? err.message : "Unknown error");
+          // The diagnostics described the text of the last parse that produced
+          // a graph; the editor now holds text that failed, so their line
+          // numbers no longer point at what they describe (specs/graph-view.md
+          // §1).
+          setDiagnostics(NO_DIAGNOSTICS);
         }
       })();
     }, PARSE_DEBOUNCE_MS);
@@ -86,6 +98,7 @@ export function useIRWorkspace() {
     code,
     setCode,
     error,
+    diagnostics,
     nodes,
     edges,
     onNodesChange,

--- a/src/irModes/llvmMode.ts
+++ b/src/irModes/llvmMode.ts
@@ -46,6 +46,8 @@ define i32 @func(i32 %0, i32 %1, i1  %2) {
 // The LLVM parsers are synchronous; the registry contract is async. Adapt them
 // here rather than making the parser layer lie about being async. Each adapter
 // is a single const because views[0] must share the top-level parse's identity.
+// `LLVMParseResult` already IS an `IRParseResult`, so the module's recoverable
+// diagnostics (specs/llvm-ir.md §3.4) reach the status footer with no mapping.
 const parseCfg = async (code: string) => parseLLVM(code);
 const parseUseDef = async (code: string) => parseLLVMUseDef(code);
 

--- a/src/irModes/mermaidMode.ts
+++ b/src/irModes/mermaidMode.ts
@@ -13,7 +13,9 @@ const DEFAULT_CODE = `graph TD
 
 // parseMermaid is synchronous today; the registry contract is async. See
 // llvmMode.ts for why the adapter lives here and not in the parser layer.
-const parse = async (code: string) => parseMermaid(code);
+// The Mermaid parser either produces a graph or throws — it has no recoverable
+// middle ground to report, so the result carries no diagnostics.
+const parse = async (code: string) => ({ graph: parseMermaid(code) });
 
 export const mermaidMode = {
   key: "mermaid" as const,

--- a/src/irModes/selectionDAGMode.ts
+++ b/src/irModes/selectionDAGMode.ts
@@ -24,7 +24,12 @@ SelectionDAG has 22 nodes:
 
 // parseSelectionDAGToGraphData is synchronous; the registry contract is async.
 // See llvmMode.ts for why the adapter lives here and not in the parser layer.
-const parse = async (code: string) => parseSelectionDAGToGraphData(code);
+// The parser's per-line tolerance (registry contract, "Known behavior
+// difference") is exactly what diagnostics are for, but it does not track which
+// lines it skipped, so this result carries none yet.
+const parse = async (code: string) => ({
+  graph: parseSelectionDAGToGraphData(code),
+});
 
 export const selectionDAGMode = {
   key: "selectionDAG" as const,

--- a/src/irModes/types.ts
+++ b/src/irModes/types.ts
@@ -4,6 +4,28 @@ import type { GraphData } from "../types/graph";
 import type { IREdgeBuilder } from "../utils/layout";
 
 /**
+ * One recoverable problem found while parsing: the parser produced a graph but
+ * had to recover from a line rather than understand it. See the registry
+ * contract, "Recoverable diagnostics". `line` is 1-based in the editor text and
+ * `message` carries no severity word — the status footer writes `warning:`.
+ */
+export interface IRParseDiagnostic {
+  line: number;
+  message: string;
+}
+
+/**
+ * What a mode's `parse` resolves to. The graph is what the layout stage
+ * consumes; diagnostics travel beside it, never inside `GraphData`, because
+ * they describe the parse rather than the graph (registry contract).
+ */
+export interface IRParseResult {
+  graph: GraphData;
+  /** Omitted when the parse was clean. */
+  diagnostics?: IRParseDiagnostic[];
+}
+
+/**
  * Everything a graph view needs to support one IR (LLVM-IR, Mermaid,
  * SelectionDAG, ...). See docs/internal/contracts/ir-mode-registry.md.
  * Adding a new IR should mean adding one of these plus the IR's own
@@ -18,12 +40,13 @@ export interface IRModeDefinition {
   editorLanguage: string;
   /** Code shown in the editor when this mode is selected. */
   defaultCode: string;
-  /** Text -> graph. Rejects with an Error on invalid input (see the registry
-   * contract for SelectionDAG's per-line tolerance, which is not an exception
-   * to this). Async because a parser may need to load before it can parse; a
-   * synchronous parser is adapted here, not rewritten. Stale results are
-   * discarded by the caller — see the contract, "Parsing is asynchronous". */
-  parse: (code: string) => Promise<GraphData>;
+  /** Text -> graph + diagnostics. Rejects with an Error on invalid input (see
+   * the registry contract for SelectionDAG's per-line tolerance, which is not
+   * an exception to this). Async because a parser may need to load before it
+   * can parse; a synchronous parser is adapted here, not rewritten. Stale
+   * results are discarded by the caller — see the contract, "Parsing is
+   * asynchronous". */
+  parse: (code: string) => Promise<IRParseResult>;
   /** This mode's React Flow node renderers, keyed by the camelCase nodeType.
    * Covers every view's renderers (GraphViewer merges per mode, not per view). */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -47,8 +70,8 @@ export interface IRViewDefinition {
   key: string;
   /** Toggle label, e.g. "CFG". */
   label: string;
-  /** Text -> graph; same reject-on-invalid rule as the mode's parse. */
-  parse: (code: string) => Promise<GraphData>;
+  /** Text -> graph + diagnostics; same reject-on-invalid rule as the mode's parse. */
+  parse: (code: string) => Promise<IRParseResult>;
   /** Defaults to the mode's edgeBuilder. */
   edgeBuilder?: IREdgeBuilder;
   /** Defaults to the mode's layoutOptions. */

--- a/src/parser/__tests__/llvm/corpus.test.ts
+++ b/src/parser/__tests__/llvm/corpus.test.ts
@@ -20,7 +20,7 @@ function assertMatchesProjection(entry: CorpusEntry): void {
   const input = readFileSync(join(corpusDir, entry.file), "utf8");
 
   const ast = parseLLVMToAST(input);
-  const graph = parseLLVM(input);
+  const { graph } = parseLLVM(input);
 
   const functions = ast.functions.map((func) => ({
     name: func.name,

--- a/src/parser/__tests__/llvm/errors.test.ts
+++ b/src/parser/__tests__/llvm/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseLLVM, parseLLVMToAST } from "../../llvm";
+import { parseLLVM, parseLLVMToAST, parseLLVMUseDef } from "../../llvm";
 
 describe("llvm parser", () => {
   describe("errors", () => {
@@ -23,7 +23,7 @@ define void @f() {
         "unreachable",
       );
 
-      const graph = parseLLVM(input);
+      const { graph } = parseLLVM(input);
       expect(
         graph.nodes.find((node) => node.nodeType === "llvm-exit"),
       ).toBeUndefined();
@@ -60,7 +60,7 @@ define void @f(i32 %v) {
 d:
   ret void
 }`;
-      const graph = parseLLVM(input);
+      const { graph } = parseLLVM(input);
       const edge = graph.edges.find(
         (e) =>
           e.source.includes("_block_entry") && e.target.includes("_block_d"),
@@ -77,6 +77,33 @@ define void @f() {
       expect(() => parseLLVMToAST(input)).toThrow(
         /Line 4: block 'entry' of function '@f' has no terminator/,
       );
+    });
+
+    it("when a recovery happened, should return the diagnostics beside the graph", () => {
+      // The graph-producing entry point carries §3.4's recoverable diagnostics
+      // through to its caller (contracts/ir-mode-registry.md, "Recoverable
+      // diagnostics"); the mode passes the result to the status footer as-is.
+      const input = `
+define void @f() {
+  br label %missing
+}`;
+      const { graph, diagnostics } = parseLLVM(input);
+
+      expect(graph.nodes.length).toBeGreaterThan(0);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics?.[0].line).toBe(3);
+      expect(diagnostics?.[0].message).toMatch(
+        /terminator targets label '%missing'/,
+      );
+    });
+
+    it("when the parse is clean, should return no diagnostics", () => {
+      const input = `
+define void @f() {
+  ret void
+}`;
+      expect(parseLLVM(input).diagnostics).toBeUndefined();
+      expect(parseLLVMUseDef(input).diagnostics).toBeUndefined();
     });
 
     it("when input contains semicolon comments, should parse them as whitespace", () => {

--- a/src/parser/__tests__/llvm/graphData.test.ts
+++ b/src/parser/__tests__/llvm/graphData.test.ts
@@ -6,14 +6,14 @@ import { llvmComplexModule, llvmMinimalRet } from "../helpers/llvmFixtures";
 describe("llvm parser", () => {
   describe("graph data", () => {
     it("when parseLLVM is used, should match convertASTToGraph(parseLLVMToAST(input))", () => {
-      const direct = parseLLVM(llvmComplexModule);
+      const direct = parseLLVM(llvmComplexModule).graph;
       const viaAst = convertASTToGraph(parseLLVMToAST(llvmComplexModule));
 
       expect(direct).toEqual(viaAst);
     });
 
     it("when minimal function is parsed, should return TD graph with nodes and edges", () => {
-      const graph = parseLLVM(llvmMinimalRet);
+      const { graph } = parseLLVM(llvmMinimalRet);
 
       expect(graph.direction).toBe("TD");
       expect(graph.nodes.length).toBeGreaterThan(0);

--- a/src/parser/llvm/index.ts
+++ b/src/parser/llvm/index.ts
@@ -1,3 +1,4 @@
 // Entry point for the line-oriented LLVM-IR parser
 // (docs/internal/specs/llvm-ir.md).
 export { parseLLVM, parseLLVMToAST, parseLLVMUseDef } from "./parse";
+export type { LLVMParseResult } from "./parse";

--- a/src/parser/llvm/parse.ts
+++ b/src/parser/llvm/parse.ts
@@ -9,24 +9,42 @@
  */
 
 import type { GraphData } from "../../types/graph";
-import type { LLVMModule } from "../../ast/llvmAST";
+import type { LLVMModule, LLVMParseDiagnostic } from "../../ast/llvmAST";
 import { convertASTToGraph } from "../../graphBuilder/llvmGraphBuilder";
 import { convertASTToUseDefGraph } from "../../graphBuilder/llvmUseDefGraphBuilder";
 import { buildModule } from "./module";
+
+/**
+ * A graph plus the recoverable diagnostics recorded on the way to it
+ * (specs/llvm-ir.md §3.4). Structurally an `IRParseResult`
+ * (contracts/ir-mode-registry.md), so `llvmMode` passes it straight through —
+ * the parser layer does not import from the registry to say so.
+ */
+export interface LLVMParseResult {
+  graph: GraphData;
+  /** Absent when the parse was clean (`LLVMModule.diagnostics` is optional). */
+  diagnostics?: LLVMParseDiagnostic[];
+}
 
 export function parseLLVMToAST(input: string): LLVMModule {
   return buildModule(input);
 }
 
-export function parseLLVM(input: string): GraphData {
-  return convertASTToGraph(buildModule(input));
+export function parseLLVM(input: string): LLVMParseResult {
+  const module = buildModule(input);
+  return { graph: convertASTToGraph(module), diagnostics: module.diagnostics };
 }
 
 /**
  * Use-Def projection of the same text: the second view of the `llvm-ir`
  * mode (docs/internal/specs/llvm-use-def-view.md). Same AST, different
- * graphBuilder — no parser changes are involved.
+ * graphBuilder — no parser changes are involved, so its diagnostics are the
+ * same ones the CFG view reports.
  */
-export function parseLLVMUseDef(input: string): GraphData {
-  return convertASTToUseDefGraph(buildModule(input));
+export function parseLLVMUseDef(input: string): LLVMParseResult {
+  const module = buildModule(input);
+  return {
+    graph: convertASTToUseDefGraph(module),
+    diagnostics: module.diagnostics,
+  };
 }


### PR DESCRIPTION
The line-oriented LLVM parser records recoverable problems — implicit-id fallback, dangling terminator targets, label-after-unterminated-block recovery — in `LLVMModule.diagnostics`, but nothing surfaced them. They died at the mode boundary: the registry contract's `parse` resolved to a bare `GraphData`, so a user could receive a graph with no sign that the parser had recovered from a line rather than understood it.

Closes #64.

## What changed

**The contract, not just the UI.** `parse` now resolves to an `IRParseResult` (`{ graph, diagnostics? }`) rather than a `GraphData`. Putting the "recoverable problem" concept in the registry — instead of hanging an LLVM-only field off the graph payload — means the same channel already covers SelectionDAG's per-line tolerance (`contracts/ir-mode-registry.md`, "Known behavior difference") and the duplicate-label diagnostic proposed in #111, with no further contract change. Neither reports through it yet, and the docs say so rather than implying coverage.

Two properties keep this from leaking:

- **Diagnostics are not graph data.** They describe the parse, so they never enter `GraphData` and the layout stage never sees them — a topology signature is unaffected.
- **No mapping layer.** `LLVMParseResult` is structurally an `IRParseResult`, so `llvmMode`'s adapters stay one-liners and the parser layer still does not import from the registry. This mirrors how `LogicalLineDiagnostic` is already assignable to `LLVMParseDiagnostic`.

**Presentation.** The status footer keeps its success line and adds one `warning: line N: <message>` line per diagnostic, with a 2 px amber left rule (new `warn` token, `#9A6700`). The prefix is deliberately not `error:` so that "did this input parse?" stays answerable by looking for a single word; correspondingly, the parser's messages carry no severity word of their own — the footer owns severity. An error outranks warnings on the left rule, and the two never co-occur: a failed parse clears the diagnostics, because their line numbers describe text the editor no longer holds.

Inline Monaco markers were considered and deliberately left out of scope — diagnostics are line-anchored and would eventually want to live next to the line, but that means amending `graph-view.md` §6.3's "the footer is the only place parse status is reported", which is a separate decision.

## Docs first

- `contracts/ir-mode-registry.md` — new "Recoverable diagnostics" section; `parse`/view signatures; SelectionDAG note.
- `specs/graph-view.md` — §1 (diagnostics replaced on success, cleared on failure, with the reason), §6.3 (the three footer states and severity precedence), §6.6 (the `warn` token).
- `specs/llvm-ir.md` — §3.4 now describes the actual behavior instead of pointing at this issue; the matching §5 limitation is gone.
- `architecture.md` — data-flow and layer map.

## Review notes

- `parseLLVM` / `parseLLVMUseDef` changed shape; every call site (5 test files) was updated rather than kept compatible, per the repo's no-back-compat principle.
- `EditorPanel.test.tsx` is new and calls `cleanup` itself: Vitest runs without `globals`, so testing-library's auto-cleanup is off and stacked renders would otherwise break `getByTestId`.
- Verified in the real app, not only in tests: input with a dangling `br label %missing` renders `✓ parsed · 8 nodes · 10 edges` plus `warning: line 3: terminator targets label '%missing', ...` with no `error:`; breaking the input replaces it with the error and drops the warning.
- `npm run test:run` (605 passed), `npm run test:e2e` (9 passed), `npm run lint`, `npm run format`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)