### PR TITLE
fix(llvm): serialize graph node and edge ids injectively

### DIFF
--- a/docs/internal/contracts/graph-data.md
+++ b/docs/internal/contracts/graph-data.md
@@ -30,6 +30,25 @@ mode-specific edge type — that is what lets `useGraphData` and `layout.ts` run
 pattern when it is set. The LLVM Use-Def view sets it on phi incoming-value edges
 (`specs/llvm-use-def-view.md` §3.1).
 
+## Id uniqueness
+
+**Ids are unique within a `GraphData`**: no two nodes share an `id`, and no two edges share
+one (nodes and edges are separate namespaces). This is an obligation on every graphBuilder,
+not a property converter/layout can restore — React Flow drops a duplicate id silently, so a
+violation surfaces as a node or edge that is simply missing, with no error anywhere.
+
+Ids are **opaque** downstream: converter, layout, and the edge router compare and index them
+but never parse them, so each mode is free to choose its own id grammar. How each mode meets
+the obligation:
+
+- **LLVM** (both views) serializes a structured key injectively — `specs/llvm-ir.md` §4.1.
+  Distinct keys always produce distinct ids, which reduces uniqueness to the parser keeping
+  its AST keys distinct ([Issue #111](https://github.com/himadajin/ir-visualizer/issues/111)).
+- **Mermaid** keys nodes by their source id and collects them through a `Map`, so a node
+  mentioned several times in the source is one node; edge ids carry their source-order index.
+- **SelectionDAG** uses the printed `tN` node numbers as ids and inherits uniqueness from the
+  input's numbering; edge ids carry the operand index.
+
 ## GraphNode.astData
 
 `astData` is a discriminated union keyed on `nodeType`, one variant per concrete node renderer:

--- a/docs/internal/specs/llvm-ir.md
+++ b/docs/internal/specs/llvm-ir.md
@@ -280,10 +280,6 @@ uniform-successor rule instead of crashing.
 
 `parseLLVM(input)` is exactly `convertASTToGraph(parseLLVMToAST(input))`.
 
-ID namespacing: node ids embed the function name (`func_<name>_block_<label>` etc.) so
-multiple functions can reuse block labels (`entry`, numeric labels) without collision; ids
-are unique across the whole graph.
-
 The produced graph always has `direction: "TD"`.
 
 > Pinned by: `src/graphBuilder/__tests__/llvm/edges.test.ts`,
@@ -292,11 +288,72 @@ The produced graph always has `direction: "TD"`.
 > `src/parser/__tests__/llvm/graphData.test.ts`,
 > `src/parser/__tests__/llvm/errors.test.ts`
 
+### 4.1 Node and edge ids
+
+Both LLVM views build ids the same way, from `src/graphBuilder/llvmIds.ts`. An id is a
+`:`-joined list of fragments, where `:` separates and `%` escapes. A fragment carrying free
+text — a name, a block id, a case value — is escaped so it can contain neither character:
+`%` becomes `%25`, `:` becomes `%3A`, and nothing else is rewritten. Fixed tags (`func`,
+`block`, `edge`, …) come from a closed vocabulary and never need escaping. Ids are therefore
+**injective** — two different sources never produce the same id — and decodable back to their
+fragments.
+
+A name is reduced to its **canonical** form before it is escaped: sigil removed, surrounding
+quotes removed, escape sequences kept verbatim. This is the reduction the tokenizer already
+performs for `Token.value` (§1), so block ids and terminator targets arrive canonical and
+only the AST's raw-text names (function, global, metadata, attribute group) are reduced here.
+`@"main"` and `@main` are the same LLVM name and share an id by construction; `@"a@b"` keeps
+its inner `@` and stays distinct from `@ab`. The AST deliberately keeps the raw spelling for
+display, which is why the reduction is restated in the id layer instead of imported from
+`src/parser` (`architecture.md`).
+
+| `nodeType`            | Id                                                |
+| --------------------- | ------------------------------------------------- |
+| `llvm-functionHeader` | `func:<name>:header`                              |
+| `llvm-basicBlock`     | `func:<name>:block:<blockId>`                     |
+| `llvm-exit`           | `func:<name>:exit`                                |
+| `llvm-globalVariable` | `global:<name>`                                   |
+| `llvm-attributeGroup` | `attr:<id>`                                       |
+| `llvm-metadata`       | `meta:<id>`                                       |
+| `llvm-declaration`    | `decl:<index>` — 0-based position in module order |
+
+Declarations are keyed by position because their names are not extracted (§5); every other
+kind is keyed by its canonical name, so the id is stable under edits elsewhere in the module.
+Use-Def node ids follow the same grammar under the same `func:<name>` prefix
+(`specs/llvm-use-def-view.md` §2).
+
+An edge id is the tag `edge`, then its source id, its target id, then the variant fragments
+that distinguish parallel edges between the same pair:
+
+| Edge (§4 rule)         | Variant                   |
+| ---------------------- | ------------------------- |
+| header → entry (1)     | _none_                    |
+| conditional `br` (2)   | `true` / `false`          |
+| unconditional `br` (3) | _none_                    |
+| `ret` → exit (4)       | _none_                    |
+| `switch` (5)           | `default`, `case:<value>` |
+| `invoke` (6)           | `to` / `unwind`           |
+| uniform successors (7) | `succ:<index>`            |
+
+The successor index (rule 7) and the case value (rule 5) are what keep two edges to the same
+target apart; a `switch` whose case value is literally `default` stays distinct from the
+default edge because the tag is separate from the value.
+
+Splicing whole ids into an edge id needs no second escaping level: every id kind is a fixed
+number of fragments once its tags are read (after `func` comes one name fragment, then a tag
+that fixes the rest), so a concatenation of ids reads back unambiguously.
+
+> Pinned by: `src/graphBuilder/__tests__/llvm/invariants.test.ts`,
+> `src/graphBuilder/__tests__/llvm/useDefGraph.test.ts`
+
 ## 5. Known limitations
 
 - **Duplicate explicit labels are not diagnosed.** Two `a:` labels in one function produce
   two blocks with the same id — and thus colliding graph node ids (_observed, untested_).
-  The implicit-numbering collision fallback (§3.3) covers implicit ids only.
+  The implicit-numbering collision fallback (§3.3) covers implicit ids only. This is the one
+  remaining way to get two identical ids: §4.1's serialization is injective, so identical ids
+  can only come from two AST blocks that genuinely share a key
+  ([Issue #111](https://github.com/himadajin/ir-visualizer/issues/111)).
 - `catchswitch`, `catchret`, `cleanupret`, `callbr`, and `indirectbr` are understood only
   through the uniform successor rule: their edges are unlabeled and carry no per-opcode
   semantics (e.g. a `callbr` fallthrough edge is not distinguished from its indirect
@@ -317,4 +374,5 @@ The produced graph always has `direction: "TD"`.
 - `LLVMModule.diagnostics` is recorded but not surfaced in the UI
   ([Issue #64](https://github.com/himadajin/ir-visualizer/issues/64)).
 - Extracting declaration names is still not done (`LLVMDeclaration.name` is always the
-  literal `"declaration"`).
+  literal `"declaration"`), which is why declaration node ids are keyed by position (§4.1)
+  rather than by name.

--- a/docs/internal/specs/llvm-use-def-view.md
+++ b/docs/internal/specs/llvm-use-def-view.md
@@ -27,17 +27,13 @@ targets, debug records — produce **no nodes**.
 
 ## 2. Nodes
 
-All ids are namespaced by function, using the same `func_<name>` prefixing
-convention as the CFG builder, so identical block labels or value names across
-functions cannot collide. Quoted identifiers are an exception: `uniqueId` strips every
-`@`, `%`, and `"` character anywhere in the name, so a quoted name whose _contents_
-include those characters can still collide with an unrelated name after stripping
-(e.g. `@"a@b"` and `@ab` both prefix to `func_ab`) — an encoding gap shared with the CFG
-builder (`llvmGraphBuilder.ts`) (_observed, untested_).
+Ids follow the shared grammar of `specs/llvm-ir.md` §4.1 and sit under the same
+`func:<name>` prefix as the CFG builder's, so identical block labels or value names
+across functions cannot collide, and the two views namespace identically.
 
 ### 2.1 Instruction nodes
 
-`nodeType: "llvm-useDefInstruction"`, id `<funcPrefix>_ud_<blockId>_i<n>` where
+`nodeType: "llvm-useDefInstruction"`, id `func:<name>:ud:<blockId>:<n>` where
 `n` is the 0-based index of the line among the lines its block actually emits,
 in program order.
 
@@ -67,13 +63,13 @@ line, `originalText === ""`, no `defs`/`uses`) never produce a node.
 `nodeType: "llvm-useDefValue"`, `astData: { name, kind, paramType? }`:
 
 - `kind: "argument"` — one per **named** function parameter, id
-  `<funcPrefix>_udarg_<name>`, emitted whether or not the parameter is used;
+  `func:<name>:udarg:<value name>`, emitted whether or not the parameter is used;
   `paramType` is the parameter's raw type text. Unnamed parameters get no node
   (the parser leaves `name: null`); a body referring to an implicit `%0`-style
   parameter name resolves as `external` instead.
 - `kind: "external"` — created **lazily** for a `uses` entry whose name has no
   known def in the function (degraded parses, undefined names, implicit
-  parameter names), id `<funcPrefix>_udext_<name>`. Use extraction is heuristic
+  parameter names), id `func:<name>:udext:<value name>`. Use extraction is heuristic
   (§3.5), so edge construction must be total rather than throwing on an
   unresolved name.
 
@@ -83,7 +79,7 @@ For every emitted node `N` and every name `v` in `N.uses`, one edge from the
 node that defines `v` — the instruction node whose `def` is `v`, else the
 argument value node for `v`, else a lazily created external value node — to `N`.
 
-- `id`: `e-<sourceId>-<targetId>-<v>`.
+- `id`: `edge:<sourceId>:<targetId>:<v>` (`specs/llvm-ir.md` §4.1).
 - `targetHandle`: `"u-<v>"` — the edge lands on the target card's per-operand
   port for `v` (§4). Sources use the defining node's single source handle.
 - **No label.** The defined name is already visible in the source node's text.

--- a/src/graphBuilder/__tests__/llvm/edges.test.ts
+++ b/src/graphBuilder/__tests__/llvm/edges.test.ts
@@ -117,7 +117,7 @@ describe("llvm graphBuilder", () => {
       const entryId = graph.nodes.find(
         (node) =>
           node.nodeType === "llvm-basicBlock" &&
-          node.id.includes("_block_entry"),
+          node.id.includes(":block:entry"),
       )?.id;
       expect(entryId).toBeDefined();
 
@@ -158,7 +158,7 @@ describe("llvm graphBuilder", () => {
       const entryId = graph.nodes.find(
         (node) =>
           node.nodeType === "llvm-basicBlock" &&
-          node.id.includes("_block_entry"),
+          node.id.includes(":block:entry"),
       )?.id;
       expect(entryId).toBeDefined();
 
@@ -194,7 +194,7 @@ describe("llvm graphBuilder", () => {
       const entryId = graph.nodes.find(
         (node) =>
           node.nodeType === "llvm-basicBlock" &&
-          node.id.includes("_block_entry"),
+          node.id.includes(":block:entry"),
       )?.id;
       expect(entryId).toBeDefined();
 
@@ -258,13 +258,13 @@ describe("llvm graphBuilder", () => {
       const entryId = graph.nodes.find(
         (node) =>
           node.nodeType === "llvm-basicBlock" &&
-          node.id.includes("_block_entry"),
+          node.id.includes(":block:entry"),
       )?.id;
       expect(entryId).toBeDefined();
 
       const edges = edgesFrom(graph.edges, entryId!);
       expect(edges).toHaveLength(1);
-      expect(edges[0].target).toContain("_block_d");
+      expect(edges[0].target).toContain(":block:d");
       expect(edges[0].label).toBeUndefined();
     });
 

--- a/src/graphBuilder/__tests__/llvm/invariants.test.ts
+++ b/src/graphBuilder/__tests__/llvm/invariants.test.ts
@@ -5,6 +5,7 @@ import {
   createBlock,
   createFunction,
   createModule,
+  createOpaqueTerminator,
   createRetTerminator,
 } from "../helpers/llvmFixtures";
 import type { LLVMBrInstruction } from "../../../ast/llvmAST";
@@ -14,6 +15,10 @@ const COVERAGE_CHECKPOINTS = [
   "id-uniqueness",
   "exit-dedup",
   "function-scope-namespacing",
+  "name-canonicalization",
+  "quoted-name-injectivity",
+  "declaration-id-uniqueness",
+  "parallel-successor-edges",
 ] as const;
 
 describe("llvm graphBuilder", () => {
@@ -91,6 +96,122 @@ describe("llvm graphBuilder", () => {
 
       const header = findNodeByType(graph.nodes, "llvm-functionHeader");
       expect(header).toBeDefined();
+    });
+
+    it("when a name is quoted, should key the id by its canonical form", () => {
+      // Spec §4.1: the sigil and the surrounding quotes are not part of the
+      // name, so `@"main"` is the same LLVM name as `@main` and gets the
+      // same id — the quotes are syntax, not content.
+      const graph = convertASTToGraph(
+        createModule({
+          functions: [
+            createFunction('@"main"', [
+              createBlock("entry", createRetTerminator()),
+            ]),
+          ],
+        }),
+      );
+
+      expect(findNodeByType(graph.nodes, "llvm-functionHeader")?.id).toBe(
+        "func:main:header",
+      );
+    });
+
+    it("when a quoted name contains a sigil, should not collide with the stripped name", () => {
+      // Regression: the id used to be built by deleting every `@`, `%`, and
+      // `"` anywhere in the name, so `@"a@b"` and `@ab` both became
+      // `func_ab` and React Flow silently dropped the second function.
+      const graph = convertASTToGraph(
+        createModule({
+          functions: [
+            createFunction('@"a@b"', [
+              createBlock("entry", createRetTerminator()),
+            ]),
+            createFunction("@ab", [
+              createBlock("entry", createRetTerminator()),
+            ]),
+          ],
+        }),
+      );
+
+      expectUniqueIds(graph.nodes);
+      expectUniqueIds(graph.edges);
+      expect(
+        graph.nodes.filter((node) => node.nodeType === "llvm-basicBlock"),
+      ).toHaveLength(2);
+    });
+
+    it("when a name contains the separator, should escape it rather than merge fragments", () => {
+      // A quoted name may contain `:`; escaping it is what keeps a name from
+      // impersonating the fragment boundary (§4.1).
+      const graph = convertASTToGraph(
+        createModule({
+          functions: [
+            createFunction('@"a:block:b"', [
+              createBlock("entry", createRetTerminator()),
+            ]),
+          ],
+        }),
+      );
+
+      expect(findNodeByType(graph.nodes, "llvm-functionHeader")?.id).toBe(
+        "func:a%3Ablock%3Ab:header",
+      );
+    });
+
+    it("when a module has several declarations, should give each its own id", () => {
+      // Declaration names are not extracted (§5), so every declaration
+      // carried the same name-derived id and all but one node vanished.
+      const graph = convertASTToGraph(
+        createModule({
+          declarations: [
+            {
+              type: "Declaration",
+              name: "declaration",
+              definition: "declare i32 @a()",
+            },
+            {
+              type: "Declaration",
+              name: "declaration",
+              definition: "declare i32 @b()",
+            },
+          ],
+        }),
+      );
+
+      const declarations = graph.nodes.filter(
+        (node) => node.nodeType === "llvm-declaration",
+      );
+      expect(declarations).toHaveLength(2);
+      expectUniqueIds(declarations);
+    });
+
+    it("when a terminator repeats a successor, should keep both edges", () => {
+      // Rule 7 edges are unlabeled, so the successor index is the only thing
+      // separating two edges to the same target (§4.1).
+      const graph = convertASTToGraph(
+        createModule({
+          functions: [
+            createFunction("foo", [
+              createBlock(
+                "entry",
+                createOpaqueTerminator(
+                  "indirectbr",
+                  ["a", "a"],
+                  "indirectbr ptr %p, [label %a, label %a]",
+                ),
+              ),
+              createBlock("a", createRetTerminator()),
+            ]),
+          ],
+        }),
+      );
+
+      const parallel = graph.edges.filter(
+        (edge) => edge.target === "func:foo:block:a",
+      );
+      expect(parallel).toHaveLength(2);
+      expectUniqueIds(parallel);
     });
   });
 });

--- a/src/graphBuilder/__tests__/llvm/useDefGraph.test.ts
+++ b/src/graphBuilder/__tests__/llvm/useDefGraph.test.ts
@@ -198,7 +198,7 @@ describe("llvm useDef graphBuilder", () => {
       expect(instructionData(nodes[0]).text).toBe("%a = add i32 1, 2");
       // The skipped `fence` line consumes no index: emitted lines are what
       // `i<n>` counts (spec §2.1).
-      expect(nodes[0].id).toBe("func_foo_ud_entry_i0");
+      expect(nodes[0].id).toBe("func:foo:ud:entry:0");
     });
 
     it("terminators that read or define values get nodes", () => {
@@ -265,7 +265,7 @@ describe("llvm useDef graphBuilder", () => {
       );
 
       const ids = instructionNodes(graph.nodes).map((node) => node.id);
-      expect(ids).toEqual(["func_foo_ud_entry_i0", "func_bar_ud_entry_i0"]);
+      expect(ids).toEqual(["func:foo:ud:entry:0", "func:bar:ud:entry:0"]);
       expectUniqueIds(graph.nodes);
     });
 
@@ -361,8 +361,8 @@ describe("llvm useDef graphBuilder", () => {
       const args = valueNodes(graph.nodes);
       expect(args).toHaveLength(2);
       expect(args.map((node) => node.id)).toEqual([
-        "func_foo_udarg_x",
-        "func_foo_udarg_y",
+        "func:foo:udarg:x",
+        "func:foo:udarg:y",
       ]);
       expect(args[0].astData).toEqual({
         name: "x",
@@ -402,7 +402,7 @@ describe("llvm useDef graphBuilder", () => {
         ),
       ).toHaveLength(0);
       // The implicit `%0` parameter name resolves as external instead.
-      expect(graph.nodes.map((node) => node.id)).toContain("func_foo_udext_0");
+      expect(graph.nodes.map((node) => node.id)).toContain("func:foo:udext:0");
     });
 
     it("external value node for names with no known def", () => {
@@ -427,7 +427,7 @@ describe("llvm useDef graphBuilder", () => {
 
       const externals = valueNodes(graph.nodes);
       expect(externals).toHaveLength(1);
-      expect(externals[0].id).toBe("func_foo_udext_undef");
+      expect(externals[0].id).toBe("func:foo:udext:undef");
       expect(externals[0].astData).toEqual({ name: "undef", kind: "external" });
       // Created once and reused by every unresolved reader.
       expect(
@@ -498,7 +498,7 @@ describe("llvm useDef graphBuilder", () => {
       );
 
       expect(graph.edges[0].id).toBe(
-        "e-func_foo_ud_entry_i0-func_foo_ud_entry_i1-a",
+        "edge:func:foo:ud:entry:0:func:foo:ud:entry:1:a",
       );
     });
 
@@ -534,8 +534,8 @@ describe("llvm useDef graphBuilder", () => {
       );
 
       expect(graph.edges).toHaveLength(1);
-      expect(graph.edges[0].source).toBe("func_foo_udarg_x");
-      expect(graph.edges[0].target).toBe("func_foo_ud_entry_i0");
+      expect(graph.edges[0].source).toBe("func:foo:udarg:x");
+      expect(graph.edges[0].target).toBe("func:foo:ud:entry:0");
       expect(graph.edges[0].label).toBeUndefined();
     });
 
@@ -592,7 +592,7 @@ describe("llvm useDef graphBuilder", () => {
       expect(graph.edges[0].label).toBe("%a (%bb1, %bb2)");
       expect(graph.edges[0].dashed).toBe(true);
       expect(graph.edges[0].id).toBe(
-        "e-func_foo_ud_bb1_i0-func_foo_ud_join_i0-a",
+        "edge:func:foo:ud:bb1:0:func:foo:ud:join:0:a",
       );
     });
 
@@ -676,7 +676,7 @@ describe("llvm useDef graphBuilder", () => {
       // Two functions that are identical in every way the ids are built
       // from — same block label ("entry"), same instruction defs/uses
       // ("a", "b", "c"), same named parameter ("x"), same unresolved name
-      // ("undef") — so only the func_<name> prefix (spec §2) can keep
+      // ("undef") — so only the func:<name> prefix (spec §2) can keep
       // instruction, argument, external, and edge ids from colliding.
       const makeFunction = (name: string): LLVMFunction =>
         func(
@@ -718,21 +718,77 @@ describe("llvm useDef graphBuilder", () => {
       expect(graph.edges).toHaveLength(8);
       expectUniqueIds(graph.edges);
 
-      // Explicit edge-id uniqueness check: the "-a" suffix (edge id embeds
+      // Explicit edge-id uniqueness check: the ":a" suffix (edge id embeds
       // the value name, spec §3) is identical for both functions, so this
-      // is exactly the case that would collide without the func_<name>
+      // is exactly the case that would collide without the func:<name>
       // prefix on the edge's source/target ids.
       const edgeIdsEndingInA = graph.edges
         .map((edge) => edge.id)
-        .filter((id) => id.endsWith("-a"));
+        .filter((id) => id.endsWith(":a"));
       expect(edgeIdsEndingInA).toHaveLength(2);
       expect(new Set(edgeIdsEndingInA).size).toBe(2);
       expect(edgeIdsEndingInA).toEqual(
         expect.arrayContaining([
-          "e-func_foo_ud_entry_i0-func_foo_ud_entry_i1-a",
-          "e-func_bar_ud_entry_i0-func_bar_ud_entry_i1-a",
+          "edge:func:foo:ud:entry:0:func:foo:ud:entry:1:a",
+          "edge:func:bar:ud:entry:0:func:bar:ud:entry:1:a",
         ]),
       );
+    });
+
+    it("a quoted function name containing a sigil does not collide with the stripped name", () => {
+      // Regression, the Use-Def half of the same defect: ids used to be
+      // built by deleting every `@`, `%`, and `"` anywhere in the name, so
+      // `@"a@b"` and `@ab` shared the `func_ab` prefix and every node and
+      // edge of the second function was dropped by React Flow.
+      const makeFunction = (name: string): LLVMFunction =>
+        func(
+          name,
+          [
+            block(
+              "entry",
+              "entry",
+              [
+                line({ text: "%a = add i32 1, 2", defs: ["a"] }),
+                line({ text: "%b = mul i32 %a, %x", defs: ["b"], uses: ["a"] }),
+              ],
+              terminator({ text: "ret i32 %b", opcode: "ret", uses: ["b"] }),
+            ),
+          ],
+          [{ type: "i32", name: "%x" }],
+        );
+
+      const graph = convertASTToUseDefGraph(
+        moduleOf(makeFunction('@"a@b"'), makeFunction("@ab")),
+      );
+
+      expect(instructionNodes(graph.nodes)).toHaveLength(6);
+      expectUniqueIds(graph.nodes);
+      expectUniqueIds(graph.edges);
+    });
+
+    it("a value name containing the separator is escaped, not merged into the id", () => {
+      // Quoted local names can contain `:`; escaping is what keeps the name
+      // from impersonating a fragment boundary (specs/llvm-ir.md §4.1).
+      const graph = convertASTToUseDefGraph(
+        moduleOf(
+          func(
+            "@f",
+            [
+              block(
+                "entry",
+                "entry",
+                [line({ text: '%a = add i32 %"x:y", 1', defs: ["a"] })],
+                terminator({ text: "ret i32 %a", opcode: "ret", uses: ["a"] }),
+              ),
+            ],
+            [{ type: "i32", name: '%"x:y"' }],
+          ),
+        ),
+      );
+
+      expect(valueNodes(graph.nodes).map((node) => node.id)).toEqual([
+        "func:f:udarg:x%3Ay",
+      ]);
     });
   });
 });

--- a/src/graphBuilder/llvmGraphBuilder.ts
+++ b/src/graphBuilder/llvmGraphBuilder.ts
@@ -1,5 +1,16 @@
 import type { GraphData, GraphNode, GraphEdge } from "../types/graph";
 import type { LLVMModule, LLVMBasicBlock } from "../ast/llvmAST";
+import {
+  attributeGroupId,
+  basicBlockId,
+  declarationId,
+  edgeId,
+  functionExitId,
+  functionHeaderId,
+  functionId,
+  globalVariableId,
+  metadataId,
+} from "./llvmIds";
 
 /**
  * Build the label text from a BasicBlock's instructions and terminator.
@@ -18,15 +29,11 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
   const nodes: GraphNode[] = [];
   const edges: GraphEdge[] = [];
 
-  // Helper to generate unique IDs if necessary
-  const uniqueId = (prefix: string, name: string) =>
-    `${prefix}_${name.replace(/[@%"]/g, "")}`;
-
   // 1. Process Global Variables
   if (module.globalVariables) {
     module.globalVariables.forEach((gVar) => {
       nodes.push({
-        id: uniqueId("global", gVar.name),
+        id: globalVariableId(gVar.name),
         label: gVar.originalText,
         type: "square",
         language: "llvm",
@@ -40,7 +47,7 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
   if (module.attributes) {
     module.attributes.forEach((attr) => {
       nodes.push({
-        id: uniqueId("attr", attr.id),
+        id: attributeGroupId(attr.id),
         label: attr.originalText,
         type: "square",
         language: "llvm",
@@ -54,7 +61,7 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
   if (module.metadata) {
     module.metadata.forEach((meta) => {
       nodes.push({
-        id: uniqueId("meta", meta.id),
+        id: metadataId(meta.id),
         label: meta.originalText,
         type: "square",
         language: "llvm",
@@ -66,9 +73,9 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
 
   // 4. Process Declarations
   if (module.declarations) {
-    module.declarations.forEach((decl) => {
+    module.declarations.forEach((decl, index) => {
       nodes.push({
-        id: uniqueId("decl", decl.name),
+        id: declarationId(index),
         label: decl.definition,
         type: "square",
         language: "llvm",
@@ -80,11 +87,10 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
 
   // 5. Process Functions
   module.functions.forEach((func) => {
-    // Namespace function blocks to avoid collisions if multiple functions use same labels (e.g. "entry")
-    // Although LLVM IR usually has implicit or explicit numbering that prevents simple clashes,
-    // separate functions definitely have separate scopes.
-    const funcPrefix = uniqueId("func", func.name);
-    const headerId = `${funcPrefix}_header`;
+    // Every id below hangs off the function's own namespace (§4.1), so blocks
+    // and values may reuse labels such as `entry` across functions.
+    const funcPrefix = functionId(func.name);
+    const headerId = functionHeaderId(funcPrefix);
 
     // Entry Node
     nodes.push({
@@ -102,12 +108,7 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
     const blocks = func.blocks;
 
     blocks.forEach((block) => {
-      // Block IDs need to be scoped to function because 'entry' or numbered blocks '%1' repeat across functions.
-      // Using a composite ID: funcName_blockName
-      const rawBlockId = block.id;
-      // block.id comes from Label rule (ident) or 'entry'.
-      // If it's a numeric label from source (like "4:"), ohm might capture "4".
-      const blockId = `${funcPrefix}_block_${rawBlockId}`;
+      const blockId = basicBlockId(funcPrefix, block.id);
 
       nodes.push({
         id: blockId,
@@ -129,18 +130,21 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
         // opcode-based switch would read fields such a node does not have.
         if ("condition" in terminator && terminator.condition !== undefined) {
           // Conditional branch: true / false labeled edges.
-          const trueId = `${funcPrefix}_block_${terminator.trueTarget ?? ""}`;
-          const falseId = `${funcPrefix}_block_${terminator.falseTarget ?? ""}`;
+          const trueId = basicBlockId(funcPrefix, terminator.trueTarget ?? "");
+          const falseId = basicBlockId(
+            funcPrefix,
+            terminator.falseTarget ?? "",
+          );
 
           edges.push({
-            id: `e-${blockId}-${trueId}-true`,
+            id: edgeId(blockId, trueId, "true"),
             source: blockId,
             target: trueId,
             label: "true",
             type: "arrow",
           });
           edges.push({
-            id: `e-${blockId}-${falseId}-false`,
+            id: edgeId(blockId, falseId, "false"),
             source: blockId,
             target: falseId,
             label: "false",
@@ -151,9 +155,9 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
           terminator.destination !== undefined
         ) {
           // Unconditional branch: one unlabeled edge.
-          const targetId = `${funcPrefix}_block_${terminator.destination}`;
+          const targetId = basicBlockId(funcPrefix, terminator.destination);
           edges.push({
-            id: `e-${blockId}-${targetId}`,
+            id: edgeId(blockId, targetId),
             source: blockId,
             target: targetId,
             type: "arrow",
@@ -162,7 +166,7 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
           // ret has no positive shape marker; the parser never produces an
           // opaque node with opcode "ret", so the opcode check is exact.
           // One shared exit node per function, created on first ret.
-          const exitId = `${funcPrefix}_exit`;
+          const exitId = functionExitId(funcPrefix);
 
           if (!nodes.find((n) => n.id === exitId)) {
             nodes.push({
@@ -176,16 +180,16 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
           }
 
           edges.push({
-            id: `e-${blockId}-${exitId}`,
+            id: edgeId(blockId, exitId),
             source: blockId,
             target: exitId,
             type: "arrow",
           });
         } else if ("defaultTarget" in terminator) {
           // Structured switch: default edge + one labeled edge per case.
-          const defaultId = `${funcPrefix}_block_${terminator.defaultTarget}`;
+          const defaultId = basicBlockId(funcPrefix, terminator.defaultTarget);
           edges.push({
-            id: `e-${blockId}-${defaultId}-default`,
+            id: edgeId(blockId, defaultId, "default"),
             source: blockId,
             target: defaultId,
             label: "default",
@@ -193,9 +197,9 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
           });
 
           terminator.cases.forEach((c) => {
-            const targetId = `${funcPrefix}_block_${c.target}`;
+            const targetId = basicBlockId(funcPrefix, c.target);
             edges.push({
-              id: `e-${blockId}-${targetId}-case-${c.value}`,
+              id: edgeId(blockId, targetId, "case", c.value),
               source: blockId,
               target: targetId,
               label: c.value,
@@ -204,17 +208,17 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
           });
         } else if ("normalTarget" in terminator) {
           // Structured invoke: `to`- and `unwind`-labeled edges.
-          const toId = `${funcPrefix}_block_${terminator.normalTarget}`;
-          const unwindId = `${funcPrefix}_block_${terminator.unwindTarget}`;
+          const toId = basicBlockId(funcPrefix, terminator.normalTarget);
+          const unwindId = basicBlockId(funcPrefix, terminator.unwindTarget);
           edges.push({
-            id: `e-${blockId}-${toId}-to`,
+            id: edgeId(blockId, toId, "to"),
             source: blockId,
             target: toId,
             label: "to",
             type: "arrow",
           });
           edges.push({
-            id: `e-${blockId}-${unwindId}-unwind`,
+            id: edgeId(blockId, unwindId, "unwind"),
             source: blockId,
             target: unwindId,
             label: "unwind",
@@ -226,9 +230,9 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
           // degraded br/switch/invoke). unreachable / resume / unwind
           // arrive with successors: [] and correctly gain no edge.
           terminator.successors.forEach((successor, index) => {
-            const targetId = `${funcPrefix}_block_${successor}`;
+            const targetId = basicBlockId(funcPrefix, successor);
             edges.push({
-              id: `e-${blockId}-${targetId}-s${String(index)}`,
+              id: edgeId(blockId, targetId, "succ", String(index)),
               source: blockId,
               target: targetId,
               type: "arrow",
@@ -239,9 +243,9 @@ export function convertASTToGraph(module: LLVMModule): GraphData {
     });
 
     if (func.entry) {
-      const entryBlockId = `${funcPrefix}_block_${func.entry.id}`;
+      const entryBlockId = basicBlockId(funcPrefix, func.entry.id);
       edges.push({
-        id: `e-${headerId}-${entryBlockId}`,
+        id: edgeId(headerId, entryBlockId),
         source: headerId,
         target: entryBlockId,
         type: "arrow",

--- a/src/graphBuilder/llvmIds.ts
+++ b/src/graphBuilder/llvmIds.ts
@@ -1,0 +1,99 @@
+/**
+ * The LLVM node/edge id convention (`specs/llvm-ir.md` §4.1), shared by the CFG
+ * builder and the Use-Def builder so both views namespace identically.
+ *
+ * Two rules produce every id. A name is reduced to its canonical form — sigil
+ * and surrounding quotes removed — so that spellings LLVM considers equal are
+ * equal here too. Every fragment is then escaped so it can contain neither the
+ * separator nor the escape character, and the fragments are joined. Distinct
+ * keys therefore always produce distinct ids, and an id decodes back to its
+ * fragments.
+ *
+ * The constructors below are the only supported way to build these ids:
+ * escaping applies once, at the point a raw fragment enters, and an already
+ * built id is spliced in as-is (it is already a valid fragment sequence).
+ */
+
+const SEPARATOR = ":";
+
+/**
+ * Escape a free-text fragment. `%` goes first so that the `%` introduced by the
+ * `:` rule is not escaped again; decoding is the reverse pair.
+ */
+function fragment(raw: string): string {
+  return raw.replace(/%/g, "%25").replace(/:/g, "%3A");
+}
+
+/**
+ * The canonical form of a name: sigil dropped, surrounding quotes dropped,
+ * escape sequences kept verbatim (never unescaped) — the same reduction the
+ * tokenizer performs for `Token.value`, restated here because `src/graphBuilder`
+ * imports downward only (`architecture.md`) and the AST keeps the raw spelling
+ * for display. Total: an unterminated quoted name keeps its opening quote
+ * rather than throwing.
+ */
+export function canonicalName(raw: string): string {
+  const withoutSigil = /^[@%!#]/.test(raw) ? raw.slice(1) : raw;
+  const quoted = /^"(.*)"$/.exec(withoutSigil);
+  return quoted === null ? withoutSigil : quoted[1];
+}
+
+/** Join parts that are already escaped (raw text must go through `fragment`). */
+const join = (...parts: string[]): string => parts.join(SEPARATOR);
+
+/** `func:<name>` — the per-function namespace both views hang their ids on. */
+export const functionId = (name: string): string =>
+  join("func", fragment(canonicalName(name)));
+
+export const functionHeaderId = (funcId: string): string =>
+  join(funcId, "header");
+
+export const functionExitId = (funcId: string): string => join(funcId, "exit");
+
+export const basicBlockId = (funcId: string, blockId: string): string =>
+  join(funcId, "block", fragment(blockId));
+
+export const globalVariableId = (name: string): string =>
+  join("global", fragment(canonicalName(name)));
+
+export const attributeGroupId = (id: string): string =>
+  join("attr", fragment(canonicalName(id)));
+
+export const metadataId = (id: string): string =>
+  join("meta", fragment(canonicalName(id)));
+
+/**
+ * Declarations are keyed by their position in module order: their names are not
+ * extracted yet (`specs/llvm-ir.md` §5), so every declaration would otherwise
+ * carry the same id.
+ */
+export const declarationId = (index: number): string =>
+  join("decl", String(index));
+
+/**
+ * Use-Def view ids, named after the tags they emit rather than the view: a
+ * `useDef…` name reads as a React hook to the lint rules.
+ */
+export const udLineId = (
+  funcId: string,
+  blockId: string,
+  index: number,
+): string => join(funcId, "ud", fragment(blockId), String(index));
+
+export const udArgumentId = (funcId: string, name: string): string =>
+  join(funcId, "udarg", fragment(name));
+
+export const udExternalId = (funcId: string, name: string): string =>
+  join(funcId, "udext", fragment(name));
+
+/**
+ * `edge:<source>:<target>[:<variant>…]`. The endpoint ids are spliced in whole:
+ * every id kind has a fixed fragment count once its tags are read, so the
+ * concatenation reads back unambiguously without a second escaping level. The
+ * variant fragments are what keep parallel edges between one pair apart.
+ */
+export const edgeId = (
+  source: string,
+  target: string,
+  ...variant: string[]
+): string => join("edge", source, target, ...variant.map(fragment));

--- a/src/graphBuilder/llvmUseDefGraphBuilder.ts
+++ b/src/graphBuilder/llvmUseDefGraphBuilder.ts
@@ -6,6 +6,14 @@ import type {
   LLVMModule,
   LLVMTerminator,
 } from "../ast/llvmAST";
+import {
+  canonicalName,
+  edgeId,
+  functionId,
+  udArgumentId,
+  udExternalId,
+  udLineId,
+} from "./llvmIds";
 
 /**
  * Use-Def view builder (docs/internal/specs/llvm-use-def-view.md): SSA
@@ -21,25 +29,10 @@ import type {
  * — never participate in SSA dataflow and contribute nothing here.
  */
 
-/** Matches llvmGraphBuilder's uniqueId so both views namespace the same way. */
-const uniqueId = (prefix: string, name: string) =>
-  `${prefix}_${name.replace(/[@%"]/g, "")}`;
-
 /** One line already emitted as a node, queued for the edge pass. */
 interface EmittedLine {
   nodeId: string;
   line: LLVMInstruction | LLVMTerminator;
-}
-
-/**
- * The sigil-free, unquoted form of a raw local name as the tokenizer would
- * canonicalize it, so parameter names compare equal to `uses` entries
- * (`%"odd name"` → `odd name`).
- */
-function localName(raw: string): string {
-  const withoutSigil = raw.startsWith("%") ? raw.slice(1) : raw;
-  const quoted = /^"(.*)"$/.exec(withoutSigil);
-  return quoted === null ? withoutSigil : quoted[1];
 }
 
 /**
@@ -86,7 +79,7 @@ function buildFunctionGraph(
   nodes: GraphNode[],
   edges: GraphEdge[],
 ): void {
-  const funcPrefix = uniqueId("func", func.name);
+  const funcPrefix = functionId(func.name);
   /** value name -> id of the node that defines it (argument or instruction) */
   const defSource = new Map<string, string>();
   /** instruction node ids — these expose a "def" source port (spec §3). */
@@ -98,8 +91,10 @@ function buildFunctionGraph(
   // against, so a body reading an implicit `%0` resolves as external.
   func.params.forEach((param) => {
     if (param.name === null) return;
-    const name = localName(param.name);
-    const argId = `${funcPrefix}_udarg_${name}`;
+    // The canonical form is what `uses` entries carry, so a parameter written
+    // `%"odd name"` compares equal to the body's reads of it.
+    const name = canonicalName(param.name);
+    const argId = udArgumentId(funcPrefix, name);
     nodes.push({
       id: argId,
       label: param.type === "" ? `%${name}` : `%${name}: ${param.type}`,
@@ -132,7 +127,7 @@ function buildFunctionGraph(
     let index = 0;
     lines.forEach(({ line, term }) => {
       if (!participates(line)) return;
-      const nodeId = `${funcPrefix}_ud_${block.id}_i${String(index)}`;
+      const nodeId = udLineId(funcPrefix, block.id, index);
       index++;
       const def = line.defs?.[0] ?? null;
       nodes.push({
@@ -165,7 +160,7 @@ function buildFunctionGraph(
     if (known !== undefined) return known;
     let externalId = externals.get(name);
     if (externalId === undefined) {
-      externalId = `${funcPrefix}_udext_${name}`;
+      externalId = udExternalId(funcPrefix, name);
       externals.set(name, externalId);
       nodes.push({
         id: externalId,
@@ -190,7 +185,7 @@ function buildFunctionGraph(
       // label rather than producing several colliding edges.
       const fromBlocks = incoming?.get(name);
       const edge: GraphEdge = {
-        id: `e-${sourceId}-${nodeId}-${name}`,
+        id: edgeId(sourceId, nodeId, name),
         source: sourceId,
         target: nodeId,
         type: "arrow",

--- a/src/parser/__tests__/llvm/corpus/manifest.ts
+++ b/src/parser/__tests__/llvm/corpus/manifest.ts
@@ -9,7 +9,8 @@
 
 /**
  * A [source, target, label?] edge triple using the graphBuilder's node id
- * scheme (`func_<name>_header`, `func_<name>_block_<id>`, `func_<name>_exit`).
+ * scheme (`specs/llvm-ir.md` §4.1: `func:<name>:header`,
+ * `func:<name>:block:<id>`, `func:<name>:exit`).
  * Compared order-independently, but as the complete edge set: no missing or
  * extra edges are allowed.
  */
@@ -51,8 +52,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@main", blockIds: ["entry"] }],
       edges: [
-        ["func_main_header", "func_main_block_entry"],
-        ["func_main_block_entry", "func_main_exit"],
+        ["func:main:header", "func:main:block:entry"],
+        ["func:main:block:entry", "func:main:exit"],
       ],
       terminatorOpcodes: { "@main": ["ret"] },
     },
@@ -63,8 +64,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@main", blockIds: ["entry"] }],
       edges: [
-        ["func_main_header", "func_main_block_entry"],
-        ["func_main_block_entry", "func_main_exit"],
+        ["func:main:header", "func:main:block:entry"],
+        ["func:main:block:entry", "func:main:exit"],
       ],
       terminatorOpcodes: { "@main": ["ret"] },
       moduleCounts: { globals: 1, declarations: 1 },
@@ -76,8 +77,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@main", blockIds: ["entry"] }],
       edges: [
-        ["func_main_header", "func_main_block_entry"],
-        ["func_main_block_entry", "func_main_exit"],
+        ["func:main:header", "func:main:block:entry"],
+        ["func:main:block:entry", "func:main:exit"],
       ],
       terminatorOpcodes: { "@main": ["ret"] },
       moduleCounts: { globals: 1 },
@@ -89,7 +90,7 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       // unreachable has no successors and no exit edge (spec section 3.2).
-      edges: [["func_f_header", "func_f_block_entry"]],
+      edges: [["func:f:header", "func:f:block:entry"]],
       terminatorOpcodes: { "@f": ["unreachable"] },
     },
   },
@@ -99,8 +100,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
     },
@@ -111,11 +112,11 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry", "a", "b"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_block_a", "true"],
-        ["func_f_block_entry", "func_f_block_b", "false"],
-        ["func_f_block_a", "func_f_exit"],
-        ["func_f_block_b", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:block:a", "true"],
+        ["func:f:block:entry", "func:f:block:b", "false"],
+        ["func:f:block:a", "func:f:exit"],
+        ["func:f:block:b", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["br", "ret", "ret"] },
     },
@@ -126,8 +127,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
       moduleCounts: { globals: 1 },
@@ -139,9 +140,9 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry", "loop"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_block_loop"],
-        ["func_f_block_loop", "func_f_block_loop"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:block:loop"],
+        ["func:f:block:loop", "func:f:block:loop"],
       ],
       terminatorOpcodes: { "@f": ["br", "br"] },
       moduleCounts: { metadata: 1 },
@@ -153,11 +154,11 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry", "a", "b"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_block_a", "true"],
-        ["func_f_block_entry", "func_f_block_b", "false"],
-        ["func_f_block_a", "func_f_exit"],
-        ["func_f_block_b", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:block:a", "true"],
+        ["func:f:block:entry", "func:f:block:b", "false"],
+        ["func:f:block:a", "func:f:exit"],
+        ["func:f:block:b", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["br", "ret", "ret"] },
       moduleCounts: { metadata: 1 },
@@ -169,8 +170,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
     },
@@ -181,8 +182,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
     },
@@ -193,8 +194,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
     },
@@ -205,11 +206,11 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry", "a", "d"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_block_d", "default"],
-        ["func_f_block_entry", "func_f_block_a", "-1"],
-        ["func_f_block_a", "func_f_exit"],
-        ["func_f_block_d", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:block:d", "default"],
+        ["func:f:block:entry", "func:f:block:a", "-1"],
+        ["func:f:block:a", "func:f:exit"],
+        ["func:f:block:d", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["switch", "ret", "ret"] },
     },
@@ -222,10 +223,10 @@ export const corpusEntries: CorpusEntry[] = [
       // invoke: `to` edge labeled "to", `unwind` edge labeled "unwind";
       // resume has no successors and no exit edge (spec section 3.2).
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_block_cont", "to"],
-        ["func_f_block_entry", "func_f_block_lpad", "unwind"],
-        ["func_f_block_cont", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:block:cont", "to"],
+        ["func:f:block:entry", "func:f:block:lpad", "unwind"],
+        ["func:f:block:cont", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["invoke", "ret", "resume"] },
       moduleCounts: { declarations: 2 },
@@ -237,12 +238,12 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry", "a", "b", "m"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_block_a", "true"],
-        ["func_f_block_entry", "func_f_block_b", "false"],
-        ["func_f_block_a", "func_f_block_m"],
-        ["func_f_block_b", "func_f_block_m"],
-        ["func_f_block_m", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:block:a", "true"],
+        ["func:f:block:entry", "func:f:block:b", "false"],
+        ["func:f:block:a", "func:f:block:m"],
+        ["func:f:block:b", "func:f:block:m"],
+        ["func:f:block:m", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["br", "br", "br", "ret"] },
     },
@@ -253,8 +254,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@main", blockIds: ["entry"] }],
       edges: [
-        ["func_main_header", "func_main_block_entry"],
-        ["func_main_block_entry", "func_main_exit"],
+        ["func:main:header", "func:main:block:entry"],
+        ["func:main:block:entry", "func:main:exit"],
       ],
       terminatorOpcodes: { "@main": ["ret"] },
       moduleCounts: { globals: 1 },
@@ -266,8 +267,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
     },
@@ -278,8 +279,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
     },
@@ -290,8 +291,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
     },
@@ -304,11 +305,11 @@ export const corpusEntries: CorpusEntry[] = [
       // callbr: fallthrough `to` edge and indirect-target edges, all
       // unlabeled (spec section 3.2).
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_block_cont"],
-        ["func_f_block_entry", "func_f_block_alt"],
-        ["func_f_block_cont", "func_f_exit"],
-        ["func_f_block_alt", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:block:cont"],
+        ["func:f:block:entry", "func:f:block:alt"],
+        ["func:f:block:cont", "func:f:exit"],
+        ["func:f:block:alt", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["callbr", "ret", "ret"] },
     },
@@ -322,8 +323,8 @@ export const corpusEntries: CorpusEntry[] = [
       // instruction results, not labels.
       functions: [{ name: "@main", blockIds: ["entry"] }],
       edges: [
-        ["func_main_header", "func_main_block_entry"],
-        ["func_main_block_entry", "func_main_exit"],
+        ["func:main:header", "func:main:block:entry"],
+        ["func:main:block:entry", "func:main:exit"],
       ],
       terminatorOpcodes: { "@main": ["ret"] },
     },
@@ -334,8 +335,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
       moduleCounts: { declarations: 1 },
@@ -347,8 +348,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
     },
@@ -359,8 +360,8 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["ret"] },
     },
@@ -371,11 +372,11 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@f", blockIds: ["entry", "a", "b"] }],
       edges: [
-        ["func_f_header", "func_f_block_entry"],
-        ["func_f_block_entry", "func_f_block_a", "true"],
-        ["func_f_block_entry", "func_f_block_b", "false"],
-        ["func_f_block_a", "func_f_exit"],
-        ["func_f_block_b", "func_f_exit"],
+        ["func:f:header", "func:f:block:entry"],
+        ["func:f:block:entry", "func:f:block:a", "true"],
+        ["func:f:block:entry", "func:f:block:b", "false"],
+        ["func:f:block:a", "func:f:exit"],
+        ["func:f:block:b", "func:f:exit"],
       ],
       terminatorOpcodes: { "@f": ["br", "ret", "ret"] },
     },
@@ -388,10 +389,10 @@ export const corpusEntries: CorpusEntry[] = [
       // unwind (like resume) has no successors and no exit edge (spec
       // section 3.2).
       edges: [
-        ["func_main_header", "func_main_block_entry"],
-        ["func_main_block_entry", "func_main_block_ok", "to"],
-        ["func_main_block_entry", "func_main_block_err", "unwind"],
-        ["func_main_block_ok", "func_main_exit"],
+        ["func:main:header", "func:main:block:entry"],
+        ["func:main:block:entry", "func:main:block:ok", "to"],
+        ["func:main:block:entry", "func:main:block:err", "unwind"],
+        ["func:main:block:ok", "func:main:exit"],
       ],
       terminatorOpcodes: { "@main": ["invoke", "ret", "unwind"] },
       moduleCounts: { globals: 1, declarations: 1 },
@@ -406,11 +407,11 @@ export const corpusEntries: CorpusEntry[] = [
       // from the ; <label>:N boundary hints (spec section 3.3).
       functions: [{ name: "@loop", blockIds: ["0", "1", "6"] }],
       edges: [
-        ["func_loop_header", "func_loop_block_0"],
-        ["func_loop_block_0", "func_loop_block_1"],
-        ["func_loop_block_1", "func_loop_block_1", "true"],
-        ["func_loop_block_1", "func_loop_block_6", "false"],
-        ["func_loop_block_6", "func_loop_exit"],
+        ["func:loop:header", "func:loop:block:0"],
+        ["func:loop:block:0", "func:loop:block:1"],
+        ["func:loop:block:1", "func:loop:block:1", "true"],
+        ["func:loop:block:1", "func:loop:block:6", "false"],
+        ["func:loop:block:6", "func:loop:exit"],
       ],
       terminatorOpcodes: { "@loop": ["br", "br", "ret"] },
       moduleCounts: { globals: 1, metadata: 1 },
@@ -422,12 +423,12 @@ export const corpusEntries: CorpusEntry[] = [
     expected: {
       functions: [{ name: "@main", blockIds: ["0", "5", "8", "9"] }],
       edges: [
-        ["func_main_header", "func_main_block_0"],
-        ["func_main_block_0", "func_main_block_5", "true"],
-        ["func_main_block_0", "func_main_block_8", "false"],
-        ["func_main_block_5", "func_main_block_9"],
-        ["func_main_block_8", "func_main_block_9"],
-        ["func_main_block_9", "func_main_exit"],
+        ["func:main:header", "func:main:block:0"],
+        ["func:main:block:0", "func:main:block:5", "true"],
+        ["func:main:block:0", "func:main:block:8", "false"],
+        ["func:main:block:5", "func:main:block:9"],
+        ["func:main:block:8", "func:main:block:9"],
+        ["func:main:block:9", "func:main:exit"],
       ],
       terminatorOpcodes: { "@main": ["br", "br", "br", "ret"] },
       moduleCounts: { metadata: 4, attributes: 1 },
@@ -441,12 +442,12 @@ export const corpusEntries: CorpusEntry[] = [
         { name: "@run", blockIds: ["entry", "cont1", "cont2", "lpad"] },
       ],
       edges: [
-        ["func_run_header", "func_run_block_entry"],
-        ["func_run_block_entry", "func_run_block_cont1", "to"],
-        ["func_run_block_entry", "func_run_block_lpad", "unwind"],
-        ["func_run_block_cont1", "func_run_block_cont2", "to"],
-        ["func_run_block_cont1", "func_run_block_lpad", "unwind"],
-        ["func_run_block_cont2", "func_run_exit"],
+        ["func:run:header", "func:run:block:entry"],
+        ["func:run:block:entry", "func:run:block:cont1", "to"],
+        ["func:run:block:entry", "func:run:block:lpad", "unwind"],
+        ["func:run:block:cont1", "func:run:block:cont2", "to"],
+        ["func:run:block:cont1", "func:run:block:lpad", "unwind"],
+        ["func:run:block:cont2", "func:run:exit"],
       ],
       terminatorOpcodes: { "@run": ["invoke", "invoke", "ret", "resume"] },
       moduleCounts: { declarations: 2 },
@@ -463,18 +464,18 @@ export const corpusEntries: CorpusEntry[] = [
         },
       ],
       edges: [
-        ["func_classify_header", "func_classify_block_entry"],
-        ["func_classify_block_entry", "func_classify_block_other", "default"],
-        ["func_classify_block_entry", "func_classify_block_neg", "-1"],
-        ["func_classify_block_entry", "func_classify_block_zero", "0"],
-        ["func_classify_block_entry", "func_classify_block_one", "1"],
-        ["func_classify_block_entry", "func_classify_block_big", "4294967296"],
-        ["func_classify_block_neg", "func_classify_block_merge"],
-        ["func_classify_block_zero", "func_classify_block_merge"],
-        ["func_classify_block_one", "func_classify_block_merge"],
-        ["func_classify_block_big", "func_classify_block_merge"],
-        ["func_classify_block_other", "func_classify_block_merge"],
-        ["func_classify_block_merge", "func_classify_exit"],
+        ["func:classify:header", "func:classify:block:entry"],
+        ["func:classify:block:entry", "func:classify:block:other", "default"],
+        ["func:classify:block:entry", "func:classify:block:neg", "-1"],
+        ["func:classify:block:entry", "func:classify:block:zero", "0"],
+        ["func:classify:block:entry", "func:classify:block:one", "1"],
+        ["func:classify:block:entry", "func:classify:block:big", "4294967296"],
+        ["func:classify:block:neg", "func:classify:block:merge"],
+        ["func:classify:block:zero", "func:classify:block:merge"],
+        ["func:classify:block:one", "func:classify:block:merge"],
+        ["func:classify:block:big", "func:classify:block:merge"],
+        ["func:classify:block:other", "func:classify:block:merge"],
+        ["func:classify:block:merge", "func:classify:exit"],
       ],
       terminatorOpcodes: {
         "@classify": ["switch", "br", "br", "br", "br", "br", "ret"],
@@ -491,12 +492,12 @@ export const corpusEntries: CorpusEntry[] = [
         { name: "@sumlanes", blockIds: ["entry"] },
       ],
       edges: [
-        ["func_pack_header", "func_pack_block_entry"],
-        ["func_pack_block_entry", "func_pack_exit"],
-        ["func_second_header", "func_second_block_entry"],
-        ["func_second_block_entry", "func_second_exit"],
-        ["func_sumlanes_header", "func_sumlanes_block_entry"],
-        ["func_sumlanes_block_entry", "func_sumlanes_exit"],
+        ["func:pack:header", "func:pack:block:entry"],
+        ["func:pack:block:entry", "func:pack:exit"],
+        ["func:second:header", "func:second:block:entry"],
+        ["func:second:block:entry", "func:second:exit"],
+        ["func:sumlanes:header", "func:sumlanes:block:entry"],
+        ["func:sumlanes:block:entry", "func:sumlanes:exit"],
       ],
       terminatorOpcodes: {
         "@pack": ["ret"],

--- a/src/parser/__tests__/llvm/errors.test.ts
+++ b/src/parser/__tests__/llvm/errors.test.ts
@@ -63,7 +63,7 @@ d:
       const graph = parseLLVM(input);
       const edge = graph.edges.find(
         (e) =>
-          e.source.includes("_block_entry") && e.target.includes("_block_d"),
+          e.source.includes(":block:entry") && e.target.includes(":block:d"),
       );
       expect(edge).toBeDefined();
       expect(edge?.label).toBeUndefined();


### PR DESCRIPTION
Closes #59.

## What changed

Node and edge ids of both LLVM views are now a canonicalization followed by an injective
serialization, specified in `specs/llvm-ir.md` §4.1 and implemented once in
`src/graphBuilder/llvmIds.ts` for the CFG and Use-Def builders.

1. A name's identity is its content — sigil and surrounding quotes removed, escape sequences
   verbatim. This is the reduction the tokenizer already performs for `Token.value`, and the
   form block ids and terminator targets already arrive in. `@"main"` and `@main` are the same
   LLVM name and share an id; `@"a@b"` keeps its inner `@`.
2. An id is a `:`-joined list of fragments whose free text percent-escapes `%` and `:`.
   Edge ids splice whole endpoint ids plus a variant (`true`/`false`, `case:<value>`,
   `succ:<index>`, …); each id kind has a fixed fragment count once its tags are read, so no
   second escaping level is needed.

`contracts/graph-data.md` now states id uniqueness as an obligation on every graphBuilder and
records how each mode meets it.

## Why

`uniqueId` deleted every `@`, `%`, and `"` anywhere in a name, so `@"a@b"` and `@ab` both
became `func_ab`. React Flow drops duplicate ids silently, so the second function's graph
disappeared with no error.

Stripping was only the visible half, which is why the fix is the id convention rather than
that one helper:

- Fragments were joined with `_`, a character LLVM identifiers commonly contain, so the join
  itself was not injective (block `x_i0` and instruction 0 of block `x` both produced
  `…_ud_x_i0`).
- `LLVMDeclaration.name` is always the literal `"declaration"` (`specs/llvm-ir.md` §5), so
  every `declare` line in a module shared the id `decl_declaration` and all but one
  declaration node was dropped. Declarations are now keyed by module position.
- Rule-7 successor edges were unlabeled and unindexed, so a terminator repeating a successor
  (`indirectbr … [label %a, label %a]`) produced two edges with one id. They now carry
  `succ:<index>`.

Keeping `_` as the separator was rejected: it would have forced escaping in nearly every
name. `:` cannot occur in an unquoted LLVM identifier, so escaping only fires on exotic
quoted names and ordinary ids stay readable (`func:main:block:entry`).

## Notes for reviewers

- **Ids change shape.** Byte compatibility with the old strings was given up deliberately;
  ids are internal values and nothing parses them. Most of the diff is the corpus manifest's
  expected edge pairs following that rename.
- The `llvmIds` constructors for the Use-Def view are named `udLineId` / `udArgumentId` /
  `udExternalId` rather than `useDef…` because a `use`-prefixed function name trips
  `react-hooks/rules-of-hooks`.
- Uniqueness now reduces to the parser keeping AST keys distinct. The one remaining source of
  duplicates — two explicit `a:` labels in one function — is split out to #111 and referenced
  from `specs/llvm-ir.md` §5.
- Not addressed here: SelectionDAG uses the printed `tN` numbers as ids with no dedup, so an
  input repeating a number would still collide. Different mode, no issue filed yet.

## Verification

- `npm run test:run` — 601 passed. New tests: CFG side pins canonicalization, the quoted-vs-plain
  collision pair, separator escaping, declaration id uniqueness and repeated successors;
  Use-Def side pins its own collision pair and value-name escaping.
- `npm run test:e2e` — 9 passed. `npm run lint`, `npm run format` clean.
- Checked both views in the running app: CFG 8 nodes / 10 edges and Use-Def 18 nodes /
  23 edges from the default code, with live `data-id`s such as `func:func:block:4` and
  `func:func:ud:12:3` — React Flow, ELK, and the edge router all handle `:` in ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
