### PR TITLE
fix(llvm-parser): diagnose duplicate explicit block labels

### DIFF
--- a/docs/internal/contracts/graph-data.md
+++ b/docs/internal/contracts/graph-data.md
@@ -43,7 +43,7 @@ the obligation:
 
 - **LLVM** (both views) serializes a structured key injectively — `specs/llvm-ir.md` §4.1.
   Distinct keys always produce distinct ids, which reduces uniqueness to the parser keeping
-  its AST keys distinct ([Issue #111](https://github.com/himadajin/ir-visualizer/issues/111)).
+  its AST keys distinct; block ids are unique within a function by `specs/llvm-ir.md` §3.3.
 - **Mermaid** keys nodes by their source id and collects them through a `Map`, so a node
   mentioned several times in the source is one node; edge ids carry their source-order index.
 - **SelectionDAG** uses the printed `tN` node numbers as ids and inherits uniqueness from the

--- a/docs/internal/specs/llvm-ir.md
+++ b/docs/internal/specs/llvm-ir.md
@@ -160,9 +160,10 @@ fail the parse. `parseTerminator` is total: it never throws, on any input.
 > `src/parser/__tests__/llvm/errors.test.ts`,
 > `src/parser/__tests__/llvm/corpus.test.ts`
 
-### 3.3 Implicit block numbering
+### 3.3 Block ids
 
-A block that starts without a label line gets its id from, in priority order:
+A block started by a label line takes that label as its id, in the canonical form of §1. A
+block that starts without a label line gets its id from, in priority order:
 
 1. the `N` of an adjacent `; <label>:N` boundary comment (which also resynchronizes the
    counter to N+1);
@@ -181,10 +182,21 @@ incoming-block reference `[ v, %N ]`; numeric instruction results (`%1 = ...`) d
 count. Otherwise the entry takes the counter value (e.g. `0`, or `3` after three unnamed
 parameters).
 
+**Ids are unique within a function.** Rule 3's rename is not specific to implicit blocks: a
+label line whose id is already taken — `a:` … `a:` — is renamed from the same `implicit_<k>`
+sequence and records a diagnostic naming the duplicated label. The renamed block keeps the
+written label in `LLVMBasicBlock.label`, so both blocks still display `a` and only their
+identity differs. Terminators targeting `%a` reach the first block, the one that kept the id.
+Real LLVM rejects a duplicated label outright; the parser degrades visibly instead, because a
+shared id would collapse two blocks into one graph node and silently drop the second along
+with its edges (§4.1's serialization is injective, so a duplicate block id is the only way to
+reach a duplicate node id).
+
 Every terminator target that no block id claims produces a diagnostic — never a throw,
 never a silent dangling edge.
 
 > Pinned by: `src/parser/llvm/__tests__/module.test.ts`,
+> `src/parser/__tests__/llvm/errors.test.ts`,
 > `src/parser/__tests__/llvm/corpus.test.ts`
 
 ### 3.4 Error policy
@@ -194,7 +206,7 @@ never a silent dangling edge.
 | Unrecognized line inside a function body                                                                                                      | Kept as an opaque `LLVMGenericInstruction` (opcode = first token); never a throw                  |
 | Unrecognized non-blank line at top level                                                                                                      | Throw — garbage input still shows a parse error                                                   |
 | Structural error (no terminator before `}`, `}` without `define`, unclosed function at EOF, `define` without `{`, empty body, unbalanced `[`) | Throw, with a message naming the 1-based source line and the problem in plain words (`Line N: …`) |
-| Recoverable oddity (implicit-id fallback, dangling terminator target, label after an unterminated block)                                      | Recorded in `LLVMModule.diagnostics` (present only when non-empty), not thrown                    |
+| Recoverable oddity (block-id collision fallback, dangling terminator target, label after an unterminated block)                               | Recorded in `LLVMModule.diagnostics` (present only when non-empty), not thrown                    |
 
 **Label-after-unterminated-block recovery:** when a label line arrives while the previous
 block has no terminator, the parser does not throw and does not absorb the label. The
@@ -352,12 +364,6 @@ that fixes the rest), so a concatenation of ids reads back unambiguously.
 
 ## 5. Known limitations
 
-- **Duplicate explicit labels are not diagnosed.** Two `a:` labels in one function produce
-  two blocks with the same id — and thus colliding graph node ids (_observed, untested_).
-  The implicit-numbering collision fallback (§3.3) covers implicit ids only. This is the one
-  remaining way to get two identical ids: §4.1's serialization is injective, so identical ids
-  can only come from two AST blocks that genuinely share a key
-  ([Issue #111](https://github.com/himadajin/ir-visualizer/issues/111)).
 - `catchswitch`, `catchret`, `cleanupret`, `callbr`, and `indirectbr` are understood only
   through the uniform successor rule: their edges are unlabeled and carry no per-opcode
   semantics (e.g. a `callbr` fallthrough edge is not distinguished from its indirect

--- a/src/parser/__tests__/llvm/errors.test.ts
+++ b/src/parser/__tests__/llvm/errors.test.ts
@@ -97,6 +97,36 @@ define void @f() {
       );
     });
 
+    it("when a label is written twice, should keep both blocks in the graph", () => {
+      // Block ids are unique within a function (§3.3), so the second `a:`
+      // gets its own node instead of colliding with the first and being
+      // dropped by React Flow with nothing shown to the user.
+      const input = `
+define i32 @f() {
+entry:
+  br label %a
+a:
+  br label %b
+a:
+  br label %b
+b:
+  ret i32 0
+}`;
+      const { graph, diagnostics } = parseLLVM(input);
+
+      const blockIds = graph.nodes
+        .filter((node) => node.nodeType === "llvm-basicBlock")
+        .map((node) => node.id);
+      expect(blockIds).toHaveLength(4);
+      expect(new Set(blockIds).size).toBe(4);
+      expect(blockIds).toContain("func:f:block:a");
+      expect(blockIds).toContain("func:f:block:implicit_0");
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics?.[0].line).toBe(7);
+      expect(diagnostics?.[0].message).toMatch(/block label 'a:' is already/);
+    });
+
     it("when the parse is clean, should return no diagnostics", () => {
       const input = `
 define void @f() {

--- a/src/parser/llvm/__tests__/module.test.ts
+++ b/src/parser/llvm/__tests__/module.test.ts
@@ -97,7 +97,7 @@ next:
     });
   });
 
-  describe("implicit block numbering (§3.3)", () => {
+  describe("block ids (§3.3)", () => {
     it("when unlabeled entry has no numeric label uses, should keep id 'entry'", () => {
       const module = buildModule(`define i32 @main() {
   %1 = alloca i32
@@ -279,6 +279,49 @@ a:
       expect(module.diagnostics?.[0].message).toMatch(
         /implicit block id '5' is already taken/,
       );
+    });
+
+    it("when an explicit label repeats an id, should rename the block with a diagnostic", () => {
+      const module = buildModule(`define i32 @f() {
+entry:
+  br label %a
+a:
+  br label %b
+a:
+  br label %b
+b:
+  ret i32 0
+}`);
+      const blocks = module.functions[0].blocks;
+      expect(blocks.map((b) => b.id)).toEqual([
+        "entry",
+        "a",
+        "implicit_0",
+        "b",
+      ]);
+      // Only the identity is renamed: the block still displays what the
+      // source wrote, so nothing about the input disappears from the view.
+      expect(blocks[2].label).toBe("a");
+      expect(module.diagnostics).toHaveLength(1);
+      expect(module.diagnostics?.[0].line).toBe(6);
+      expect(module.diagnostics?.[0].message).toMatch(
+        /block label 'a:' is already taken in this function; the block was renamed 'implicit_0'\./,
+      );
+    });
+
+    it("when a duplicated label is a terminator target, should not report it as dangling", () => {
+      const module = buildModule(`define void @f() {
+entry:
+  br label %a
+a:
+  ret void
+a:
+  ret void
+}`);
+      // `%a` still resolves — the first block kept the id — so the rename is
+      // the only diagnostic; no dangling-target report is invented for it.
+      expect(module.diagnostics).toHaveLength(1);
+      expect(module.diagnostics?.[0].message).toMatch(/block label 'a:'/);
     });
 
     it("when a terminator targets a label no block claims, should record a diagnostic, not throw", () => {

--- a/src/parser/llvm/module.ts
+++ b/src/parser/llvm/module.ts
@@ -22,7 +22,7 @@
  *   here to that throw; the reader itself stays pure.
  * - Unrecognized in-body line → opaque instruction, never a throw.
  * - Recoverable oddities → `LLVMModule.diagnostics` (set only when
- *   non-empty): implicit-block-id fallback, terminator targets no block
+ *   non-empty): block-id collision fallback, terminator targets no block
  *   claims, and a label starting a new block while the previous block has
  *   no terminator (see below).
  *
@@ -47,8 +47,8 @@
  *   the source, and `LLVMParam.name` already admits null for the unnamed
  *   LLVM 2.x style params.
  *
- * Implicit block numbering (§3.3) — id priority for a block that starts
- * without a label line:
+ * Block ids (§3.3) — a block started by a label line takes that label as
+ * its id; id priority for a block that starts without a label line:
  * 1. the `N` of an adjacent `; <label>:N` boundary comment (layer 1's
  *    `labelHint`), which also resynchronizes the counter to N+1;
  * 2. the unnamed-value counter. It starts from the parameter list: each
@@ -61,6 +61,15 @@
  *    LLVM's printer numbering for printer-generated input.
  * 3. fallback `implicit_<k>` plus a diagnostic, used when the candidate id
  *    from 1–2 collides with a block id this function already assigned.
+ *
+ * Rule 3 is not specific to implicit blocks: a label line whose id is
+ * already taken (`a:` … `a:`, which real LLVM rejects) is renamed from the
+ * same sequence and gets its own diagnostic. Block ids are therefore unique
+ * within a function, which is what keeps two blocks from collapsing into
+ * one graph node — §4.1's node ids are injective, so a shared block id is
+ * the only way to reach a duplicate node id, and React Flow drops such a
+ * node with no error at all. The renamed block keeps its written label, so
+ * only its identity changes, not what the node displays.
  *
  * The unlabeled entry block keeps the legacy id `entry` when the body never
  * *uses* a numeric label — a use is a `label %N` token pair, a
@@ -366,6 +375,29 @@ function assembleFunction(
     current = null;
   };
 
+  /**
+   * The id a new block may keep (§3.3 rule 3): the candidate itself, or a
+   * fresh `implicit_<k>` plus a diagnostic when this function already
+   * assigned it. `subject` names the candidate the way the source wrote it,
+   * so implicit ids and explicit labels each read naturally.
+   */
+  const claimId = (
+    candidate: string,
+    line: LogicalLine,
+    subject: string,
+  ): string => {
+    if (!usedIds.has(candidate)) return candidate;
+    const fallback = `implicit_${String(fallbackCount)}`;
+    fallbackCount++;
+    diagnostics.push(
+      diag(
+        line.lineNumber,
+        `${subject} is already taken in this function; the block was renamed '${fallback}'.`,
+      ),
+    );
+    return fallback;
+  };
+
   /** Start the block a label-less body line implies (entry or implicit). */
   const openImplicitBlock = (line: LogicalLine): void => {
     let id: string;
@@ -381,18 +413,11 @@ function assembleFunction(
       id = String(counter); // priority 2: the unnamed-value counter
       counter++;
     }
-    if (usedIds.has(id)) {
-      const fallback = `implicit_${String(fallbackCount)}`;
-      fallbackCount++;
-      diagnostics.push(
-        diag(
-          line.lineNumber,
-          `implicit block id '${id}' is already taken in this function; the block was renamed '${fallback}'.`,
-        ),
-      );
-      id = fallback;
-    }
-    current = { id, label: null, instructions: [] };
+    current = {
+      id: claimId(id, line, `implicit block id '${id}'`),
+      label: null,
+      instructions: [],
+    };
   };
 
   /** `%N = ...` results and printed `N:` labels resync the counter (§3.3). */
@@ -415,7 +440,13 @@ function assembleFunction(
           closeBlock(syntheticTerminator());
         }
         observeNumericDefinition(classified.id);
-        current = { id: classified.id, label: classified.id, instructions: [] };
+        // The label stays as written even when the id is renamed (§3.3):
+        // the duplicate is visible in the diagnostics, not in the node.
+        current = {
+          id: claimId(classified.id, line, `block label '${classified.id}:'`),
+          label: classified.id,
+          instructions: [],
+        };
         break;
       }
       case "terminator": {


### PR DESCRIPTION
Two blocks in one function could share a `LLVMBasicBlock.id` with nothing diagnosing it: an explicit label written twice — `a:` … `a:` — produced two blocks with the id `a`, because the `specs/llvm-ir.md` §3.3 collision fallback covered implicit ids only. Node ids are an injective serialization of the AST key (§4.1, #113), so a shared block id was the one remaining way to reach a duplicate node id, and React Flow drops a duplicate without an error — the second block and its edges vanished from the CFG and Use-Def views with nothing shown to the user.

Route both id sources through one `claimId` helper, so rule 3's rename covers explicit labels too: the colliding block takes the next `implicit_<k>` and records a diagnostic naming the duplicated label. The renamed block keeps its written label, so both blocks still display `a` and only their identity differs; terminators targeting `%a` reach the block that kept the id. Real LLVM rejects such input outright, so the goal is a visible, non-lossy degradation rather than acceptance. The diagnostic reaches the status footer through the existing `IRParseResult.diagnostics` channel (#112) — no new plumbing.

"Ids are unique within a `GraphData`" (`contracts/graph-data.md`) now holds unconditionally for this mode, so the caveat there and the §5 limitation both go away, and §3.3 is retitled "Block ids" since it no longer describes implicit numbering alone.

## Reproduction

```llvm
define i32 @f() {
entry:
  br label %a
a:
  br label %b
a:
  br label %b
b:
  ret i32 0
}
```

Before: the CFG shows one `a` block. After: both appear (6 nodes, 5 edges), and the status footer reads `warning: line 6: block label 'a:' is already taken in this function; the block was renamed 'implicit_0'.` The second `a` has no incoming edge, which is correct — nothing targets it.

## Review notes

- The shared `implicit_<k>` sequence and counter are deliberate: a renamed explicit label is not a new naming scheme, just the existing fallback applied to one more source. The `subject` parameter of `claimId` exists so each call site phrases its own diagnostic.
- The existing implicit-id diagnostic wording is unchanged, so its test regex still matches.
- Three tests added: two assembler cases in `src/parser/llvm/__tests__/module.test.ts` (the rename plus label preservation, and that a duplicated label is not also reported as a dangling target) and one end-to-end case in `src/parser/__tests__/llvm/errors.test.ts` pinning that four distinct block nodes reach the graph.
- Verified in the running app in both the CFG and Use-Def views; the Use-Def graph is empty for this input because it has no value defs or uses, which is expected.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)