### PR TITLE
feat(edge-routing): route stability through per-edge locality

### DIFF
--- a/docs/internal/contracts/edge-routing.md
+++ b/docs/internal/contracts/edge-routing.md
@@ -8,6 +8,12 @@ Hanan grid, the A\* search, the fallback ladder) is an implementation detail beh
 boundary and is not reproduced here — see `src/utils/edgeRouter.ts` and its inline
 documentation for how the guarantees below are achieved.
 
+One part of the algorithm is _not_ an implementation detail, because a guarantee is stated
+against it: each edge is searched on a grid built from its own **region** rather than from
+the whole graph, and that is what makes the Locality guarantee below expressible. The region
+is defined under "Per-edge regions"; how the grid over it is searched remains behind the
+boundary.
+
 ## The frozen boundary
 
 The router implementation and its test suite are written against this boundary. It is
@@ -51,12 +57,31 @@ export interface EdgeRouterOptions {
   selfLoopGap?: number; // default 24
 }
 
+export interface RouteRegion {
+  minX: number;
+  minY: number; // bounds inclusive — see Per-edge regions
+  maxX: number;
+  maxY: number;
+}
+
 // src/utils/edgeRouter.ts
 export const routeEdges: (
   nodes: RouteNodeRect[],
   requests: RouteRequest[],
   options?: EdgeRouterOptions,
 ) => Map<string, Point[]>; // keyed by RouteRequest.id, >= 2 points, orthogonal
+
+// Locality made usable by a caller — see Per-edge regions, Narrowing a pass.
+export const ROUTE_REGION_MARGIN: number; // 192
+export const routeRegionOf: (
+  request: RouteRequest,
+  options?: EdgeRouterOptions,
+) => RouteRegion;
+
+// The input-quantization step (Input quantization), so a caller can ask whether
+// its input changed in the terms the router will actually see. Idempotent.
+export const quantizeRect: (rect: RouteNodeRect) => RouteNodeRect;
+export const quantizeRequest: (request: RouteRequest) => RouteRequest;
 ```
 
 `routeEdges` is a **pure function**: nothing here depends on React Flow or ELK, and no
@@ -174,6 +199,61 @@ half-open interval `[-0.5, 0.5)` that rounds to it. `bendPenalty` is floored now
 needs no floor: it is a cost, not a clearance, and zero or fractional values of it are
 ordinary input.
 
+## Per-edge regions
+
+A routed request is searched on a grid built from **its own region**, never from the whole
+graph. The region of a request is the axis-aligned bounding box of the four points that
+define it — the quantized `sourcePoint` and `targetPoint`, and the two `nodeMargin`-pushed
+points derived from them — inflated by `ROUTE_REGION_MARGIN` (**192 px**) on every side. The
+margin is a module constant (`src/utils/edgeRouter.ts`), not an option: no caller has a reason
+to vary it, and a search parameter that changes the picture is not something a call site
+should be able to disagree about.
+
+192 is measured, not chosen for roundness. Replaying both default LLVM-IR examples through
+the router at a range of margins (2026-08-11; the app's own ELK layout, node sizes and port
+offsets), the whole-graph retry below fires for one edge in each example at 48 px, for one
+edge in the CFG at 96 px, and **for no edge at all from 128 px up**; every margin in 48–384 px
+produced byte-identical routes to a graph-wide search, and full-pass timings across that range
+differed by less than the run-to-run noise. 192 is therefore the smallest tested value with
+real headroom over the threshold where the examples stop needing the retry — the region wants
+to be no larger than it has to be, since its size is exactly how much of the graph an edge is
+coupled to.
+
+Two rules together make the region the whole of what a search can see.
+
+- **Only intersecting rects take part.** A rect contributes candidate grid lines, and blocks,
+  only when its _inflated_ rect — the rect grown by `nodeMargin`, the same shape the obstacle
+  test uses — intersects the region. Every other rect is absent from that edge's search
+  entirely, rather than present but unreachable.
+- **Candidate lines are clipped to the region.** Of an intersecting rect's four inflated
+  boundaries, only those that fall inside the region become grid lines. Every grid vertex
+  therefore lies inside the region, so every segment does too. Without the clip, a rect
+  straddling the region boundary would extend the grid past it, and a route could then run
+  through a rect that was excluded for not reaching the region — the locality guarantee would
+  be bought at the price of edges crossing nodes.
+
+The two request points and their pushed points are always grid lines of their own, as they
+were before, and they lie inside the region by construction.
+
+The route a search returns is the cheapest one **on that grid**, under the tie-break order
+below. It is not promised to be the cheapest orthogonal path in the plane — it was not before
+either, since the grid has only ever held rect boundaries — and one consequence of the region
+is worth stating plainly: a detour that would have to leave the region to be found is not
+found, and the request falls to the retry below.
+
+**A request whose region offers no path is retried once, on the whole graph.** The ladder is
+exactly two rungs — the region, then every rect — and the second one exists so that this
+change cannot make an edge less routable than it was: any request that had a path before still
+has the same one available. Only a request that fails on _both_ rungs reaches the no-path
+fallback, which is what makes "no path" mean geometrically unroutable input. A request routed
+on the second rung is a function of every rect in the graph, and the Locality guarantee below
+is not claimed for it; the router does not report which rung it used, so a caller that needs to
+know must reproduce the region test itself.
+
+Self-loops and the fallback shape need no region: a self-loop is synthesized from its own
+node's rect (see Self-loops) and the fallback from the request alone (it does no obstacle
+avoidance at all), so both are already functions of strictly less than the region's rects.
+
 ## Guarantees callers may rely on
 
 - **Orthogonality.** Every returned polyline is axis-aligned: consecutive points always
@@ -223,6 +303,17 @@ ordinary input.
 - **Determinism.** Identical input rects and requests always produce byte-identical
   points, with no dependence on the iteration order of either the `nodes` array or the
   `requests` array — reordering either changes no individual route.
+- **Locality.** A route found on its own region (see Per-edge regions) is a function of the
+  rects intersecting that region and of its own request — of nothing else in the input. Adding,
+  removing, moving or resizing any other rect leaves that polyline byte-identical, so an edge
+  changes only when something near it changed. This is the guarantee that makes the router
+  _stable_ as well as deterministic: determinism says the same input gives the same output,
+  which a search over a graph-wide grid satisfies while still letting an unrelated node's
+  one-pixel move flip a route through the tie-break. Locality is what rules that out, and it
+  is a property of the pure function, not of a cache — no route is ever kept because it was
+  the previous answer. It is claimed for searched routes on the first rung, for self-loops and
+  for fallbacks; it is **not** claimed for a route that fell through to the whole-graph retry,
+  which is by definition a function of every rect.
 - **A fixed tie-break total order.** When multiple candidate paths are equally cheap, the
   router picks among them by, in order: (1) total cost (`length + bendPenalty * turns`),
   (2) number of bends, (3) the point sequence compared lexicographically by `(x, y)` — a
@@ -369,7 +460,38 @@ from a per-edge component. There is exactly **one routing pass per graph**: it r
 handle positions), builds the `RouteNodeRect[]` / `RouteRequest[]` inputs, and calls
 `routeEdges` once per pass. The resulting `Map<string, Point[]>` is published through a
 React context; `RoutedEdge` looks up its own entry by edge id and never calls the router
-itself. During a drag the hook narrows `requests` to the edges incident to the dragged
-node (still passing the **complete** `nodes` array, since a partial route must still avoid
-every obstacle) and runs a full pass once the drag stops — see `specs/graph-view.md` §4 for
-the frame-budget measurement behind that split.
+itself. **There is one routing path**, during a drag as much as at rest — no incident-only
+mode, and no catch-up pass when a drag stops.
+
+### Narrowing a pass
+
+A caller that holds the previous pass's input and output may route a **subset** of the
+requests and reuse the rest. Locality is what makes that a pure optimization rather than a
+second answer: an edge whose region nothing near has changed would be re-routed to the
+polyline the caller already holds, so computing it and keeping it are indistinguishable.
+`routeRegionOf(request)` exports the region rule so the caller asks the router where an edge
+looks rather than reimplementing the box.
+
+The subset must be a superset of what can actually change, which takes three clauses — the
+third is the one that is easy to miss:
+
+1. a request that is **new, or whose own record changed** (either point, either side, either
+   endpoint id) — its region moved with it;
+2. a request whose region a changed rect reaches **in either its old or its new position** —
+   the space a node vacates matters as much as the space it takes, and an edge that was
+   detouring around it must be allowed to straighten;
+3. a request whose **previous polyline has a point outside its own region** — that is the
+   observable signature of the whole-graph retry above, and Locality is explicitly not
+   claimed for those routes, so they are re-routed unconditionally.
+
+A narrowed pass still passes the **complete** `nodes` array: a route must avoid every
+obstacle whether or not that obstacle moved.
+
+This is not a licence to keep a stale route. What the old drag-time split did — route only
+the edges incident to the dragged node, then a full pass on drop — is not an instance of this
+rule: the edges it left out were routing around a rect the dragged node had already vacated,
+which is clause 2, and the "full pass on drag stop" was the moment they all caught up at once.
+`src/hooks/useEdgeRoutes.ts` implements the rule, and
+`src/hooks/__tests__/useEdgeRoutes.test.ts` pins the only property that matters: a narrowed
+pass equals the full pass entry for entry. See `specs/graph-view.md` §4 for the frame budget
+that makes the narrowing worth having.

--- a/docs/internal/specs/graph-view.md
+++ b/docs/internal/specs/graph-view.md
@@ -150,15 +150,37 @@ all (#88). Until those land, an overlap in the rendered graph means nothing.
   rects it passes in; per the contract's missing-node rule their edges get no map entry and
   are **not drawn** for that frame, appearing once measurement lands. There is deliberately
   no placeholder shape — one would reintroduce a second geometry generator.
-- **During a drag**, routes recompute continuously, throttled to animation frames, and only
-  the edges incident to a moved node are re-routed (still against the complete obstacle
-  set); a full pass runs on drag stop. The split is required, not opportunistic: a full
-  pass exceeds the 16.7 ms animation-frame budget from roughly **180 nodes**, which the
-  Use-Def view can reach since it emits one node per instruction. Measured out of band on
-  an ELK-layered-shaped CFG (bare Node, warm, median of N, 2026-08-09): 60 nodes / 117
-  edges ≈ 3 ms, 180 / ~370 ≈ 16 ms, 400 / 840 ≈ 72 ms; cost depends on graph shape as
-  well as size. The in-suite 300 ms timing test is a catastrophic-regression guard, not a
-  check of this budget.
+- **During a drag**, routes recompute continuously, throttled to animation frames, through
+  **the same code path as at rest** — no incident-only mode and no catch-up pass at drag stop,
+  so no edge is ever drawn against a rect the dragged node has already left and nothing jumps
+  on drop. A pass does skip edges whose route cannot have changed, which is a pure
+  optimization and not a second answer: the router's Locality guarantee makes reusing them
+  identical to recomputing them, and `contracts/edge-routing.md` ("Narrowing a pass") states
+  the three clauses a caller owes. The narrowing is what keeps a drag inside the frame budget;
+  routing _everything_ every frame does not, which is why it is there.
+  Measured out of band, full pass, region grid vs. the graph-wide grid it replaces (bare Node,
+  warm, median of 9, 2026-08-11, this machine; ELK-layered-shaped graphs, 180×60 px nodes on a
+  260×160 px grid): 60 nodes / 117 edges **5–7 ms** vs 9–17 ms, 180 / 370 **14–23 ms** vs
+  48–104 ms, 400 / 840 **34–48 ms** vs 214–267 ms. Ranges are across repeated runs on a
+  loaded machine, so treat them as an order of magnitude, not a number. Two things follow: the
+  region grid is 2–5× cheaper than the graph-wide one at every size, and a full pass still
+  exceeds the 16.7 ms budget from roughly 180 nodes, which the Use-Def view can reach since it
+  emits one node per instruction. Cost depends on graph shape: on a fixture whose edges span
+  the whole graph rather than joining adjacent layers, every region grows to nearly the graph
+  and the advantage disappears (400 / 840: 1740 ms vs 1725 ms). Real IR graphs are layered.
+  The in-suite 300 ms timing test is a catastrophic-regression guard, not a check of this
+  budget.
+- **An edge changes only when something near it changed.** Dragging a node re-routes the
+  edges whose region it touches and leaves every other route byte-identical — the Locality
+  guarantee of `contracts/edge-routing.md`, and the reason a drag no longer perturbs edges
+  elsewhere in the graph. It holds for every edge except one that had to fall through to the
+  contract's whole-graph retry, which is the rare case of a region offering no path at all
+  (no edge in either default LLVM-IR example needs it). Measured on the Use-Def view of the
+  default example (2026-08-11, replayed through the router from the app's ELK layout): dragging
+  the `%0` argument node by 24 × 16 px changed 4 routes on the graph-wide grid — one of them an
+  edge not touching the dragged node at all — against 3 on the region grid, all of them
+  incident to it, and **no route outside the dragged node's reach changed at any drag
+  distance**.
 - **Rendering:** `RoutedEdge` draws the returned points as an orthogonal polyline with
   **rounded corners**; edge labels (phi) render at the polyline's arc-length midpoint.
 - **The bend radius is derived from the router's node margin, not chosen.** Two
@@ -224,12 +246,18 @@ all (#88). Until those land, an overlap in the rendered graph means nothing.
 > (back-edge flag inherited on content-only updates),
 > `src/utils/__tests__/converter.test.ts` (dashed chain/glue, markerStart/markerEnd).
 >
+> Also pinned by: `src/hooks/__tests__/useEdgeRoutes.test.ts` (a narrowed pass equals the
+> full pass, including when a node stops obstructing an edge, when a far node reshapes a
+> route found on the whole graph, and when a handle moves under a rect that did not).
+>
 > _(observed, untested)_: live-rect tracking while dragging and after content edits, the
-> one-pass `useEdgeRoutes` hook and its context, the unmeasured-node omission, the midpoint
-> label placement, the accent color, and the drag-time
-> throttling/incident-edges pass. The frame-budget figures are measured out of band, not by
-> the test suite. The overlap semantics are _specified, unimplemented_ — a different marker
-> from the two above: there is nothing to observe and nothing to pin until #86–#88 land.
+> hook's context publication, the unmeasured-node omission, the midpoint label placement, the
+> accent color, and the animation-frame throttling. The frame-budget figures are measured out
+> of band, not by the test suite. Locality itself _is_ pinned, at the router boundary
+> (`src/utils/__tests__/edgeRouter.test.ts`): what the suite cannot observe is only that the
+> hook feeds the router the live rects. The overlap semantics are _specified, unimplemented_ —
+> a different marker from the two above: there is nothing to observe and nothing to pin until
+> #86–#88 land.
 
 ## 5. Node dimension estimation
 

--- a/src/hooks/__tests__/useEdgeRoutes.test.ts
+++ b/src/hooks/__tests__/useEdgeRoutes.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect } from "vitest";
+import { routePass, passStateOf } from "../useEdgeRoutes";
+import {
+  routeEdges,
+  quantizeRect,
+  quantizeRequest,
+} from "../../utils/edgeRouter";
+import type {
+  Point,
+  RouteNodeRect,
+  RouteRequest,
+} from "../../types/edgeRouting";
+
+/**
+ * `routePass` narrows a pass to the edges whose route can have changed and
+ * reuses the rest (`specs/graph-view.md` §4, and the Locality guarantee of
+ * `contracts/edge-routing.md`). The narrowing is only legitimate if it is
+ * **unobservable**, so every test here asserts the same thing: the narrowed
+ * pass equals the full pass, map entry for map entry.
+ *
+ * The failure this guards against is the one the drag-time split used to have —
+ * an edge left drawn against a rect the moved node had already vacated, which
+ * then jumped when the drag stopped. That defect would show up here as a
+ * mismatch, not as a visual report.
+ */
+
+const keyOf = (routes: ReadonlyMap<string, Point[]>): string =>
+  [...routes.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(
+      ([id, points]) =>
+        `${id}=${points.map((p) => `${String(p.x)},${String(p.y)}`).join(" ")}`,
+    )
+    .join(";");
+
+/** A layered graph: rows of nodes, every edge joining one row to the next. */
+function layeredGraph(
+  rows: number,
+  perRow: number,
+): { rects: RouteNodeRect[]; requests: RouteRequest[] } {
+  const rects: RouteNodeRect[] = [];
+  for (let row = 0; row < rows; row++) {
+    for (let column = 0; column < perRow; column++) {
+      rects.push({
+        id: `n${String(row)}-${String(column)}`,
+        x: column * 240,
+        y: row * 150,
+        width: 160,
+        height: 60,
+      });
+    }
+  }
+  const rectById = new Map(rects.map((rect) => [rect.id, rect]));
+  const requests: RouteRequest[] = [];
+  for (let row = 0; row + 1 < rows; row++) {
+    for (let column = 0; column < perRow; column++) {
+      for (const shift of [0, 1]) {
+        const source = rectById.get(`n${String(row)}-${String(column)}`);
+        const target = rectById.get(
+          `n${String(row + 1)}-${String((column + shift) % perRow)}`,
+        );
+        if (source === undefined || target === undefined) continue;
+        requests.push({
+          id: `e${String(row)}-${String(column)}-${String(shift)}`,
+          source: source.id,
+          target: target.id,
+          sourcePoint: {
+            x: source.x + source.width / 2,
+            y: source.y + source.height,
+          },
+          targetPoint: { x: target.x + target.width / 2, y: target.y },
+          sourceSide: "bottom",
+          targetSide: "top",
+        });
+      }
+    }
+  }
+  return { rects, requests };
+}
+
+/** Moves one rect, carrying the endpoints anchored on it (what a drag does). */
+function moveNode(
+  rects: RouteNodeRect[],
+  requests: RouteRequest[],
+  id: string,
+  dx: number,
+  dy: number,
+): { rects: RouteNodeRect[]; requests: RouteRequest[] } {
+  return {
+    rects: rects.map((rect) =>
+      rect.id === id ? { ...rect, x: rect.x + dx, y: rect.y + dy } : rect,
+    ),
+    requests: requests.map((request) => ({
+      ...request,
+      sourcePoint:
+        request.source === id
+          ? { x: request.sourcePoint.x + dx, y: request.sourcePoint.y + dy }
+          : request.sourcePoint,
+      targetPoint:
+        request.target === id
+          ? { x: request.targetPoint.x + dx, y: request.targetPoint.y + dy }
+          : request.targetPoint,
+    })),
+  };
+}
+
+const fullPass = (rects: RouteNodeRect[], requests: RouteRequest[]) =>
+  routeEdges(rects.map(quantizeRect), requests.map(quantizeRequest));
+
+const narrowedPass = (
+  previousRects: RouteNodeRect[],
+  previousRequests: RouteRequest[],
+  rects: RouteNodeRect[],
+  requests: RouteRequest[],
+) => {
+  const beforeRects = previousRects.map(quantizeRect);
+  const beforeRequests = previousRequests.map(quantizeRequest);
+  const previous = passStateOf(
+    beforeRects,
+    beforeRequests,
+    routeEdges(beforeRects, beforeRequests),
+  );
+  return routePass(
+    previous,
+    rects.map(quantizeRect),
+    requests.map(quantizeRequest),
+  );
+};
+
+describe("routePass — a narrowed pass equals a full pass", () => {
+  it("matches after a node is dragged, at every step of the drag", () => {
+    const { rects, requests } = layeredGraph(4, 4);
+    const dragged = "n1-1";
+
+    // A drag is a sequence of small moves, each narrowed against the last —
+    // which is where a stale entry would accumulate rather than show up once.
+    let currentRects = rects;
+    let currentRequests = requests;
+    for (let step = 1; step <= 12; step++) {
+      const moved = moveNode(currentRects, currentRequests, dragged, 7, 5);
+      expect(
+        keyOf(
+          narrowedPass(
+            currentRects,
+            currentRequests,
+            moved.rects,
+            moved.requests,
+          ),
+        ),
+      ).toBe(keyOf(fullPass(moved.rects, moved.requests)));
+      currentRects = moved.rects;
+      currentRequests = moved.requests;
+    }
+  });
+
+  it("matches for moves of every size, including ones that cross other nodes", () => {
+    const { rects, requests } = layeredGraph(4, 4);
+    for (const [dx, dy] of [
+      [0, 1],
+      [3, 0],
+      [40, 0],
+      [0, 90],
+      [-120, 60],
+      [240, 150], // lands exactly on a neighbour's cell
+      [600, 450], // far outside every previous region
+      [-600, -450],
+    ]) {
+      const moved = moveNode(rects, requests, "n1-2", dx, dy);
+      expect(
+        keyOf(narrowedPass(rects, requests, moved.rects, moved.requests)),
+      ).toBe(keyOf(fullPass(moved.rects, moved.requests)));
+    }
+  });
+
+  it("matches when a node is resized, added or removed", () => {
+    const { rects, requests } = layeredGraph(3, 3);
+
+    const resized = rects.map((rect) =>
+      rect.id === "n1-1" ? { ...rect, width: 400, height: 140 } : rect,
+    );
+    expect(keyOf(narrowedPass(rects, requests, resized, requests))).toBe(
+      keyOf(fullPass(resized, requests)),
+    );
+
+    const added = [
+      ...rects,
+      { id: "extra", x: 180, y: 120, width: 200, height: 60 },
+    ];
+    expect(keyOf(narrowedPass(rects, requests, added, requests))).toBe(
+      keyOf(fullPass(added, requests)),
+    );
+
+    // Removing a rect must drop its edges' entries, not leave them standing.
+    const removed = rects.filter((rect) => rect.id !== "n1-1");
+    expect(keyOf(narrowedPass(rects, requests, removed, requests))).toBe(
+      keyOf(fullPass(removed, requests)),
+    );
+  });
+
+  it("matches when edges themselves come and go", () => {
+    const { rects, requests } = layeredGraph(3, 3);
+    const fewer = requests.slice(0, requests.length - 3);
+    expect(keyOf(narrowedPass(rects, requests, rects, fewer))).toBe(
+      keyOf(fullPass(rects, fewer)),
+    );
+    expect(keyOf(narrowedPass(rects, fewer, rects, requests))).toBe(
+      keyOf(fullPass(rects, requests)),
+    );
+  });
+
+  it("matches on a graph dense enough to force whole-graph retries", () => {
+    // A wall taller than any region: the edges crossing it are routed on the
+    // contract's second rung, for which Locality is *not* claimed. They must be
+    // re-routed unconditionally, which is the case this fixture exists to hit.
+    const { rects, requests } = layeredGraph(3, 3);
+    const walled = [
+      ...rects,
+      { id: "wall", x: 300, y: -2000, width: 40, height: 4000 },
+    ];
+    for (const [dx, dy] of [
+      [11, 0],
+      [0, 37],
+      [-300, 0],
+    ]) {
+      const moved = moveNode(walled, requests, "n0-0", dx, dy);
+      expect(
+        keyOf(narrowedPass(walled, requests, moved.rects, moved.requests)),
+      ).toBe(keyOf(fullPass(moved.rects, moved.requests)));
+    }
+  });
+
+  it("matches when a node stops obstructing an edge by moving away", () => {
+    // The space a node *vacates* matters as much as the space it takes: this
+    // edge detours around OBS, and once OBS leaves, the detour must go with it.
+    // A narrowing that only looks at where things moved *to* keeps the stale
+    // detour — the exact shape of the defect the old drag-time split had.
+    const rects: RouteNodeRect[] = [
+      { id: "A", x: 0, y: 0, width: 100, height: 40 },
+      { id: "B", x: 0, y: 400, width: 100, height: 40 },
+      { id: "OBS", x: 0, y: 180, width: 100, height: 40 },
+    ];
+    const requests: RouteRequest[] = [
+      {
+        id: "A-B",
+        source: "A",
+        target: "B",
+        sourcePoint: { x: 50, y: 40 },
+        targetPoint: { x: 50, y: 400 },
+        sourceSide: "bottom",
+        targetSide: "top",
+      },
+    ];
+    const detoured = fullPass(rects, requests).get("A-B");
+    expect(detoured === undefined ? 0 : detoured.length).toBeGreaterThan(2);
+
+    for (const [dx, dy] of [
+      [900, 0],
+      [0, 900],
+      [-900, -900],
+    ]) {
+      const moved = moveNode(rects, requests, "OBS", dx, dy);
+      expect(
+        keyOf(narrowedPass(rects, requests, moved.rects, moved.requests)),
+      ).toBe(keyOf(fullPass(moved.rects, moved.requests)));
+    }
+  });
+
+  it("matches when a far node reshapes a route that was found on the whole graph", () => {
+    // A wall wider than any region forces this edge onto the contract's second
+    // rung, where the route runs far outside its own region and Locality does
+    // not hold. Moving a node that is nowhere near the region — but squarely on
+    // that long way round — must therefore still re-route it.
+    const rects: RouteNodeRect[] = [
+      { id: "A", x: 0, y: 0, width: 100, height: 40 },
+      { id: "B", x: 0, y: 600, width: 100, height: 40 },
+      // Open only at its right end, so the way round is a known corridor.
+      { id: "WALL", x: -3000, y: 280, width: 4000, height: 40 },
+      // Just clear of that corridor to begin with; the moves below close it.
+      { id: "FAR", x: 1100, y: 200, width: 200, height: 200 },
+    ];
+    const requests: RouteRequest[] = [
+      {
+        id: "A-B",
+        source: "A",
+        target: "B",
+        sourcePoint: { x: 50, y: 40 },
+        targetPoint: { x: 50, y: 600 },
+        sourceSide: "bottom",
+        targetSide: "top",
+      },
+    ];
+    const region = { minX: 50 - 192, maxX: 50 + 192 };
+    const points = fullPass(rects, requests).get("A-B");
+    expect(points).toBeDefined();
+    // Precondition of the fixture: the route really does leave its region.
+    expect(points?.some((p) => p.x < region.minX || p.x > region.maxX)).toBe(
+      true,
+    );
+
+    for (const [dx, dy] of [
+      [-100, 0], // steps into the corridor
+      [-160, 0],
+      [-100, 40],
+    ]) {
+      const moved = moveNode(rects, requests, "FAR", dx, dy);
+      const after = fullPass(moved.rects, moved.requests);
+      // Precondition: this move really does reshape the route. Without it the
+      // assertion below would hold for a narrowing that reused everything.
+      expect(keyOf(after)).not.toBe(keyOf(fullPass(rects, requests)));
+      expect(
+        keyOf(narrowedPass(rects, requests, moved.rects, moved.requests)),
+      ).toBe(keyOf(after));
+    }
+  });
+
+  it("matches when a handle moves while its node's rect stays put", () => {
+    // A per-operand port can shift (the Use-Def view) while the card keeps its
+    // measured size: the request changed, no rect did. Nothing in the rect diff
+    // sees this, so the request's own record has to be compared.
+    const { rects, requests } = layeredGraph(3, 3);
+    const shifted = requests.map((request, index) =>
+      index === 0
+        ? {
+            ...request,
+            sourcePoint: {
+              x: request.sourcePoint.x - 60,
+              y: request.sourcePoint.y,
+            },
+          }
+        : request,
+    );
+    const after = fullPass(rects, shifted);
+    expect(keyOf(after)).not.toBe(keyOf(fullPass(rects, requests)));
+    expect(keyOf(narrowedPass(rects, requests, rects, shifted))).toBe(
+      keyOf(after),
+    );
+  });
+
+  it("routes everything when there is no previous pass", () => {
+    const { rects, requests } = layeredGraph(3, 3);
+    expect(keyOf(routePass(null, rects, requests))).toBe(
+      keyOf(routeEdges(rects, requests)),
+    );
+  });
+});

--- a/src/hooks/useEdgeRoutes.ts
+++ b/src/hooks/useEdgeRoutes.ts
@@ -13,10 +13,17 @@ import {
   type Edge,
   type InternalNode,
 } from "@xyflow/react";
-import { routeEdges } from "../utils/edgeRouter";
+import {
+  DEFAULT_NODE_MARGIN,
+  quantizeRect,
+  quantizeRequest,
+  routeEdges,
+  routeRegionOf,
+} from "../utils/edgeRouter";
 import type {
   Point,
   RouteNodeRect,
+  RouteRegion,
   RouteRequest,
   RouteSide,
 } from "../types/edgeRouting";
@@ -182,9 +189,18 @@ const collectRequests = (
 };
 
 /**
- * Cheap fingerprint of everything the router reads. React Flow's store also
- * notifies on viewport changes (panning, zooming), which move no rect and no
- * handle; comparing this string keeps those frames from re-routing anything.
+ * Cheap fingerprint of everything the router reads, over **quantized** rects and
+ * requests. React Flow's store also notifies on viewport changes (panning,
+ * zooming), which move no rect and no handle; comparing this string keeps those
+ * frames from re-routing anything.
+ *
+ * Quantizing first is what makes the fingerprint agree with the router about
+ * what "changed" means. Measured rects and handle positions carry fractional
+ * parts that drift with font loading and zoom transforms, and the router snaps
+ * every coordinate to an integer lattice before it looks at anything
+ * (`contracts/edge-routing.md`, "Input quantization"), so two states that differ
+ * below half a pixel are the same input and re-routing them produces the same
+ * map. Hashing the raw floats instead ran a pass per jitter frame.
  */
 const inputSignature = (
   rects: readonly RouteNodeRect[],
@@ -208,68 +224,178 @@ const inputSignature = (
   return parts.join(";");
 };
 
+/** The rect grown by `nodeMargin`, which is the shape a region is tested against. */
+const inflatedBox = (rect: RouteNodeRect): RouteRegion => ({
+  minX: rect.x - DEFAULT_NODE_MARGIN,
+  minY: rect.y - DEFAULT_NODE_MARGIN,
+  maxX: rect.x + rect.width + DEFAULT_NODE_MARGIN,
+  maxY: rect.y + rect.height + DEFAULT_NODE_MARGIN,
+});
+
+const boxesOverlap = (a: RouteRegion, b: RouteRegion): boolean =>
+  a.minX <= b.maxX && a.maxX >= b.minX && a.minY <= b.maxY && a.maxY >= b.minY;
+
+const sameRect = (a: RouteNodeRect, b: RouteNodeRect): boolean =>
+  a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+
+const sameRequest = (a: RouteRequest, b: RouteRequest): boolean =>
+  a.source === b.source &&
+  a.target === b.target &&
+  a.sourceSide === b.sourceSide &&
+  a.targetSide === b.targetSide &&
+  a.sourcePoint.x === b.sourcePoint.x &&
+  a.sourcePoint.y === b.sourcePoint.y &&
+  a.targetPoint.x === b.targetPoint.x &&
+  a.targetPoint.y === b.targetPoint.y;
+
+/** What one pass routed, kept so the next one can narrow (see `affectedRequests`). */
+interface PassState {
+  rects: Map<string, RouteNodeRect>;
+  requests: Map<string, RouteRequest>;
+  routes: EdgeRouteMap;
+}
+
+/**
+ * The requests whose route may differ from the previous pass — a **superset**,
+ * which is what makes routing only these and reusing the rest observationally
+ * identical to a full pass.
+ *
+ * The router's Locality guarantee (`contracts/edge-routing.md`) is what this
+ * rests on: a route found on its region is a function of the rects reaching that
+ * region, so an edge no changed rect comes near returns exactly the polyline it
+ * already has. Three things are therefore in the set, and the third is the one
+ * that is easy to forget:
+ *
+ * 1. requests that are new, or whose own record moved — their region moved too;
+ * 2. requests whose region a changed rect reaches, in **either** its old or its
+ *    new position, since both the vacated space and the occupied one matter;
+ * 3. requests whose previous route left its own region — the signature of the
+ *    contract's whole-graph retry, for which Locality is explicitly not claimed.
+ */
+const affectedRequests = (
+  requests: readonly RouteRequest[],
+  rects: readonly RouteNodeRect[],
+  previous: PassState,
+): RouteRequest[] => {
+  const changedBoxes: RouteRegion[] = [];
+  const seen = new Set<string>();
+  for (const rect of rects) {
+    seen.add(rect.id);
+    const before = previous.rects.get(rect.id);
+    if (before === undefined) {
+      changedBoxes.push(inflatedBox(rect));
+    } else if (!sameRect(before, rect)) {
+      changedBoxes.push(inflatedBox(before), inflatedBox(rect));
+    }
+  }
+  for (const [id, rect] of previous.rects) {
+    if (!seen.has(id)) changedBoxes.push(inflatedBox(rect)); // removed
+  }
+
+  return requests.filter((request) => {
+    const before = previous.requests.get(request.id);
+    if (before === undefined || !sameRequest(before, request)) return true;
+    const points = previous.routes.get(request.id);
+    if (points === undefined) return true;
+    const region = routeRegionOf(request);
+    for (const point of points) {
+      if (
+        point.x < region.minX ||
+        point.x > region.maxX ||
+        point.y < region.minY ||
+        point.y > region.maxY
+      ) {
+        return true; // left its region: possibly the whole-graph rung
+      }
+    }
+    return changedBoxes.some((box) => boxesOverlap(box, region));
+  });
+};
+
+/**
+ * One pass: the routes for `requests` against `rects`, reusing every polyline
+ * the change cannot have altered.
+ *
+ * Pure, and **equal to `routeEdges(rects, requests)` entry for entry** — that
+ * equality is the whole contract of this function, and it is what
+ * `__tests__/useEdgeRoutes.test.ts` pins. `previous === null` (the first pass,
+ * or after any doubt) simply routes everything.
+ */
+export const routePass = (
+  previous: PassState | null,
+  rects: RouteNodeRect[],
+  requests: RouteRequest[],
+): EdgeRouteMap => {
+  if (previous === null) return routeEdges(rects, requests);
+
+  const affected = affectedRequests(requests, rects, previous);
+  const affectedIds = new Set(affected.map((request) => request.id));
+  const routed = routeEdges(rects, affected);
+  const merged = new Map<string, Point[]>();
+  for (const request of requests) {
+    // An affected request takes the new answer, including "no entry" — the
+    // contract's missing-node rule, which a stale entry would paper over.
+    const points = affectedIds.has(request.id)
+      ? routed.get(request.id)
+      : previous.routes.get(request.id);
+    if (points !== undefined) merged.set(request.id, points);
+  }
+  return merged;
+};
+
+/** The pass state to carry into the next `routePass`. */
+export const passStateOf = (
+  rects: RouteNodeRect[],
+  requests: RouteRequest[],
+  routes: EdgeRouteMap,
+): PassState => ({
+  rects: new Map(rects.map((rect) => [rect.id, rect])),
+  requests: new Map(requests.map((request) => [request.id, request])),
+  routes,
+});
+
 /**
  * Runs the routing pass and returns the current route map.
  *
- * Throttled to animation frames. **During a drag only the edges incident to a
- * moved node are re-routed** and the results are merged over the previous map;
- * a full pass runs on drag stop (`specs/graph-view.md` §4). That split is
- * required rather than opportunistic: a full pass overruns the 16.7 ms frame
- * budget from roughly 180 nodes, which the Use-Def view can reach. The router
- * is a pure function of the rects it is given, so an incident-only pass is
- * just a call with a filtered `requests` array — the `nodes` array stays
- * complete, or the partial routes would route through the wrong obstacles.
+ * Throttled to animation frames. **There is one routing path**, during a drag
+ * exactly as at rest (`specs/graph-view.md` §4): no incident-only mode, and no
+ * catch-up pass on drop. No edge is left drawn against a rect the dragged node
+ * has already vacated, so nothing jumps when it is released — the visible defect
+ * the old split produced.
+ *
+ * What a pass does skip is edges whose route cannot have changed, which the
+ * router's Locality guarantee makes a pure optimization rather than a second
+ * answer (`affectedRequests` above, and the contract's "Narrowing a pass").
+ * Skipping is worth having: routing everything costs 15-25 ms at 180 nodes and
+ * 35-50 ms at 400 (`specs/graph-view.md` §4), over the 16.7 ms frame budget,
+ * while a drag genuinely affects a handful of edges. The `nodes` array stays
+ * complete either way — a narrowed pass must still route around every obstacle.
  */
 export const useEdgeRoutes = (): EdgeRouteMap => {
   const store = useStoreApi();
   const [routes, setRoutes] = useState<EdgeRouteMap>(EMPTY_ROUTES);
 
-  const routesRef = useRef<EdgeRouteMap>(EMPTY_ROUTES);
   const frameRef = useRef<number | null>(null);
   const signatureRef = useRef<string | null>(null);
-  const wasDraggingRef = useRef(false);
+  const passRef = useRef<PassState | null>(null);
 
   useEffect(() => {
     const runPass = () => {
       frameRef.current = null;
       const { nodeLookup, edges } = store.getState();
 
-      const rects = collectRects(nodeLookup);
-      const requests = collectRequests(edges, nodeLookup);
-      const signature = inputSignature(rects, requests);
+      // Quantized here rather than inside `routeEdges` alone, so that the
+      // fingerprint below and the router agree on what changed. Re-quantizing
+      // integers is the identity, so the router sees exactly these values.
+      const rects = collectRects(nodeLookup).map(quantizeRect);
+      const requests = collectRequests(edges, nodeLookup).map(quantizeRequest);
 
-      const dragged = new Set<string>();
-      for (const node of nodeLookup.values()) {
-        if (node.dragging === true) dragged.add(node.id);
-      }
-      const isDragging = dragged.size > 0;
-      // A drag that just stopped needs the full pass even though nothing moved
-      // in this frame: the edges that are not incident to the dragged node were
-      // left routing around its old rect.
-      const dragJustStopped = wasDraggingRef.current && !isDragging;
-      wasDraggingRef.current = isDragging;
-      if (signature === signatureRef.current && !dragJustStopped) return;
+      const signature = inputSignature(rects, requests);
+      if (signature === signatureRef.current) return;
       signatureRef.current = signature;
 
-      let next: EdgeRouteMap;
-      if (isDragging) {
-        const incident = requests.filter(
-          (request) =>
-            dragged.has(request.source) || dragged.has(request.target),
-        );
-        const partial = routeEdges(rects, incident);
-        const merged = new Map(routesRef.current);
-        for (const request of incident) {
-          const points = partial.get(request.id);
-          if (points === undefined) merged.delete(request.id);
-          else merged.set(request.id, points);
-        }
-        next = merged;
-      } else {
-        next = routeEdges(rects, requests);
-      }
-
-      routesRef.current = next;
+      const next = routePass(passRef.current, rects, requests);
+      passRef.current = passStateOf(rects, requests, next);
       setRoutes(next);
     };
 

--- a/src/types/edgeRouting.ts
+++ b/src/types/edgeRouting.ts
@@ -35,3 +35,16 @@ export interface EdgeRouterOptions {
   bendPenalty?: number; // default 30
   selfLoopGap?: number; // default 24
 }
+
+/**
+ * The part of the plane one request is searched in — an axis-aligned box, bounds
+ * inclusive (`contracts/edge-routing.md`, "Per-edge regions"). A route found
+ * here is a function of the rects reaching this box and of nothing else, which
+ * is what lets a caller decide that an edge cannot have changed.
+ */
+export interface RouteRegion {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}

--- a/src/utils/__tests__/edgeRouter.test.ts
+++ b/src/utils/__tests__/edgeRouter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { routeEdges } from "../edgeRouter";
+import { ROUTE_REGION_MARGIN, routeEdges } from "../edgeRouter";
 import type {
   Point,
   RouteNodeRect,
@@ -2898,6 +2898,172 @@ describe("routeEdges — quantization: determinism on fractional input (contract
     expect(at106[0]).toEqual({ x: 40, y: 11 });
     expect(at104).toEqual(at102);
     expect(at106).not.toEqual(at104);
+  });
+});
+
+describe("routeEdges — locality (contract: 'Locality', 'Per-edge regions')", () => {
+  // The guarantee under test: a route found on its own region is a function of
+  // the rects that region reaches and of its own request — of nothing else in
+  // the input. It is what makes the router *stable* and not merely
+  // deterministic, so these are the tests that would catch a search quietly
+  // going back to a graph-wide grid: determinism alone cannot, since a
+  // graph-wide search is perfectly deterministic while still letting an
+  // unrelated node's one-pixel move flip a route through the tie-break.
+  //
+  // Distances are stated in terms of `ROUTE_REGION_MARGIN` rather than as
+  // literals, so retuning the constant re-aims these fixtures instead of
+  // breaking them.
+
+  /** The region of `simpleTwoNodeCase`'s request, per the contract's definition. */
+  const SIMPLE_REGION = {
+    minX: 40 - ROUTE_REGION_MARGIN,
+    maxX: 200 + ROUTE_REGION_MARGIN,
+    minY: 20 - ROUTE_REGION_MARGIN,
+    maxY: 20 + ROUTE_REGION_MARGIN,
+  };
+
+  /**
+   * A 40×40 rect at `(x, y)`, asserted to be clear of `SIMPLE_REGION` — the
+   * assertion is inside the helper so that a fixture cannot silently stop
+   * testing what it claims to by drifting into the region.
+   */
+  function bystander(id: string, x: number, y: number): RouteNodeRect {
+    const inflatedMinX = x - 12;
+    const inflatedMinY = y - 12;
+    expect(
+      inflatedMinX > SIMPLE_REGION.maxX || inflatedMinY > SIMPLE_REGION.maxY,
+    ).toBe(true);
+    return { id, x, y, width: 40, height: 40 };
+  }
+
+  it("leaves a route byte-identical wherever a rect outside its region sits", () => {
+    const { nodes, request } = simpleTwoNodeCase();
+    const alone = routeEdges(nodes, [request]).get(request.id);
+
+    for (const [x, y] of [
+      [500, 500],
+      [900, 500],
+      [500, 1_200],
+      [2_000, 2_000],
+      [-3_000, 900],
+    ]) {
+      const withBystander = routeEdges(
+        [...nodes, bystander("BY", x, y)],
+        [request],
+      ).get(request.id);
+      expect(withBystander).toEqual(alone);
+    }
+  });
+
+  it("leaves a route byte-identical when a rect outside its region is resized or removed", () => {
+    const { nodes, request } = simpleTwoNodeCase();
+    const far = bystander("BY", 800, 800);
+    const alone = routeEdges(nodes, [request]).get(request.id);
+
+    expect(routeEdges([...nodes, far], [request]).get(request.id)).toEqual(
+      alone,
+    );
+    expect(
+      routeEdges(
+        [...nodes, { ...far, width: 400, height: 400 }],
+        [request],
+      ).get(request.id),
+    ).toEqual(alone);
+  });
+
+  it("still routes around a rect inside the region — the guarantee is not vacuity", () => {
+    // The companion every locality test needs: if the router ignored rects
+    // wholesale, every assertion above would pass. This one fails unless the
+    // rects a region *does* reach are still obstacles.
+    const { nodes, request } = simpleTwoNodeCase();
+    const alone = routeEdges(nodes, [request]).get(request.id)!;
+    const obstacle: RouteNodeRect = {
+      id: "OBS",
+      x: 100,
+      y: 0,
+      width: 40,
+      height: 40,
+    };
+
+    const detoured = routeEdges([...nodes, obstacle], [request]).get(
+      request.id,
+    )!;
+
+    expect(detoured).not.toEqual(alone);
+    expect(anyMiddleSegmentCrossesRectInterior(detoured, obstacle)).toBe(false);
+  });
+
+  it("keeps a first-rung route inside its own region", () => {
+    // Every grid vertex of a region search lies inside the region — the clip
+    // described in "Per-edge regions", which is what makes the rects the region
+    // selected provably the only ones that can block. A route that left the
+    // region could run through a rect that was excluded for not reaching it.
+    const nodes: RouteNodeRect[] = [
+      { id: "A", x: 0, y: 0, width: 40, height: 40 },
+      { id: "B", x: 400, y: 0, width: 40, height: 40 },
+      // Straddles the region boundary: its top is far outside, its bottom edge
+      // sits inside, and it stands squarely on the straight line A → B.
+      { id: "TALL", x: 200, y: -3_000, width: 40, height: 3_030 },
+    ];
+    const request: RouteRequest = {
+      id: "e-A-B",
+      source: "A",
+      target: "B",
+      sourcePoint: { x: 40, y: 20 },
+      targetPoint: { x: 400, y: 20 },
+      sourceSide: "right",
+      targetSide: "left",
+    };
+    const region = {
+      minX: 40 - ROUTE_REGION_MARGIN,
+      maxX: 400 + ROUTE_REGION_MARGIN,
+      minY: 20 - ROUTE_REGION_MARGIN,
+      maxY: 20 + ROUTE_REGION_MARGIN,
+    };
+
+    const points = routeEdges(nodes, [request]).get(request.id)!;
+
+    expect(isFallbackShape(points, request)).toBe(false);
+    expect(anyMiddleSegmentCrossesRectInterior(points, nodes[2])).toBe(false);
+    for (const point of points) {
+      expect(point.x).toBeGreaterThanOrEqual(region.minX);
+      expect(point.x).toBeLessThanOrEqual(region.maxX);
+      expect(point.y).toBeGreaterThanOrEqual(region.minY);
+      expect(point.y).toBeLessThanOrEqual(region.maxY);
+    }
+  });
+
+  it("retries on the whole graph when the region offers no path at all", () => {
+    // The second rung. The wall spans the region on both sides, so no path
+    // exists on the region grid; the way around it is a detour thousands of
+    // pixels long, which only the graph-wide grid holds. What the rung buys is
+    // that regions cannot make an edge less routable than it was: this must
+    // come back as a searched route, not as the no-path fallback.
+    const nodes: RouteNodeRect[] = [
+      { id: "A", x: 0, y: 0, width: 40, height: 40 },
+      { id: "B", x: 400, y: 0, width: 40, height: 40 },
+      { id: "WALL", x: 200, y: -3_000, width: 40, height: 6_000 },
+    ];
+    const request: RouteRequest = {
+      id: "e-A-B",
+      source: "A",
+      target: "B",
+      sourcePoint: { x: 40, y: 20 },
+      targetPoint: { x: 400, y: 20 },
+      sourceSide: "right",
+      targetSide: "left",
+    };
+
+    const points = routeEdges(nodes, [request]).get(request.id)!;
+
+    expect(isFallbackShape(points, request)).toBe(false);
+    expect(isOrthogonalPolyline(points)).toBe(true);
+    expect(anyMiddleSegmentCrossesRectInterior(points, nodes[2])).toBe(false);
+    // It left the region — which is the point of the rung, and why Locality is
+    // explicitly not claimed for a route that needed it.
+    expect(points.some((point) => point.y > 20 + ROUTE_REGION_MARGIN)).toBe(
+      true,
+    );
   });
 });
 

--- a/src/utils/edgeRouter.ts
+++ b/src/utils/edgeRouter.ts
@@ -2,6 +2,7 @@ import type {
   EdgeRouterOptions,
   Point,
   RouteNodeRect,
+  RouteRegion,
   RouteRequest,
   RouteSide,
 } from "../types/edgeRouting";
@@ -9,11 +10,17 @@ import type {
 /**
  * Self-contained orthogonal edge router (`contracts/edge-routing.md`,
  * `specs/graph-view.md` §4). Every input coordinate is snapped to an integer
- * lattice at the entry of `routeEdges`; node rects are the only obstacles; a
- * sparse Hanan grid over the inflated rects is searched per edge with A*, and
- * the result is a rounded-corner-ready polyline. A routed edge begins and ends
- * exactly at its quantized handle positions; a self-loop is synthesized from its
- * node's rect alone and is exempt from that rule.
+ * lattice at the entry of `routeEdges`; node rects are the only obstacles; each
+ * edge is searched with A* over a sparse Hanan grid built from the rects near
+ * **it** — its region — and the result is a rounded-corner-ready polyline. A
+ * routed edge begins and ends exactly at its quantized handle positions; a
+ * self-loop is synthesized from its node's rect alone and is exempt from that
+ * rule.
+ *
+ * The region is why this router is stable and not merely deterministic: a route
+ * is a function of the rects near it, so an unrelated node moving cannot flip it
+ * through a tie-break on a shared grid. That is a guarantee of the module, not
+ * an optimization — see "Per-edge regions" and "Locality" in the contract.
  */
 
 /** Clearance kept around every node rect, px. */
@@ -22,6 +29,23 @@ export const DEFAULT_NODE_MARGIN = 12;
 export const DEFAULT_BEND_PENALTY = 30;
 /** Distance from a node's right edge to its self-loop lane, px. */
 export const DEFAULT_SELF_LOOP_GAP = 24;
+
+/**
+ * How far beyond its own endpoints an edge's search may look, px
+ * (`contracts/edge-routing.md`, "Per-edge regions"). A request is searched on a
+ * grid built from the rects intersecting its region — the bounding box of its
+ * two request points and their two pushed points, inflated by this — which is
+ * what the Locality guarantee is stated against: move a rect this region does
+ * not reach and the route cannot change, because that rect was never in the
+ * search.
+ *
+ * It is a constant rather than an `EdgeRouterOptions` field on purpose. No
+ * caller has a reason to vary it, and it is not a preference: it trades how far
+ * a detour may be looked for against how much of the graph an edge is coupled
+ * to, and both sides of that trade are properties of this router, not of a call
+ * site.
+ */
+export const ROUTE_REGION_MARGIN = 192;
 
 /**
  * Room a synthesized shape keeps where the clearance it is given leaves none
@@ -124,8 +148,15 @@ const quantize = (value: number): number => {
  * are these rects inflated by `nodeMargin`, and a band of that width around a
  * rect of no extent still has an interior. Coincident boundaries are likewise
  * left alone — `sortedUnique` already folds them when the grid is built.
+ *
+ * Exported because a caller that wants to know whether its input has really
+ * changed has to ask in the router's terms: two measurements a fraction of a
+ * pixel apart are the same input here, and rounding the four fields
+ * independently is not the same question — it can call `x = 10.0, w = 20.4` and
+ * `x = 10.4, w = 20.4` equal, where this makes them 20 px and 21 px wide.
+ * Re-passing an already-quantized rect to `routeEdges` is the identity.
  */
-const quantizeRect = (rect: RouteNodeRect): RouteNodeRect => {
+export const quantizeRect = (rect: RouteNodeRect): RouteNodeRect => {
   const x = quantize(rect.x);
   const y = quantize(rect.y);
   return {
@@ -142,9 +173,9 @@ const quantizeRect = (rect: RouteNodeRect): RouteNodeRect => {
  * position is a point, not an interval, so there is no companion field whose
  * consistency has to be preserved and `x` and `y` round independently.
  * Everything else — the ids and the two sides — is not a coordinate and passes
- * through untouched.
+ * through untouched. Exported for the same reason as `quantizeRect` above.
  */
-const quantizeRequest = (request: RouteRequest): RouteRequest => ({
+export const quantizeRequest = (request: RouteRequest): RouteRequest => ({
   ...request,
   sourcePoint: {
     x: quantize(request.sourcePoint.x),
@@ -275,18 +306,108 @@ interface Label {
   points: Point[] | null;
 }
 
-interface RouterContext {
-  nodeMargin: number;
-  bendPenalty: number;
+/** "Is this point strictly inside an obstacle the route must respect?" */
+type IsBlocked = (
+  x: number,
+  y: number,
+  exemptA: string | null,
+  exemptB: string | null,
+) => boolean;
+
+/**
+ * Everything one search may see: the candidate grid lines and the obstacles.
+ * There are two of these per pass — one built per edge from its own region, and
+ * the graph-wide one kept for the retry rung (`contracts/edge-routing.md`,
+ * "Per-edge regions"). Confining a search to a scope is what makes the Locality
+ * guarantee true by construction rather than by argument: a rect outside the
+ * scope is not reachable-but-unchosen, it is absent.
+ */
+interface SearchScope {
   gridXs: number[];
   gridYs: number[];
-  isBlocked: (
-    x: number,
-    y: number,
-    exemptA: string | null,
-    exemptB: string | null,
-  ) => boolean;
+  isBlocked: IsBlocked;
 }
+
+/**
+ * The region of a request: the bounding box of the four points that define it —
+ * the two quantized request points and the two `nodeMargin`-pushed points — with
+ * `ROUTE_REGION_MARGIN` added on every side.
+ */
+const regionOf = (points: Point[]): RouteRegion => {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const point of points) {
+    minX = Math.min(minX, point.x);
+    minY = Math.min(minY, point.y);
+    maxX = Math.max(maxX, point.x);
+    maxY = Math.max(maxY, point.y);
+  }
+  return {
+    minX: minX - ROUTE_REGION_MARGIN,
+    minY: minY - ROUTE_REGION_MARGIN,
+    maxX: maxX + ROUTE_REGION_MARGIN,
+    maxY: maxY + ROUTE_REGION_MARGIN,
+  };
+};
+
+/**
+ * Overlap test used to select the rects of a region, deliberately **non-strict**
+ * — a rect touching the region along a boundary is taken in. Blocking is a
+ * strict-interior test, so such a rect can block nothing inside the region and
+ * taking it in changes no route; the conservative direction is the safe one to
+ * be wrong in, and it keeps this test independent of the blocking one.
+ */
+const intersectsRegion = (rect: InflatedRect, region: RouteRegion): boolean =>
+  rect.minX <= region.maxX &&
+  rect.maxX >= region.minX &&
+  rect.minY <= region.maxY &&
+  rect.maxY >= region.minY;
+
+/**
+ * The scope of one request: the rects whose inflated form reaches its region,
+ * and of their boundaries only those falling **inside** the region.
+ *
+ * The clip is what confines the search to the region, and it is load-bearing
+ * rather than tidy. A rect straddling the region boundary contributes a far
+ * boundary outside it; keeping that line would let the grid — and a route on
+ * it — run past the region and into a rect that was excluded for not reaching
+ * the region, so an edge could cross a node that was never given a chance to
+ * block it. With the clip every grid vertex lies inside the region, so every
+ * segment does too.
+ *
+ * That last fact is also why the obstacle test does not have to be rebuilt per
+ * region: a rect containing a point inside the region necessarily intersects
+ * the region, so asking the graph-wide index about a point in here can only
+ * ever be answered by a rect this region selected. The shared index is
+ * therefore the same function as a region-local one would be, at the cost of
+ * building it once per pass instead of once per edge.
+ */
+const scopeOfRegion = (
+  inflated: InflatedRect[],
+  region: RouteRegion,
+  isBlocked: IsBlocked,
+): SearchScope => {
+  const gridXs: number[] = [];
+  const gridYs: number[] = [];
+  for (const rect of inflated) {
+    if (!intersectsRegion(rect, region)) continue;
+    if (rect.minX >= region.minX && rect.minX <= region.maxX) {
+      gridXs.push(rect.minX);
+    }
+    if (rect.maxX >= region.minX && rect.maxX <= region.maxX) {
+      gridXs.push(rect.maxX);
+    }
+    if (rect.minY >= region.minY && rect.minY <= region.maxY) {
+      gridYs.push(rect.minY);
+    }
+    if (rect.maxY >= region.minY && rect.maxY <= region.maxY) {
+      gridYs.push(rect.maxY);
+    }
+  }
+  return { gridXs, gridYs, isBlocked };
+};
 
 /**
  * Binary heap over the tie-break total order (`contracts/edge-routing.md`,
@@ -364,25 +485,30 @@ const remainingTurnsBound = (
  * Cheapest grid path from the pushed source point to the pushed target point,
  * or `null` when the grid offers none. Returns `[S, ...bends, T]`; the exact
  * handle positions are added by the caller.
+ *
+ * "The grid" is the given scope's — this edge's region, or the whole graph on
+ * the retry rung. The search below cannot tell the two apart, which is the
+ * point: locality is a property of what the scope contains, not of the search.
  */
 const routeOnGrid = (
   request: RouteRequest,
   start: Point,
   end: Point,
-  context: RouterContext,
+  scope: SearchScope,
+  bendPenalty: number,
 ): Point[] | null => {
-  // Candidate lines: every inflated rect edge, plus this edge's endpoints. The
-  // pushed points are included as well so that they are always grid vertices,
-  // even for a handle that does not sit on its node's boundary.
+  // Candidate lines: every inflated rect edge in scope, plus this edge's
+  // endpoints. The pushed points are included as well so that they are always
+  // grid vertices, even for a handle that does not sit on its node's boundary.
   const xs = sortedUnique([
-    ...context.gridXs,
+    ...scope.gridXs,
     request.sourcePoint.x,
     request.targetPoint.x,
     start.x,
     end.x,
   ]);
   const ys = sortedUnique([
-    ...context.gridYs,
+    ...scope.gridYs,
     request.sourcePoint.y,
     request.targetPoint.y,
     start.y,
@@ -399,7 +525,6 @@ const routeOnGrid = (
 
   const width = xs.length;
   const height = ys.length;
-  const { bendPenalty } = context;
   // The route leaves along the source handle's outward normal and arrives along
   // the target handle's inward normal, so turns are counted over the whole
   // returned polyline, stubs included.
@@ -511,7 +636,7 @@ const routeOnGrid = (
       const nextAtStart = nextXi === startXi && nextYi === startYi;
       const nextAtEnd = nextXi === endXi && nextYi === endYi;
       if (
-        context.isBlocked(
+        scope.isBlocked(
           (x + nextX) / 2,
           (y + nextY) / 2,
           labelAtStart || nextAtStart ? request.source : null,
@@ -738,6 +863,9 @@ const selfLoopPoints = (
  * Routes every request against the live node rects. Pure: the same rects and
  * requests always produce byte-identical polylines, and no route depends on the
  * order of either input array (`contracts/edge-routing.md`, "Determinism").
+ * Stronger, and the reason regions exist: a route found on its region depends
+ * only on the rects that region reaches, so moving anything else leaves it
+ * byte-identical (`contracts/edge-routing.md`, "Locality").
  *
  * Keyed by `RouteRequest.id`; a request naming a node absent from `nodes` gets
  * no entry at all (`contracts/edge-routing.md`, "Missing nodes").
@@ -789,9 +917,12 @@ export const routeEdges = (
     maxX: node.x + node.width + nodeMargin,
     maxY: node.y + node.height + nodeMargin,
   }));
-  const context: RouterContext = {
-    nodeMargin,
-    bendPenalty,
+  // The retry rung: every rect, unclipped, which is what the search saw for
+  // every edge before regions existed. Its obstacle index is built once per
+  // pass rather than once per edge — the cost that used to buy a graph-wide
+  // search for everyone now only has to be worth it for the requests that
+  // actually fall through.
+  const globalScope: SearchScope = {
     gridXs: inflated.flatMap((rect) => [rect.minX, rect.maxX]),
     gridYs: inflated.flatMap((rect) => [rect.minY, rect.maxY]),
     isBlocked: buildObstacleIndex(inflated),
@@ -826,7 +957,27 @@ export const routeEdges = (
       request.targetSide,
       nodeMargin,
     );
-    const grid = routeOnGrid(request, start, end, context);
+    // Two rungs, in this order (`contracts/edge-routing.md`, "Per-edge
+    // regions"): this edge's own region, then the whole graph. The second is
+    // what keeps the region from making an edge less routable than it was —
+    // whatever had a path before still has one — so only input with no
+    // orthogonal path at all reaches the fallback below.
+    const region = regionOf([
+      request.sourcePoint,
+      request.targetPoint,
+      start,
+      end,
+    ]);
+    // (Identical to `routeRegionOf(request)` below, which is that rule made
+    // available to callers; both go through `regionOf`.)
+    const grid =
+      routeOnGrid(
+        request,
+        start,
+        end,
+        scopeOfRegion(inflated, region, globalScope.isBlocked),
+        bendPenalty,
+      ) ?? routeOnGrid(request, start, end, globalScope, bendPenalty);
     const points = dropDuplicates(
       grid !== null
         ? [
@@ -849,4 +1000,35 @@ export const routeEdges = (
     );
   }
   return routes;
+};
+
+/**
+ * The region one request is searched in (`contracts/edge-routing.md`, "Per-edge
+ * regions"), on the quantized request — the same box `routeEdges` builds, from
+ * the same `regionOf`.
+ *
+ * Exported so that a caller holding the previous pass's input and output can
+ * work out which routes a change *cannot* have altered, and skip them. That is
+ * a pure optimization and only because of Locality: a route found on its region
+ * is a function of the rects reaching this box, so if none of them moved,
+ * re-routing would return the polyline the caller already has.
+ *
+ * Two conditions the caller owes, both stated in the contract under Locality:
+ * a request whose own record changed is always affected (its region moved with
+ * it), and a **previous route with a point outside this box** must always be
+ * re-routed — leaving the region is exactly the signature of the whole-graph
+ * retry, and Locality is not claimed for those.
+ */
+export const routeRegionOf = (
+  request: RouteRequest,
+  options: EdgeRouterOptions = {},
+): RouteRegion => {
+  const nodeMargin = quantize(options.nodeMargin ?? DEFAULT_NODE_MARGIN);
+  const quantized = quantizeRequest(request);
+  return regionOf([
+    quantized.sourcePoint,
+    quantized.targetPoint,
+    pushOutward(quantized.sourcePoint, quantized.sourceSide, nodeMargin),
+    pushOutward(quantized.targetPoint, quantized.targetSide, nodeMargin),
+  ]);
 };


### PR DESCRIPTION
Closes #90.

Dragging one node changed the routes of edges that had nothing to do with it, because every
node's inflated rect boundary was a grid line for every edge's search: moving anything
perturbed every search space, and equal-cost alternatives then flipped through the tie-break.
The router was deterministic but not stable. On top of that, a drag re-routed only the edges
incident to the dragged node and ran a full pass on drop, so the rest kept routing around the
node's old rect and jumped all at once when it was released.

## What changed

**Per-edge regions.** Each edge is now searched on a grid built from the rects intersecting
its own region — the bounding box of its request points and pushed points, inflated by
`ROUTE_REGION_MARGIN` — with candidate lines clipped to that region. The clip is
load-bearing rather than tidy: it keeps every grid vertex, and so every segment, inside the
region, which is what makes the selected rects provably the only ones that can block. The
contract gains **Locality**: a route found on its region is a function of the rects reaching
that region and of nothing else in the input. A request whose region offers no path is
retried once on the whole graph, so no edge becomes less routable than it was; Locality is
explicitly not claimed for those, and no edge in either default example needs the retry.

**One routing path.** The incident-only drag pass and the catch-up pass on drop are gone, so
no edge is ever drawn against a rect the dragged node has already vacated. A pass still skips
edges whose route cannot have changed, but under Locality that is a pure optimization —
`src/hooks/__tests__/useEdgeRoutes.test.ts` pins it as equal to a full pass, entry for entry —
rather than the different answer the old split produced. It is needed: routing everything
costs 14-23 ms at 180 nodes, over the frame budget. Getting the narrowing right takes three
clauses, and the third is the one that is easy to miss — a route that left its own region was
found on the whole-graph rung, so it must be re-routed unconditionally.

**Quantized input fingerprint.** `useEdgeRoutes` hashed raw measured floats, so sub-pixel
jitter from font loading or zoom transforms ran a pass whose result was identical. It now
hashes what the router actually sees. This was left here explicitly by #89.

**Dropped from #90 as specified:** the translation-invariant tie-break. It is a no-op —
`comparePointSequences` only ever compares candidates of one edge, which all start at the same
pushed source point, so restating it relative to that point subtracts a constant from every
candidate and preserves the order exactly. The instability was the candidate set moving, not
the comparison being absolute.

## Measurements

Replayed offline from the app's own ELK layout, node sizes and per-operand port offsets;
timings in bare Node, warm, median of 9 (2026-08-11, this machine). Region grid vs. the
graph-wide grid it replaces:

| | region | graph-wide |
| --- | --- | --- |
| 60 nodes / 117 edges | 5-7 ms | 9-17 ms |
| 180 / 370 | 14-23 ms | 48-104 ms |
| 400 / 840 | 34-48 ms | 214-267 ms |

- **Routes are unchanged**: byte-identical on both default LLVM-IR examples (0 of 23 Use-Def,
  0 of 10 CFG) and on layered synthetics up to 400 nodes. This is a stability change, not a
  change to the picture.
- **The repro**: dragging `%0` by 24 x 16 px changed 4 routes on the graph-wide grid, one of
  them not incident to the dragged node, against 3 on the region grid, all incident — and no
  route outside the dragged node's reach changed at any drag distance tested.
- **`ROUTE_REGION_MARGIN = 192` is measured**: the whole-graph retry fires for one edge per
  example at 48 px, one (CFG) at 96 px, and for none from 128 px up, while timings across
  48-384 px differ by less than run-to-run noise. 192 is the smallest tested value with
  headroom over that threshold — the region should be no larger than it has to be, since its
  size is exactly how much of the graph an edge is coupled to.
- Shape matters more than size: on a fixture whose edges span the whole graph instead of
  joining adjacent layers, every region grows to nearly the graph and the advantage
  disappears (400 / 840: 1740 ms vs 1725 ms). Real IR graphs are layered.

## Tests

629 pass. Five new router tests pin Locality (out-of-region rects moving, resizing, being
added or removed; a first-rung route staying inside its region; the whole-graph retry), and
nine pin that a narrowed pass equals a full pass. The equivalence tests were rewritten after
the first version proved vacuous: all three mutants of the narrowing rule (drop the
whole-graph-retry clause, ignore a rect's vacated position, ignore a request's own change)
now fail the suite.

## Not verified

The "no visible jump at drag stop" criterion was not confirmed by eye. The dev-server preview
wedged repeatedly in the session this was written in — including on an unmodified checkout —
and drag input timed out. Structurally the catch-up pass no longer exists, and the
equivalence tests cover a twelve-step drag, so a stale route cannot survive a frame; the
visual check is still worth doing once by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
